### PR TITLE
Word relevancy improvements - incorporate the position at which matches occur.

### DIFF
--- a/tests/unit_tests/completion_test.coffee
+++ b/tests/unit_tests/completion_test.coffee
@@ -183,45 +183,6 @@ context "RankingUtils.wordRelevancy",
     highScore = RankingUtils.wordRelevancy(["com"], "http://stackoverflow.com/same", "abcX com")
     assert.isTrue highScore > lowScore
 
-  # WARNING: The following tests may be hardware dependent.  They depend upon
-  # different but algebraically-equivalent sequences of floating point
-  # operations yielding the same results.  That they ever work at all is quite
-  # remarkable.
-  should "exactly equal oldWordRelevancy for whole word matches (in a URL)", ->
-    newScore  = RankingUtils.wordRelevancy(["com"], "http://stackoverflow.com/same", "irrelevant")
-    oldScore  = RankingUtils.oldWordRelevancy(["com"], "http://stackoverflow.com/same", "irrelevant")
-    assert.isTrue newScore == oldScore # remarkable! Exactly equal floats.
-
-  should "2/3 * oldWordRelevancy for matches at the start of a word (in a URL)", ->
-    newScore  = RankingUtils.wordRelevancy(["sta"], "http://stackoverflow.com/same", "irrelevant")
-    oldScore  = (2.0/3.0) * RankingUtils.oldWordRelevancy(["sta"], "http://stackoverflow.com/same", "irrelevant")
-    assert.isTrue newScore == oldScore # remarkable! Exactly equal floats.
-
-  should "1/3 * oldWordRelevancy for matches within a word (in a URL)", ->
-    newScore  = RankingUtils.wordRelevancy(["over"], "http://stackoverflow.com/same", "irrelevant")
-    oldScore  = (1.0/3.0) * RankingUtils.oldWordRelevancy(["over"], "http://stackoverflow.com/same", "irrelevant")
-    assert.isTrue newScore == oldScore # remarkable! Exactly equal floats.
-
-  should "exactly equal oldWordRelevancy for whole word matches (in a title)", ->
-    newScore  = RankingUtils.wordRelevancy(["relevant"], "http://stackoverflow.com/same", "XX relevant YY")
-    # Multiply by 2 to account for new wordRelevancy favoring title.
-    oldScore  = 2 * RankingUtils.oldWordRelevancy(["relevant"], "http://stackoverflow.com/same", "XX relevant YY")
-    assert.isTrue newScore == oldScore  # remarkable! Exactly equal floats.
-
-  should "2/3 * oldWordRelevancy for matches at the start of a word (in a title)", ->
-    newScore  = RankingUtils.wordRelevancy(["relev"], "http://stackoverflow.com/same", "XX relevant YY")
-    # Multiply by 2 to account for new wordRelevancy favoring title.
-    oldScore  = (2.0/3.0) * 2 * RankingUtils.oldWordRelevancy(["relev"], "http://stackoverflow.com/same", "XX relevant YY")
-    assert.isTrue newScore == oldScore  # remarkable! Exactly equal floats.
-
-  should "1/3 * oldWordRelevancy for matches within a word (in a title)", ->
-    newScore  = RankingUtils.wordRelevancy(["elev"], "http://stackoverflow.com/same", "XX relevant YY")
-    # Multiply by 2 to account for new wordRelevancy favoring title.
-    oldScore  = (1.0/3.0) * 2 * RankingUtils.oldWordRelevancy(["elev"], "http://stackoverflow.com/same", "XX relevant YY")
-    assert.isTrue newScore == oldScore  # remarkable! Exactly equal floats.
-  #
-  # End of possibly hardware-dependent tests.
-
   # # TODO: (smblott)
   # #       Word relevancy should take into account the number of matches (it doesn't currently).
   # should "get a higher relevancy score for multiple matches (in a URL)", ->
@@ -234,6 +195,49 @@ context "RankingUtils.wordRelevancy",
   #   highScore = RankingUtils.wordRelevancy(["bbc"], "http://stackoverflow.com/same", "BBC Radio 4 (BBCr4)")
   #   assert.isTrue highScore > lowScore
 
