### PR TITLE
set overflow to none, just in case a website sets it to auto/scroll

### DIFF
--- a/background/settings.js
+++ b/background/settings.js
@@ -13,6 +13,7 @@ var settings = {
       "/* linkhint boxes */ " + "\n" +
       "background-color: yellow;" + "\n" +
       "border: 1px solid #E3BE23;" + "\n" +
+      "overflow: hidden;" + "\n" +
       "}" + "\n\n" +
       "div > .vimiumHintMarker span {" + "\n" +
       "/* linkhint text */ " + "\n" +


### PR DESCRIPTION
Test case: https://www.prosite.de/index.html
style.css:28 sets overflow for all `<div>` elements to auto
Press 'f', most of the link hints are unreadable.
