### PR TITLE
Use smartcase for vomnibar queries.

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -355,10 +355,8 @@ RegexpCache =
     # Avoid cost of constructing new strings if prefix/suffix are empty (which is expected to be a common case).
     regexpString = prefix + regexpString if prefix
     regexpString = regexpString + suffix if suffix
-    return @cache[regexpString] if @cache[regexpString]
-    # Smartcase: regexp is case insensitive, unless `string` contains a capital letter.
-    modifier = if /[A-Z]/.test string then "" else "i"
-    @cache[regexpString] = new RegExp(regexpString, modifier)
+    # Smartcase: Regexp is case insensitive, unless `string` contains a capital letter (testing `string`, not `regexpString`).
+    @cache[regexpString] ||= new RegExp regexpString, (if /[A-Z]/.test string then "" else "i")
 
 # Provides cached access to Chrome's history. As the user browses to new pages, we add those pages to this
 # history cache.

--- a/tests/unit_tests/completion_test.coffee
+++ b/tests/unit_tests/completion_test.coffee
@@ -266,9 +266,17 @@ context "RankingUtils",
   should "do a case insensitive match on several terms", ->
     assert.isTrue RankingUtils.matches(["ari"], "DOES_NOT_MATCH", "DOES_NOT_MATCH_EITHER", "MARio")
 
-  should "do a smartcase match", ->
+  should "do a smartcase match (positive)", ->
     assert.isTrue RankingUtils.matches(["Mar"], "Mario")
+
+  should "do a smartcase match (negative)", ->
     assert.isFalse RankingUtils.matches(["Mar"], "mario")
+
+  should "do a match with regexp meta-characters (positive)", ->
+    assert.isTrue RankingUtils.matches(["ma.io"], "ma.io")
+
+  should "do a match with regexp meta-characters (negative)", ->
+    assert.isFalse RankingUtils.matches(["ma.io"], "mario")
 
   should "do a smartcase match on full term", ->
     assert.isTrue RankingUtils.matches(["Mario"], "Mario")


### PR DESCRIPTION
It's probably obvious, but ... Why would we want this?
- Smartcase is the best of both worlds.
- We already have smartcase for "Find" in the front end, it's inconsistent not to have it for the vomnibar too.

This PR also:
- Adjusts existing unit tests for smartcase.
- Adds tests for smartcase.
- Adds tests for queries including RegExp meta-characters.
