### PR TITLE
Asking for comments: passing ESC events through to the page

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -386,7 +386,6 @@ onKeydown = (event) ->
       if (isEditable(event.srcElement))
         event.srcElement.blur()
       exitInsertMode()
-      DomUtils.suppressEvent(event)
 
   else if (findMode)
     if (KeyboardUtils.isEscape(event))


### PR DESCRIPTION
Issue #499 mentions that Vimium breaks escape-to-close-chat-tabs on facebook.com. The easiest way to fix this is to simply allow those events to propagate normally to the page. The current behavior was chosen because users might want to leave the chat field without closing the tab (or similar on other sites), but &lt;C-[&gt; already exists as an alternative to ESC that serves that purpose.

We could add an advanced option to configure this behavior. Or we could add a third, non-vim-standard escape sequence with the pass through behavior. But I wanted to suggest this one line change for comments, since it's simple, and it's likely to be what users expect (which is to say, it's what I expect :)
