### PR TITLE
Add a generated file to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ lib/clipboard.js
 lib/dom_utils.js
 lib/keyboard_utils.js
 lib/utils.js
+options/options.js


### PR DESCRIPTION
A recent commit converted options.js to CS without adding to the gitignore.
