### PR TITLE
Reimplement out-of-order link hints generation

### DIFF
--- a/linkHints.js
+++ b/linkHints.js
@@ -322,9 +322,26 @@ var alphabetHints = {
           visibleElements.length, settings.get('linkHintCharacters').length));
     var hintMarkers = [];
 
-    for (var i = 0, count = visibleElements.length; i < count; i++) {
-      var hintString = this.numberToHintString(i, digitsNeeded);
+    var start = 0, j = 0, increment = 1;
+    var count = visibleElements.length;
+    if (count > 10)
+      increment = parseInt(count / 3, 10); // Dividing by 3 seems to work fine
+                                           // for achieving the spread out effect
+
+    for (var i = 0; i < count; i++) {
+      var hintString = this.numberToHintString(j, digitsNeeded);
       var marker = hintUtils.createMarkerFor(visibleElements[i]);
+
+      // The following makes the link hints appear to spread out after the
+      // first key is hit. This is helpful on a page that has http links that
+      // are close to each other where link hints of 2 characters or more
+      // occlude each other.
+      j += increment;
+      if (j >= count) {
+        start++;
+        j = start;
+      }
+
       marker.innerHTML = hintUtils.spanWrap(hintString);
       marker.setAttribute("hintString", hintString);
       hintMarkers.push(marker);
@@ -353,11 +370,6 @@ var alphabetHints = {
     for (var i = 0; i < numHintDigits - hintStringLength; i++)
       hintString.unshift(settings.get('linkHintCharacters')[0]);
 
-    // Reversing the hint string has the advantage of making the link hints
-    // appear to spread out after the first key is hit. This is helpful on a
-    // page that has http links that are close to each other where link hints
-    // of 2 characters or more occlude each other.
-    hintString.reverse();
     return hintString.join("");
   },
 


### PR DESCRIPTION
The original implementation (325e8b8e3b31ae2a7379f32e657bdade8a2efe0d)
generates unnecessary trailing characters in the hint strings due to the
reversal of the hint strings.

A solution for removing the trailing characters using trie was suggested in
pull request #424 but was deemed too complicated for the goal.

This commits achieves similar "spread-out effect" without reversing the hint
string using a simpler method than the "complicated-fix-on-top-of-a-hack" trie one.
