### PR TITLE
Remove focus after selecting link in LinkHintsMode.

### DIFF
--- a/linkHints.js
+++ b/linkHints.js
@@ -301,6 +301,7 @@ function deactivateLinkHintsMode() {
   hintKeystrokeQueue = [];
   document.removeEventListener("keydown", onKeyDownInLinkHintsMode, true);
   document.removeEventListener("keyup", onKeyUpInLinkHintsMode, true);
+  document.activeElement.blur();
   linkHintsModeActivated = false;
   HUD.hide();
 }


### PR DESCRIPTION
Using link hints mode to open a link in a new tab would leave the link focused. This causes problems on sites that have their own keyboard shortcuts, where you might expect "enter" to do one thing, but instead it opens the link you opened earlier because it has focus.
