### PR TITLE
Bugfix: Really hide bookmark dialog

### DIFF
--- a/completionDialog.js
+++ b/completionDialog.js
@@ -16,6 +16,7 @@
         handlerStack.push({ keydown: this.onKeydown });
         render.call(this);
         clearInterval(this._tweenId);
+        this.container.style.display = "";
         this._tweenId = Tween.fade(this.container, 1.0, 150);
       }
     },
@@ -25,7 +26,11 @@
         this.isShown=false;
         this.currentSelection=0;
         clearInterval(this._tweenId);
-        this._tweenId = Tween.fade(this.container, 0, 150);
+        var completionContainer = this.container;
+        var cssHide = function() {
+          completionContainer.style.display = "none";
+        }
+        this._tweenId = Tween.fade(this.container, 0, 150, cssHide);
       }
     },
     getDisplayElement: function() {


### PR DESCRIPTION
Problem:
When bookmark completion is aborted using <ESC> key, the
completion dialog is faded out, zero opacity. This leaves
an invisible dialog hovering over the current page's content.
Any thing under the invisible dialog cannot get mouse focus,
including the links.

Solution:
After fading out the dialog, also hide it by its CSS display
property.
