### PR TITLE
Fixes #812 - Activate hover effect on link

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -93,6 +93,7 @@ Commands =
        "openCopiedUrlInCurrentTab", "openCopiedUrlInNewTab", "goUp", "goToRoot",
        "enterInsertMode", "focusInput",
        "LinkHints.activateMode", "LinkHints.activateModeToOpenInNewTab", "LinkHints.activateModeWithQueue",
+       "LinkHints.activateHoverEffectMode",
        "Vomnibar.activate", "Vomnibar.activateInNewTab", "Vomnibar.activateTabSelection",
        "Vomnibar.activateBookmarks", "Vomnibar.activateBookmarksInNewTab",
        "goPrevious", "goNext", "nextFrame", "Marks.activateCreateMode", "Marks.activateGotoMode"]
@@ -110,7 +111,8 @@ Commands =
   advancedCommands: [
     "scrollToLeft", "scrollToRight", "moveTabToNewWindow",
     "goUp", "goToRoot", "focusInput", "LinkHints.activateModeWithQueue",
-    "LinkHints.activateModeToOpenIncognito", "goNext", "Marks.activateCreateMode", "Marks.activateGotoMode"]
+    "LinkHints.activateModeToOpenIncognito", "LinkHints.activateHoverEffectMode",
+    "goNext", "Marks.activateCreateMode", "Marks.activateGotoMode"]
 
 defaultKeyMappings =
   "?": "showHelp"
@@ -218,6 +220,7 @@ commandDescriptions =
   'LinkHints.activateModeWithQueue': ["Open multiple links in a new tab"]
 
   "LinkHints.activateModeToOpenIncognito": ["Open a link in incognito window"]
+  "LinkHints.activateHoverEffectMode": ["Trigger a hover effect on a link"]
 
   enterFindMode: ["Enter find mode"]
   performFind: ["Cycle forward to the next find match"]

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -13,6 +13,7 @@ OPEN_IN_NEW_TAB = {}
 OPEN_WITH_QUEUE = {}
 COPY_LINK_URL = {}
 OPEN_INCOGNITO = {}
+HOVER_EFFECT = {}
 
 LinkHints =
   hintMarkerContainingDiv: null
@@ -50,6 +51,7 @@ LinkHints =
   activateModeToCopyLinkUrl: -> @activateMode(COPY_LINK_URL)
   activateModeWithQueue: -> @activateMode(OPEN_WITH_QUEUE)
   activateModeToOpenIncognito: -> @activateMode(OPEN_INCOGNITO)
+  activateHoverEffectMode: -> @activateMode(HOVER_EFFECT)
 
   activateMode: (mode = OPEN_IN_CURRENT_TAB) ->
     # we need documentElement to be ready in order to append links
@@ -99,6 +101,10 @@ LinkHints =
         chrome.extension.sendMessage(
           handler: 'openUrlInIncognito'
           url: link.href)
+    else if @mode is HOVER_EFFECT
+      HUD.show("Trigger a hover effect on a link")
+      @linkActivator = (link) ->
+        DomUtils.simulateMouseEnter(link)
     else # OPEN_IN_CURRENT_TAB
       HUD.show("Open link in current tab")
       # When we're opening the link in the current tab, don't navigate to the selected link immediately

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -98,12 +98,19 @@ DomUtils =
 
     eventSequence = ["mouseover", "mousedown", "mouseup", "click"]
     for event in eventSequence
-      mouseEvent = document.createEvent("MouseEvents")
-      mouseEvent.initMouseEvent(event, true, true, window, 1, 0, 0, 0, 0, modifiers.ctrlKey, false, false,
-          modifiers.metaKey, 0, null)
-      # Debugging note: Firefox will not execute the element's default action if we dispatch this click event,
-      # but Webkit will. Dispatching a click on an input box does not seem to focus it; we do that separately
-      element.dispatchEvent(mouseEvent)
+      @simulateMouseEvent(element, event, modifiers)
+
+  simulateMouseEnter: (element) ->
+    console.log element
+    @simulateMouseEvent(element, 'mouseover')
+
+  simulateMouseEvent: (element, event, modifiers = ctrlKey: false, metaKey: false) ->
+    mouseEvent = document.createEvent("MouseEvents")
+    mouseEvent.initMouseEvent(event, true, true, window, 1, 0, 0, 0, 0, modifiers.ctrlKey, false, false,
+        modifiers.metaKey, 0, null)
+    # Debugging note: Firefox will not execute the element's default action if we dispatch this click event,
+    # but Webkit will. Dispatching a click on an input box does not seem to focus it; we do that separately
+    element.dispatchEvent(mouseEvent)
 
   # momentarily flash a rectangular border to give user some visual feedback
   flashRect: (rect) ->


### PR DESCRIPTION
Add an unmapped command for a mode to trigger mouseover effect on a link. There are a number of caveats here:
1. I think the link hints should be filtered for this functionality to only those elements that have a mouseover event handler, but because there doesn't seem to be any way in the DOM API to retrieve the list of event handlers for an element, I am not sure this is possible.
2. For the same reason as #1, there may be some elements on the page that cannot be triggered using this function (for instance, amazon.com uses li elements for their sidenav menu items)
3. I am not aware of any way to detect whether or not the mouseover event is active on an element. Ideally I would like to have the function trigger the mouseout event if the mouseover event is active but I was unable to figure out a way to do this.
4. There doesn't seem to be a way for Javascript to move the mouse cursor to the element, only to trigger the effect. This makes sense as I imagine pages could get really annoying if they could move the mouse cursor.

In light of all this, feel free to reject the pull request and/or offer any suggestions on how to improve it. I'd be happy to work on this more if anyone has any tips.
