### PR TITLE
Pass-Thru Mode

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -120,6 +120,8 @@ function clearKeyMappingsAndSetDefaults() {
   mapKeyToCommand('t', 'createTab');
   mapKeyToCommand('d', 'removeTab');
   mapKeyToCommand('u', 'restoreTab');
+
+  mapKeyToCommand('x', 'passThru');
 }
 
 // Navigating the current page:
@@ -166,6 +168,9 @@ addCommand('createTab',           'Create new tab',    true);
 addCommand('removeTab',           'Close current tab', true);
 addCommand('restoreTab',          "Restore closed tab", true);
 
+// Enable Pass-Thru Mode
+addCommand('passThru',            'Pass-Thru Mode - Disable Vimium until ESC is pressed.');
+
 
 // An ordered listing of all available commands, grouped by type. This is the order they will
 // be shown in the help page.
@@ -175,7 +180,7 @@ var commandGroups = {
      "scrollToTop", "scrollToBottom", "scrollToLeft", "scrollToRight", "scrollPageDown", "scrollPageUp", "scrollFullPageDown",
      "reload", "toggleViewSource", "zoomIn", "zoomOut", "copyCurrentUrl", "goUp",
      "enterInsertMode", "activateLinkHintsMode", "activateLinkHintsModeToOpenInNewTab",
-     "enterFindMode", "performFind", "performBackwardsFind"],
+     "enterFindMode", "performFind", "performBackwardsFind", "passThru"],
   historyNavigation:
     ["goBack", "goForward"],
   tabManipulation:

--- a/vimiumFrontend.js
+++ b/vimiumFrontend.js
@@ -238,6 +238,13 @@ function toggleViewSourceCallback(url) {
   else { window.location.href = "view-source:" + url; }
 }
 
+var passThruMode = false;
+
+function passThru() {
+  passThruMode = true;
+  HUD.show("Pass-Thru Mode");
+}
+
 /**
  * Sends everything except i & ESC to the handler in background_page. i & ESC are special because they control
  * insert mode which is local state to the page. The key will be are either a single ascii letter or a
@@ -248,7 +255,13 @@ function toggleViewSourceCallback(url) {
 function onKeydown(event) {
   var keyChar = "";
 
-  if (linkHintsModeActivated)
+  if (passThruMode && isEscape(event)) {
+    passThruMode = false;
+    HUD.hide();
+    return;
+  }
+
+  if (linkHintsModeActivated || passThruMode)
     return;
 
   // Ignore modifier keys by themselves.


### PR DESCRIPTION
Here is the simplest implementation of Pass-Thru Mode I could come up with.

Simply press 'x' to enter Pass-Thru Mode -- all keys are ignored by Vimium and allowed to pass to the web page.

The HUD displays "Pass-Thru Mode" while enabled.

Press ESC to disable.

To test, you can:
1. Load up Google Reader.
2. Press j/k -- nothing happens.
3. Press x to enable Pass-Thru Mode.
4. Press j/k to move up and down in your reader items.
5. Press s to star an item.
6. Press ESC to exit Pass-Thru Mode.

![Pass-Thru Mode](http://imgur.com/08fqD.png)

I put this on a topic branch so as to not give you a merge conflict if you decide to pull this and not the "Key Mark" feature from my main branch. If you decide to pull both, you can simply merge my main branch and get both features at once!

Thanks for your consideration.

-Tim
