### PR TITLE
Fix regression in shuffleHints()

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -301,7 +301,7 @@ alphabetHints =
   #
   shuffleHints: (hints, characterSetLength) ->
     buckets = ([] for i in [0...characterSetLength] by 1)
-    for hint in hints
+    for hint, i in hints
       buckets[i % buckets.length].push(hint)
     result = []
     for bucket in buckets


### PR DESCRIPTION
Upgraded today and noticed that the link shuffling feature was broken.

Index variable `i` accidentally undeclared in `for in` loop

cf. ed21d9b1abe42c1556f27390476302a1393dedb8
