### PR TITLE
Include "chrome-extension" in chrome prefixes.

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -30,7 +30,7 @@ Utils =
     -> id += 1
 
   hasChromePrefix: (url) ->
-    chromePrefixes = [ 'about', 'view-source' ]
+    chromePrefixes = [ 'about', 'view-source', "chrome-extension" ]
     for prefix in chromePrefixes
       return true if url.startsWith prefix
     false


### PR DESCRIPTION
You can bookmark `chrome-extension://...` pages.  But you can't use such bookmarks: vimium sends you to the default search engine instead.
