### PR TITLE
Fix opening link in new tab bug.

### DIFF
--- a/linkHints.js
+++ b/linkHints.js
@@ -65,6 +65,8 @@ var linkHints = {
       keydown: this.onKeyDownInMode,
       keyup: this.onKeyUpInMode
     });
+        
+    this.openLinkModeToggle = false;
   },
 
   setOpenLinkMode: function(openInNewTab, withQueue, copyLinkUrl) {


### PR DESCRIPTION
I encountered a bug where opening a link in a separate tab using {f + XX} the second time fails to work correctly: the page is opened in the current tab rather than a new tab (see  #339). I have corrected this bug. 

P.S: This is my first pull request ever, so please be gentle!
