### PR TITLE
Added some new commands

### DIFF
--- a/background_page.html
+++ b/background_page.html
@@ -69,6 +69,7 @@
 
   var sendRequestHandlers = {
     getCompletionKeys: getCompletionKeys,
+	openPageInNewTab: openPageInNewTab,
     getLinkHintCss: getLinkHintCss,
     openUrlInNewTab: openUrlInNewTab,
     openUrlInCurrentTab: openUrlInCurrentTab,
@@ -247,6 +248,20 @@
     chrome.tabs.getSelected(null, function(tab) {
       chrome.tabs.create({ url: request.url, index: tab.index + 1, selected: request.selected });
     });
+  }
+  function openPageInNewTab(request) {
+    //chrome.tabs.create({'url' : request.url});
+    chrome.tabs.getSelected(null, function(tab){
+      chrome.tabs.create({'url': request.url, 'index': tab.index + 1})
+    });
+    return true;
+  }
+
+  function goHomeNewTab() {
+    chrome.tabs.getSelected(null, function(tab){
+      chrome.tabs.create({'url': "http://www.google.com", 'index': tab.index + 1})
+    });
+    //chrome.tabs.create({'url': "http://www.google.com"});
   }
   /*
    * Returns the core CSS used for link hints, along with any user-provided overrides.

--- a/commands.js
+++ b/commands.js
@@ -142,9 +142,14 @@ function clearKeyMappingsAndSetDefaults() {
     "gt": "nextTab",
     "gT": "previousTab",
 
-    "t": "createTab",
+    "t": "enterEditURLTabMode",
+    "T": "createTab",
     "x": "removeTab",
     "X": "restoreTab",
+
+	"o": "enterEditURLMode",
+	"gh": "goHomeCurTab",
+	"gH": "goHomeNewTab",
 
     "gf": "nextFrame"
   };
@@ -204,8 +209,14 @@ var commandDescriptions = {
   nextTab: ["Go one tab right", { background: true }],
   previousTab: ["Go one tab left", { background: true }],
   createTab: ["Create new tab", { background: true }],
+  enterEditURLTabMode: ["Enter a URL to open in a new tab"],
   removeTab: ["Close current tab", { background: true }],
   restoreTab: ["Restore closed tab", { background: true }],
+
+  //Navigation
+  enterEditURLMode: ["Enter a URL to open in the current tab"],
+  goHomeCurTab: ["Go home (currently google.com) in current tab"],
+  goHomeNewTab: ["Go home (currently google.com) in a new tab"],
 
   nextFrame: ["Cycle forward to the next frame on the page", { background: true }]
 };
@@ -229,9 +240,11 @@ var commandGroups = {
   historyNavigation:
     ["goBack", "goForward"],
   tabManipulation:
-    ["nextTab", "previousTab", "createTab", "removeTab", "restoreTab"],
+    ["nextTab", "previousTab", "createTab", "enterEditURLTabMode", "removeTab", "restoreTab"],
   misc:
-    ["showHelp"]
+    ["showHelp"],
+  navigation:
+    ["enterEditURLMode", "goHomeCurTab", "goHomeNewTab"]
 };
 
 // Rarely used commands are not shown by default in the help dialog or in the README. The goal is to present


### PR DESCRIPTION
I've updated my patch to work with the current vimium version, closed previous pull request, and opening this one

Added New commands:
    enterEditURLMode - default key: 'o'
        opens input similar to find box, when enter is pressed, sets the current tab's
            location to the input
    enterEditURLTabMode - default key: 't'  - createTab moved to 'T'
        opens input similar to find box, when enter is pressed, opens a new tab and
            sets it's location to the input
    goHomeCurTab - default key: 'gh'
        moves the current tab to 'http://www.google.com' looking into using homepage from chrome
    goHomeNewTab - default key: 'gH'
        opens a new tab to 'http://www.google.com' looking into using homepage from chrome

Other functions:
    Request handler:
        openPageInNewTab - request needs field 'url', opens url in new tab next to current one
    The following were based on the findMode equivalents
        handleKeyCharForEditURLMode
        handleDeleteForEditURLMode
        handleEnterForEditURLMode
        showEditURLModeHUD
        exitEditURLMode

New Variables:
    vimiumFrontend.js:
        editURLMode - bool, true if editing URL (very similar to how findMode works)
        editURLString - current string when editing URL (similar to findModeQuery)
        editURLTabMode - bool, true if we're going to open the url being entered
                in a new tab
