### PR TITLE
Re-style link hints

### DIFF
--- a/background_page.html
+++ b/background_page.html
@@ -31,9 +31,9 @@
     filterLinkHints: false,
     userDefinedLinkHintCss:
       "#vimiumHintMarkerContainer .vimiumHintMarker \n/* linkhint boxes */ " +
-      "{\nbackground-color:yellow;\nborder:1px solid #E3BE23;\n}\n\n" +
+      "{\nborder: 1px solid #AA852F;\n}\n\n" +
       "#vimiumHintMarkerContainer .vimiumHintMarker span \n/* linkhint text */ " +
-      "{\ncolor: black;\nfont-weight: bold;\nfont-size: 12px;\n}\n\n" +
+      "{\nfont-weight: bold;\n}\n\n" +
       "#vimiumHintMarkerContainer .vimiumHintMarker > .matchingCharacter {\n\n}",
     excludedUrls: "http*://mail.google.com/*\n" +
                   "http*://www.google.com/reader/*\n",

--- a/vimium.css
+++ b/vimium.css
@@ -50,23 +50,32 @@ tr.vimiumReset {
 }
 
 /* Linkhints CSS */
+
 div.internalVimiumHintMarker {
   position: absolute;
-  background-color: yellow;
-  border: 1px solid #E3BE23;
   display: block;
   top: -1px;
   left: -1px;
-  padding: 0 1px;
-  box-shadow: rgba(0, 0, 0, 0.3) 2px 2px;
+
+  font-size: 10px;
+  padding: 2px 4px 3px 4px;
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#FFF785), color-stop(100%,#FFC542));
+  border: solid 1px #C38A22;
+  border-radius: 3px;
+  box-shadow: 0px 3px 7px 0px rgba(0, 0, 0, 0.3);
 }
 
 div.internalVimiumHintMarker span {
+  color: #302505;
+  font-family: Helvetica, Arial, sans-serif;
   font-weight: bold;
+  font-size: 10px;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
 div.internalVimiumHintMarker > .matchingCharacter {
-  color: #C79F0B;
+  color: white;
+  text-shadow: 0 1px 6px rgba(0, 0, 0, 0.8);
 }
 
 /* Help Dialog CSS */


### PR DESCRIPTION
I've made a new style for the link hints which is a bit smoother:

![](http://dl.dropbox.com/u/420934/Permanent/vimium-contrast.png)

(This pull request is a continuation of #449)
