### PR TITLE
blur input then hiding fuzzyMode

### DIFF
--- a/fuzzyMode.js
+++ b/fuzzyMode.js
@@ -46,6 +46,7 @@ var fuzzyMode = (function() {
     hide: function() {
       this.box.style.display = 'none';
       this.completionList.style.display = 'none';
+      this.input.blur();
       handlerStack.pop();
     },
 


### PR DESCRIPTION
fixes that vimium doesn't work anymore when you open the selection in a
new tab because your typing will end up in fuzzy's input element.
Test:
Press "O", search something, submit, close new tab and try to use j/k in the one you used O in.
