### PR TITLE
Don't close link hints when shift is pressed

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -173,7 +173,7 @@ LinkHints =
     # TODO(philc): Ignore keys that have modifiers.
     if (KeyboardUtils.isEscape(event))
       @deactivateMode()
-    else
+    else if (event.keyCode != keyCodes.shiftKey)
       keyResult = @markerMatcher.matchHintsByKey(hintMarkers, event)
       linksMatched = keyResult.linksMatched
       delay = keyResult.delay ? 0


### PR DESCRIPTION
When shift is pressed, it would close the link hints since shift [doesn't match any links](https://github.com/philc/vimium/blob/master/content_scripts/link_hints.coffee#L180). Now it won't try matching when shift is pressed.

Fixes #697, but I'm not sure why it was working for me in an earlier version of Chromium.
