### PR TITLE
Fix #766

### DIFF
--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -297,6 +297,8 @@ body.vimiumFindMode ::selection {
 
 #vomnibar input {
   font-size: 20px;
+  height: 34px;
+  margin-bottom: 0;
   padding: 4px;
   background-color: white;
   border-radius: 3px;


### PR DESCRIPTION
Fix #766 for all pages that use bootstrap which has `input["text"]` css rules.
