### PR TITLE
Bookmark - natural traversal ordering

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -112,11 +112,11 @@ class BookmarkCompleter
   # Traverses the bookmark hierarchy, and retuns a flattened list of all bookmarks in the tree.
   traverseBookmarks: (bookmarks) ->
     results = []
-    toVisit = bookmarks
+    toVisit = bookmarks.reverse()
     while toVisit.length > 0
-      bookmark = toVisit.shift()
+      bookmark = toVisit.pop()
       results.push(bookmark)
-      toVisit.push.apply(toVisit, bookmark.children) if (bookmark.children)
+      toVisit.push.apply(toVisit, bookmark.children.reverse()) if (bookmark.children)
     results
 
   computeRelevancy: (suggestion) ->


### PR DESCRIPTION
See #691.

Changes:
- order in which bookmarks are traversed
- eliminate use of `shift` from previous version (hence, now not O(N^2)

All tests seem to pass.
