### PR TITLE
Remove f from default link hint characters

### DIFF
--- a/background_scripts/settings.coffee
+++ b/background_scripts/settings.coffee
@@ -20,7 +20,7 @@ root.Settings = Settings =
 
   defaults:
     scrollStepSize: 60
-    linkHintCharacters: "sadfjklewcmpgh"
+    linkHintCharacters: "sadjklewcmpgh"
     filterLinkHints: false
     hideHud: false
     userDefinedLinkHintCss:


### PR DESCRIPTION
Fix #638
