### PR TITLE
Fix the formating of userDefinedLinkHintCss default value

### DIFF
--- a/linkHints.js
+++ b/linkHints.js
@@ -256,7 +256,8 @@ var linkHints = {
   showMarker: function(linkMarker, matchingCharCount) {
     linkMarker.style.display = "";
     for (var j = 0, count = linkMarker.childNodes.length; j < count; j++)
-      if (j < matchingCharCount) linkMarker.childNodes[j].classList.add("matchingCharacter");
+      (j < matchingCharCount) ? linkMarker.childNodes[j].classList.add("matchingCharacter") :
+                                linkMarker.childNodes[j].classList.remove("matchingCharacter");
   },
 
   hideMarker: function(linkMarker) {


### PR DESCRIPTION
I cleaned up the userDefinedLinkHintCss default value's formatting in background_page.html to make it more readable. I looked at making it an array of strings, but it seemed like more trouble than it was worth.
