### PR TITLE
The help dialog now gets showAdvancedCommands directly from settings.

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -90,8 +90,6 @@ root.addExcludedUrl = (url) ->
   chrome.tabs.query({ windowId: chrome.windows.WINDOW_ID_CURRENT, active: true },
     (tabs) -> updateActiveState(tabs[0].id))
 
-getShowAdvancedCommands = (request) -> Settings.get("helpDialog_showAdvancedCommands")
-
 saveHelpDialogSettings = (request) ->
   Settings.set("helpDialog_showAdvancedCommands", request.showAdvancedCommands)
 
@@ -110,8 +108,6 @@ root.helpDialogHtml = (showUnboundCommands, showCommandNames, customTitle) ->
                                       showUnboundCommands, showCommandNames))
   dialogHtml = dialogHtml.replace("{{version}}", currentVersion)
   dialogHtml = dialogHtml.replace("{{title}}", customTitle || "Help")
-  dialogHtml = dialogHtml.replace("{{showAdvancedCommands}}",
-    Settings.get("helpDialog_showAdvancedCommands"))
   dialogHtml
 
 #
@@ -569,7 +565,6 @@ portHandlers =
 sendRequestHandlers =
   getCompletionKeys: getCompletionKeysRequest,
   getCurrentTabUrl: getCurrentTabUrl,
-  getShowAdvancedCommands: getShowAdvancedCommands,
   openUrlInNewTab: openUrlInNewTab,
   openUrlInCurrentTab: openUrlInCurrentTab,
   openOptionsPageInNewTab: openOptionsPageInNewTab,

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -43,7 +43,7 @@ settings =
   values: {}
   loadedValues: 0
   valuesToLoad: ["scrollStepSize", "linkHintCharacters", "filterLinkHints", "hideHud", "previousPatterns",
-      "nextPatterns", "findModeRawQuery", "userDefinedLinkHintCss"]
+      "nextPatterns", "findModeRawQuery", "userDefinedLinkHintCss", "helpDialog_showAdvancedCommands"]
   isLoaded: false
   eventListeners: {}
 
@@ -883,24 +883,23 @@ window.showHelpDialog = (html, fid) ->
   
   VimiumHelpDialog =
     # This setting is pulled out of local storage. It's false by default.
-    getShowAdvancedCommands: (callback) ->
-      chrome.extension.sendRequest({ handler: "getShowAdvancedCommands"}, callback)
+    getShowAdvancedCommands: -> settings.get("helpDialog_showAdvancedCommands")
 
     init: () ->
       this.dialogElement = document.getElementById("vimiumHelpDialog")
       this.dialogElement.getElementsByClassName("toggleAdvancedCommands")[0].addEventListener("click",
         VimiumHelpDialog.toggleAdvancedCommands, false)
       this.dialogElement.style.maxHeight = window.innerHeight - 80
-      this.getShowAdvancedCommands(this.showAdvancedCommands)
+      this.showAdvancedCommands(this.getShowAdvancedCommands())
 
     # 
     # Advanced commands are hidden by default so they don't overwhelm new and casual users.
     # 
     toggleAdvancedCommands: (event) ->
       event.preventDefault()
-      VimiumHelpDialog.getShowAdvancedCommands((value) ->
-        VimiumHelpDialog.showAdvancedCommands(!value)
-        chrome.extension.sendRequest({ handler: "saveHelpDialogSettings", showAdvancedCommands: !value }))
+      showAdvanced = VimiumHelpDialog.getShowAdvancedCommands()
+      VimiumHelpDialog.showAdvancedCommands(!showAdvanced)
+      settings.set("helpDialog_showAdvancedCommands", !showAdvanced)
 
     showAdvancedCommands: (visible) ->
       VimiumHelpDialog.dialogElement.getElementsByClassName("toggleAdvancedCommands")[0].innerHTML =


### PR DESCRIPTION
Hey @int3 this PR implements the changes that you suggested in my last PR. The showAdvancedCommands now comes directly from the settings.
