### PR TITLE
Make sure the build succeeds immediately after checkout - II

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -21,10 +21,11 @@ optArrayFromDict = (opts) ->
 
 existsSync = fs.existsSync || path.existsSync
 
+# remove the -pack-extension-key option from opts if the file is missing
 checkExtensionKey = (opts) ->
   for key, value of opts
     if key == 'pack-extension-key' && not existsSync value 
-        delete opts[key]
+      delete opts[key]
   opts
 
 # visitor will get passed the file path as a parameter


### PR DESCRIPTION
This the updated patch with the right indentation & a comment describing what checkExtensionKey (it is a filter which removes "pack-extension-key" from the opts array if the vimium.pem is missing).

This incorporates the same fix as before, for the following error I faced when I was running "cake package" immediately after checking out from git.

$ cake.coffeescript package
private key not exist
option not valid

[usage]
required opt

After the first successful package run, crxmake does create a vimium.pem for later use automatically.
