### PR TITLE
Improve consistency and fix bug in  relevancy calculation.

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -251,12 +251,15 @@ class MultiCompleter
 RankingUtils =
   # Whether the given things (usually URLs or titles) match any one of the query terms.
   # This is used to prune out irrelevant suggestions before we try to rank them, and for calculating word relevancy.
+  # Every term must match at least one thing.
   matches: (queryTerms, things...) ->
     for term in queryTerms
       regexp = RegexpCache.get(term)
+      matchedTerm = false
       for thing in things
-        return true if thing?.match && thing.match regexp
-    false
+        matchedTerm = matchedTerm || (thing?.match && thing.match regexp)
+      return false unless matchedTerm
+    true
 
   # Returns a number between [0, 1] indicating how often the query terms appear in the url and title.
   wordRelevancy: (queryTerms, url, title) ->

--- a/tests/unit_tests/completion_test.coffee
+++ b/tests/unit_tests/completion_test.coffee
@@ -167,6 +167,12 @@ context "RankingUtils",
   should "do case insensitive word relevancy (not matching)", ->
     assert.isTrue RankingUtils.wordRelevancy(["DOES_NOT_MATCH"], "MARIO", "MARio") == 0.0
 
+  should "every term must match at least one thing (matching)", ->
+    assert.isTrue RankingUtils.matches(["cat", "dog"], "catapult", "hound dog")
+
+  should "every term must match at least one thing (not matching)", ->
+    assert.isTrue not RankingUtils.matches(["cat", "dog", "wolf"], "catapult", "hound dog")
+
 # A convenience wrapper around completer.filter() so it can be called synchronously in tests.
 filterCompleter = (completer, queryTerms) ->
   results = []


### PR DESCRIPTION
The `wordRelevancy` calculation for suggestion ordering is currently _case sensitive_.  Everywhere else, matching is _case insensitive_.

This is inconsistent and probably a bug.

Example:
- Bookmark title: `Google News (GN)`.
- Query term: `gn` (lower case).
- Receives relevancy score of `0.0`.
- It only appears on the list _at all_ because it happens to pass the `RankingUtils.matches()` test  (which is case insensitive).
- It will be ranked below any other bookmark which happens to contain `gn` in its URL (in my case, this was the ID in the URL of a Google Docs document!).
- Nevertheless, the `GN` from the title _is_ highlighted in the vomnibar.

This is a particular problem for bookmarks, whose titles frequently contain capital letters.