+# WARNING: The following tests are hardware dependent.  They depend upon
+# different but algebraically-equivalent sequences of floating point
+# operations yielding the same results.  That they ever work at all is quite
+# remarkable.
+# TODO: (smblott)
+#       Remove these tests when `oldWordRelevancy` is removed.
+context "RankingUtils.wordRelevancy (temporary hardware-dependent tests)",
+  should "exactly equal oldWordRelevancy for whole word matches (in a URL)", ->
+    newScore  = RankingUtils.wordRelevancy(["com"], "http://stackoverflow.com/same", "irrelevant")
+    oldScore  = RankingUtils.oldWordRelevancy(["com"], "http://stackoverflow.com/same", "irrelevant")
+    assert.equal newScore, oldScore # remarkable! Exactly equal floats.
+
+  should "yield 2/3 * oldWordRelevancy for matches at the start of a word (in a URL)", ->
+    newScore  = RankingUtils.wordRelevancy(["sta"], "http://stackoverflow.com/same", "irrelevant")
+    oldScore  = (2.0/3.0) * RankingUtils.oldWordRelevancy(["sta"], "http://stackoverflow.com/same", "irrelevant")
+    assert.equal newScore, oldScore # remarkable! Exactly equal floats.
+
+  should "yield 1/3 * oldWordRelevancy for matches within a word (in a URL)", ->
+    newScore  = RankingUtils.wordRelevancy(["over"], "http://stackoverflow.com/same", "irrelevant")
+    oldScore  = (1.0/3.0) * RankingUtils.oldWordRelevancy(["over"], "http://stackoverflow.com/same", "irrelevant")
+    assert.equal newScore, oldScore # remarkable! Exactly equal floats.
+
+  should "exactly equal oldWordRelevancy for whole word matches (in a title)", ->
+    newScore  = RankingUtils.wordRelevancy(["relevant"], "http://stackoverflow.com/same", "XX relevant YY")
+    # Multiply by 2 to account for new wordRelevancy favoring title.
+    oldScore  = 2 * RankingUtils.oldWordRelevancy(["relevant"], "http://stackoverflow.com/same", "XX relevant YY")
+    assert.equal newScore, oldScore  # remarkable! Exactly equal floats.
+
+  should "2/3 * oldWordRelevancy for matches at the start of a word (in a title)", ->
+    newScore  = RankingUtils.wordRelevancy(["relev"], "http://stackoverflow.com/same", "XX relevant YY")
+    # Multiply by 2 to account for new wordRelevancy favoring title.
+    oldScore  = (2.0/3.0) * 2 * RankingUtils.oldWordRelevancy(["relev"], "http://stackoverflow.com/same", "XX relevant YY")
+    assert.equal newScore, oldScore  # remarkable! Exactly equal floats.
+
+  should "1/3 * oldWordRelevancy for matches within a word (in a title)", ->
+    newScore  = RankingUtils.wordRelevancy(["elev"], "http://stackoverflow.com/same", "XX relevant YY")
+    # Multiply by 2 to account for new wordRelevancy favoring title.
+    oldScore  = (1.0/3.0) * 2 * RankingUtils.oldWordRelevancy(["elev"], "http://stackoverflow.com/same", "XX relevant YY")
+    assert.equal newScore, oldScore  # remarkable! Exactly equal floats.
+#
+# End of hardware-dependent tests.
+
+context "Suggestion.pushMatchingRanges",
   should "extract ranges matching term (simple case, two matches)", ->
     ranges = []
     [ one, two, three ] = [ "one", "two", "three" ]


### PR DESCRIPTION
Implements #705.  See that post for the basic idea and its justification.

Comments:
- The structure of the `wordRelevancy` calculation is unchanged and should be recognisable.
- The code contains _extensive_ comments and explanation.  These should be removed prior to the PR being committed.
- I've included three possible "endings" to `wordRelevancy`, two of which are commented out.  The most intriguing of these is the third (see code).  Feedback on that "ending" would be particularly welcome.
- The PR currently includes unit tests which involve _exact matches of floating point numbers_.  It is possible that these may fail on some platforms.  It is my intention that these tests be removed before the PR is committed.

Costs:
- There are no additional costs for suggestions which do not match.
- There is one additional `RegExp` test for each suggestion which matches.
- There is one further additional `RegExp` test for each suggestion which matches at the start of a word.
