### PR TITLE
World's smallest bug: Correct handling of default value for scrollStepSize

### DIFF
--- a/background_scripts/settings.coffee
+++ b/background_scripts/settings.coffee
@@ -18,8 +18,10 @@ root.Settings = Settings =
 
   has: (key) -> key of localStorage
 
+  # options/options.(coffee|html) only handle booleans and strings; therefore
+  # all defaults must be booleans or strings
   defaults:
-    scrollStepSize: 60
+    scrollStepSize: "60"
     linkHintCharacters: "sadfjklewcmpgh"
     filterLinkHints: false
     hideHud: false


### PR DESCRIPTION
`scrollStepSize` is the only setting whose default value is numeric.

The following test:

```
# don't store the value if it is equal to the default, so we can change the defaults in the future
if (value == @defaults[key])
    @clear(key)
```

from `settings.coffee` _never_ succeeds for scrollStepSize:
- because `==` compiles to `===` and the types don't match.

Therefore, the default value of `scrollStepSize` is _always_ stored in `localStorage` ...  which obviates the intention of the test quoted above.

---

This bug is so small that I thought it might be ok to skip raising it as an "Issue".  My apologies if that's not ok.
