### PR TITLE
removeTab() shouldn't add callback to selectionChangedHandlers if it's undefined

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -234,12 +234,9 @@ BackgroundCommands =
   previousTab: (callback) -> selectTab(callback, "previous")
   firstTab: (callback) -> selectTab(callback, "first")
   lastTab: (callback) -> selectTab(callback, "last")
-  removeTab: (callback) ->
+  removeTab: ->
     chrome.tabs.getSelected(null, (tab) ->
-      chrome.tabs.remove(tab.id)
-      # We can't just call the callback here because we need to wait
-      # for the selection to change to consider this action done.
-      selectionChangedHandlers.push(callback))
+      chrome.tabs.remove(tab.id))
   restoreTab: (callback) ->
     # TODO(ilya): Should this be getLastFocused instead?
     chrome.windows.getCurrent((window) ->


### PR DESCRIPTION
[TL;DR](#tldr)
There is an error thrown with the code from current `master` branch:

```
Error in event handler for 'tabs.onSelectionChanged': 
Cannot call method 'call' of undefined
TypeError: Cannot call method 'call' of undefined
```

It happens after you close the tab with `x`. Inspired by the success of my other pull request I decided to track it down. =)

As a result I found that there is special case: when command is `background` and `noRepeat` at the same time it's handled by that line in [main.coffee](https://github.com/philc/vimium/blob/master/background_scripts/main.coffee#L490):

``` coffee
BackgroundCommands[registryEntry.command]()
```

And there is only one such command (`background` + `noRepeat`) — `removeTab`, which looks like this:

``` coffee
  removeTab: (callback) ->
    chrome.tabs.getSelected(null, (tab) ->
      chrome.tabs.remove(tab.id)
      # We can't just call the callback here because we need to wait
      # for the selection to change to consider this action done.
      selectionChangedHandlers.push(callback))
```

<a name="tldr"></a>As you can see it adds given callback to handlers list, but here `callback` is undefined, because this function was called on line 490 without any arguments.

I think we could fix with additional `if` statement in `removeTab()`, like this:

``` coffee
  removeTab: (callback) ->
    chrome.tabs.getSelected(null, (tab) ->
      chrome.tabs.remove(tab.id)
      selectionChangedHandlers.push(callback) if callback?)
```

Am I right? Is it ok to fix this problem like that? Or it will be better to check if callback is defined before calling it, like this:

``` coffee
chrome.tabs.onSelectionChanged.addListener (tabId, selectionInfo) ->
  if (selectionChangedHandlers.length > 0)
    selectionChangedHandlers.pop()?.call()
```
