### PR TITLE
Prevent bookmark completion box from overflowing. 

### DIFF
--- a/completionDialog.js
+++ b/completionDialog.js
@@ -118,7 +118,7 @@
         }
       }
 
-      container.style.top=(window.innerHeight/2-container.clientHeight/2) + "px";
+      container.style.top=Math.max(0,(window.innerHeight/2-container.clientHeight/2)) + "px";
       container.style.left=(window.innerWidth/2-container.clientWidth/2) + "px";
     }
   };


### PR DESCRIPTION
Happens when the partial string input matches more results
than can be displayed vertically. This causes the input section
at the top, together with the top matching URLS to disappear.

Solution is to only center the box when its height is less than
the window height, otherwise its top is at coordinate 0.
No negative top.
