### PR TITLE
Disable Vimium on Facebook by default

### DIFF
--- a/background_scripts/settings.coffee
+++ b/background_scripts/settings.coffee
@@ -49,6 +49,7 @@ root.Settings = Settings =
       """
       http*://mail.google.com/*
       http*://www.google.com/reader/*
+      http*://*.facebook.com/*
       """
     # NOTE : If a page contains both a single angle-bracket link and a double angle-bracket link, then in
     # most cases the single bracket link will be "prev/next page" and the double bracket link will be


### PR DESCRIPTION
Like Gmail, FB now implements a number of vim-style shortcuts of its
own, like jk movement and / to search. We've also been stomping on
keys like Esc to close chat tabs. If it's worth special-casing Gmail in
the defaults, it's probably worth doing the same for FB.
