### PR TITLE
Gleebox compatibility tweak

### DIFF
--- a/vimiumFrontend.js
+++ b/vimiumFrontend.js
@@ -391,12 +391,12 @@ function onKeydown(event) {
     }
   }
 
-  if (insertMode && isEscape(event))
+  if (insertMode && isEscape(event) && !isGleebox(event.srcElement))
   {
     // Note that we can't programmatically blur out of Flash embeds from Javascript.
     if (!isEmbed(event.srcElement)) {
       // Remove focus so the user can't just get himself back into insert mode by typing in the same input box.
-      if (isEditable(event.srcElement) && !isGleebox(event.srcElement)) { event.srcElement.blur(); }
+      if (isEditable(event.srcElement)) { event.srcElement.blur(); }
       exitInsertMode();
 
       // Added to prevent Google Instant from reclaiming the keystroke and putting us back into the search box.


### PR DESCRIPTION
I've found [gleebox](https://github.com/glee/glee) to be a good companion extension with vimium.  However, gleebox uses esc to clear its search box when it's visible and contains text, which conflicts with vimium's behavior of removing focus from the editable control.  This is just a minor change to prevent that, in case anyone else uses these two extensions together.
