### PR TITLE
Fix #464 - Support placeholder attribute for inputs in find mode

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -352,6 +352,8 @@ filterHints =
         showLinkText = true
       else if (element.type != "password")
         linkText = element.value
+        if not linkText and 'placeholder' of element
+          linkText = element.placeholder
       # check if there is an image embedded in the <a> tag
     else if (nodeName == "a" && !element.textContent.trim() &&
         element.firstElementChild &&


### PR DESCRIPTION
Whereas find mode normally identifies inputs by their value, if a value
is blank, find mode will use the placeholder value instead, if it exists
