### PR TITLE
getVisibleClientRect: correct top/left offset if body/html is pos. relative

### DIFF
--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -109,7 +109,7 @@ var linkHints = {
     // sometimes this is triggered before documentElement is created
     // TODO(int3): fail more gracefully?
     if (document.documentElement)
-      document.documentElement.appendChild(this.hintMarkerContainingDiv);
+      document.body.appendChild(this.hintMarkerContainingDiv);
     else
       this.deactivateMode();
   },

--- a/lib/dom_utils.js
+++ b/lib/dom_utils.js
@@ -39,6 +39,7 @@ var domUtils = {
     // Note: this call will be expensive if we modify the DOM in between calls.
     var clientRects = element.getClientRects();
     var clientRectsLength = clientRects.length;
+    var rect = null;
 
     for (var i = 0; i < clientRectsLength; i++) {
       if (clientRects[i].top < -2 || clientRects[i].top >= window.innerHeight - 4 ||
@@ -54,7 +55,7 @@ var domUtils = {
           computedStyle.getPropertyValue('display') == 'none')
         continue;
 
-      return clientRects[i];
+      rect = clientRects[i];
     }
 
     for (var i = 0; i < clientRectsLength; i++) {
@@ -69,11 +70,34 @@ var domUtils = {
           var childClientRect = this.getVisibleClientRect(element.children[j]);
           if (childClientRect === null)
             continue;
-          return childClientRect;
+          rect = childClientRect;
         }
       }
-    };
-    return null;
+    }
+
+    if (!rect)
+      return null;
+
+    // rect is readonly
+    var keys = Object.keys(rect);
+    var clone = {};
+    for (var i = 0; i < keys.length; i++) {
+      clone[keys[i]] = rect[keys[i]];
+    }
+    // if <body>/<html> is positioned relative, our absolute elements
+    // will be positioned relative to <body>/<html> and not the defaultView.
+    if (document.defaultView.getComputedStyle(document.body).position == 'relative') {
+      var bodyRect = document.body.getBoundingClientRect();
+      clone.left -= bodyRect.left + window.pageXOffset;
+      clone.top -= bodyRect.top + window.pageYOffset;
+    }
+    // if we already made up for <body>'s bounding rect we don't need to do the same for <html>
+    else if (document.defaultView.getComputedStyle(document.documentElement).position == 'relative') {
+      var docRect = document.documentElement.getBoundingClientRect();
+      clone.left -= docRect.left + window.pageXOffset;
+      clone.top -= docRect.top + window.pageYOffset;
+    }
+    return clone;
   },
 
   /*


### PR DESCRIPTION
if body/html are positioned relative, an absolute positioned element
will be positioned relative to body/html and not window.
Make up for that by substracting body's
left-/right-position (relative to the screen) + scroll-position

append hintMarkerContainingDiv to body

Test this by setting `<body>`'s position to 'relative' and adding a margin. Then press 'f'.
Repeat with `<html>` and with `<html>` and `<body>`.
