### PR TITLE
Make <Enter> on an empty vomnibar be a no-op

### DIFF
--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -112,6 +112,8 @@ class VomnibarUI
       # google.
       if (@selection == -1)
         query = @input.value.trim()
+        # <Enter> on an empty vomnibar is a no-op.
+        return unless 0 < query.length
         @hide()
         chrome.extension.sendRequest({
           handler: if openInNewTab then "openUrlInNewTab" else "openUrlInCurrentTab"


### PR DESCRIPTION
See #694.

This is not my preferred option, but it's considerably better than the current behaviour.
