### PR TITLE
Fix options link broken by 486ba68a42e2ba7b96a7a14b0ae34aca7ac7e780

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,5 @@
 function onLoad() {
-  document.getElementById("optionsLink").setAttribute("href", chrome.extension.getURL("options.html"));
+  document.getElementById("optionsLink").setAttribute("href", chrome.extension.getURL("options/options.html"));
   chrome.tabs.getSelected(null, function(tab) {
     // The common use case is to disable Vimium at the domain level.
     // This regexp will match "http://www.example.com/" from "http://www.example.com/path/to/page.html".


### PR DESCRIPTION
We needed to update the popup link to the options page after refactoring its location.
