### PR TITLE
Activate with "B" to open selection in new tab

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -11,6 +11,7 @@ Contributors:
   Bill Casarin <jb@jb55.com> (github: jb55)
   Bill Mill (github: llimllib)
   Branden Rolston <brolston@gmail.com> (github: branden)
+  Carl Helmertz <helmertz@gmail.com> (github: chelmertz)
   Christian Stefanescu (github: stchris)
   ConradIrwin
   Daniel MacDougall <dmacdougall@gmail.com> (github: dmacdougall)

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -91,8 +91,8 @@ Commands =
        "openCopiedUrlInCurrentTab", "openCopiedUrlInNewTab", "goUp",
        "enterInsertMode", "focusInput",
        "LinkHints.activateMode", "LinkHints.activateModeToOpenInNewTab", "LinkHints.activateModeWithQueue",
-       "Vomnibar.activate", "Vomnibar.activateWithCurrentUrl", "Vomnibar.activateTabSelection",
-       "Vomnibar.activateBookmarks",
+       "Vomnibar.activate", "Vomnibar.activateWithCurrentUrl", "Vomnibar.activateWithNewTab",
+       "Vomnibar.activateTabSelection", "Vomnibar.activateBookmarks",
        "goPrevious", "goNext", "nextFrame"]
     findCommands: ["enterFindMode", "performFind", "performBackwardsFind"]
     historyNavigation:
@@ -166,6 +166,7 @@ defaultKeyMappings =
 
   "o": "Vomnibar.activate"
   "O": "Vomnibar.activateWithCurrentUrl"
+  "B": "Vomnibar.activateWithNewTab"
 
   "T": "Vomnibar.activateTabSelection"
 
@@ -233,6 +234,7 @@ commandDescriptions =
 
   "Vomnibar.activate": ["Open URL, bookmark, or history entry"]
   "Vomnibar.activateWithCurrentUrl": ["Open URL, bookmark, history entry, starting with the current URL"]
+  "Vomnibar.activateWithNewTab": ["Open URL, bookmark, history entry, in a new tab"]
   "Vomnibar.activateTabSelection": ["Search through your open tabs"]
   "Vomnibar.activateBookmarks": ["Open a bookmark"]
 

--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -10,13 +10,14 @@ Vomnibar =
   #
   # Activate the Vomnibox.
   #
-  activateWithCompleter: (completerName, refreshInterval, initialQueryValue, selectFirstResult) ->
+  activateWithCompleter: (completerName, refreshInterval, initialQueryValue, selectFirstResult, forceNewTab) ->
     completer = @getCompleter(completerName)
     @vomnibarUI = new VomnibarUI() unless @vomnibarUI
     completer.refresh()
     @vomnibarUI.setInitialSelectionValue(if selectFirstResult then 0 else -1)
     @vomnibarUI.setCompleter(completer)
     @vomnibarUI.setRefreshInterval(refreshInterval)
+    @vomnibarUI.setForceNewTab(forceNewTab)
     @vomnibarUI.show()
     if (initialQueryValue)
       @vomnibarUI.setQuery(initialQueryValue)
@@ -24,6 +25,7 @@ Vomnibar =
 
   activate: -> @activateWithCompleter("omni", 100)
   activateWithCurrentUrl: -> @activateWithCompleter("omni", 100, window.location.toString())
+  activateWithNewTab: -> @activateWithCompleter("omni", 100, "", true, true)
   activateTabSelection: -> @activateWithCompleter("tabs", 0, null, true)
   activateBookmarks: -> @activateWithCompleter("bookmarks", 0, null, true)
   getUI: -> @vomnibarUI
@@ -44,6 +46,8 @@ class VomnibarUI
     @reset()
 
   setRefreshInterval: (refreshInterval) -> @refreshInterval = refreshInterval
+
+  setForceNewTab: (forceNewTab) -> @forceNewTab = forceNewTab
 
   show: ->
     @box.style.display = "block"
@@ -92,7 +96,7 @@ class VomnibarUI
     action = @actionFromKeyEvent(event)
     return true unless action # pass through
 
-    openInNewTab = (event.shiftKey || KeyboardUtils.isPrimaryModifierKey(event))
+    openInNewTab = @forceNewTab || (event.shiftKey || KeyboardUtils.isPrimaryModifierKey(event))
     if (action == "dismiss")
       @hide()
     else if (action == "up")


### PR DESCRIPTION
This patch does not include any graphical hints of which mode the
vomnibar was activated with.

Fixes #594.

Signed-off-by: Carl Helmertz helmertz@gmail.com
