### PR TITLE
Make sure the build succeeds immediately after checkout

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -19,6 +19,14 @@ optArrayFromDict = (opts) ->
       result.push "--#{key}=#{value}"
   result
 
+existsSync = fs.existsSync || path.existsSync
+
+checkExtensionKey = (opts) ->
+  for key, value of opts
+    if key == 'pack-extension-key' && not existsSync value 
+        delete opts[key]
+  opts
+
 # visitor will get passed the file path as a parameter
 visitDirectory = (directory, visitor) ->
   fs.readdirSync(directory).forEach (filename) ->
@@ -59,7 +67,7 @@ task "package", "build .crx file", ->
   manifest.update_url = "http://philc.github.com/vimium/updates.xml"
   fs.writeFileSync "manifest.json", JSON.stringify manifest
 
-  crxmake = spawn "crxmake", optArrayFromDict
+  crxmake = spawn "crxmake", optArrayFromDict checkExtensionKey
     "pack-extension": "."
     "pack-extension-key": "vimium.pem"
     "extension-output": "vimium-latest.crx"


### PR DESCRIPTION
This patch is a cleaner fix for the following error I faced when I was running "cake package" immediately after checking out from git.

$ cake.coffeescript package
private key not exist
option not valid

[usage]
  required opt

After the first successful package run, crxmake does create a vimium.pem for later use automatically.
