### PR TITLE
add workflowy.com in default excluded urls.

### DIFF
--- a/background_scripts/settings.coffee
+++ b/background_scripts/settings.coffee
@@ -49,6 +49,7 @@ root.Settings = Settings =
       """
       http*://mail.google.com/*
       http*://www.google.com/reader/*
+      http*://workflowy.com/*
       """
     # NOTE : If a page contains both a single angle-bracket link and a double angle-bracket link, then in
     # most cases the single bracket link will be "prev/next page" and the double bracket link will be


### PR DESCRIPTION
[Workflowy](https://workflowy.com) is a very popular web-app and got an excellent
keyboard support of their own. If vimium is installed, it
interferes with the default setting specifically when you
press 'Esc' to goto their search field .
