### PR TITLE
Remove entries from History/Domain completers when they're removed on chrome.

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -212,8 +212,7 @@ class DomainCompleter
   onPageVisited: (newPage) ->
     domain = @parseDomain(newPage.url)
     if domain
-      @domains[domain] ||= { entry: newPage, referenceCount: 0 }
-      slot = @domains[domain]
+      slot = @domains[domain] ||= { entry: newPage, referenceCount: 0 }
       # We want each entry in our domains hash to point to the most recent History entry for that domain.
       slot.entry = newPage if slot.entry.lastVisitTime < newPage.lastVisitTime
       slot.referenceCount += 1


### PR DESCRIPTION
Currently, if a history entry is removed in chrome (or the entire history is removed), then the effects do not propagate into vimium until the next restart.

This is a pretty inconsistent UX.

The attached code fixes this inconsistency.

---

(Edit: Comments regarding bug in `binarySearch` deleted.)
