### PR TITLE
Fixes #799 - Add link hint delay configuration

### DIFF
--- a/background_scripts/settings.coffee
+++ b/background_scripts/settings.coffee
@@ -24,6 +24,7 @@ root.Settings = Settings =
     scrollStepSize: 60
     linkHintCharacters: "sadfjklewcmpgh"
     linkHintNumbers: "0123456789"
+    linkHintDelay: 400
     filterLinkHints: false
     hideHud: false
     userDefinedLinkHintCss:

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -103,7 +103,7 @@ LinkHints =
       HUD.show("Open link in current tab")
       # When we're opening the link in the current tab, don't navigate to the selected link immediately
       # we want to give the user some time to notice which link has received focus.
-      @linkActivator = (link) -> setTimeout(DomUtils.simulateClick.bind(DomUtils, link), 400)
+      @linkActivator = (link) -> setTimeout(DomUtils.simulateClick.bind(DomUtils, link), settings.get('linkHintDelay'))
 
   #
   # Creates a link marker for the given link.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -44,7 +44,7 @@ settings =
   loadedValues: 0
   valuesToLoad: ["scrollStepSize", "linkHintCharacters", "linkHintNumbers", "filterLinkHints", "hideHud",
     "previousPatterns", "nextPatterns", "findModeRawQuery", "regexFindMode", "userDefinedLinkHintCss",
-    "helpDialog_showAdvancedCommands"]
+    "helpDialog_showAdvancedCommands", "linkHintDelay"]
   isLoaded: false
   eventListeners: {}
 

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -115,7 +115,7 @@ DomUtils =
     flashEl.style.width = rect.width + "px"
     flashEl.style.height = rect.height + "px"
     document.documentElement.appendChild(flashEl)
-    setTimeout((-> DomUtils.removeElement flashEl), 400)
+    setTimeout((-> DomUtils.removeElement flashEl), settings.get('linkHintDelay'))
 
   suppressEvent: (event) ->
     event.preventDefault()

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -4,7 +4,7 @@ bgSettings = chrome.extension.getBackgroundPage().Settings
 
 editableFields = [ "scrollStepSize", "excludedUrls", "linkHintCharacters", "linkHintNumbers",
   "userDefinedLinkHintCss", "keyMappings", "filterLinkHints", "previousPatterns",
-  "nextPatterns", "hideHud", "regexFindMode", "searchUrl"]
+  "nextPatterns", "hideHud", "regexFindMode", "searchUrl", "linkHintDelay"]
 
 canBeEmptyFields = ["excludedUrls", "keyMappings", "userDefinedLinkHintCss"]
 
@@ -61,12 +61,13 @@ saveOptions = ->
         fieldValue = field.checked
       when "number"
         fieldValue = parseFloat field.value
+        fieldValue = 0 if fieldValue < 0
       else
         fieldValue = field.value.trim()
         field.value = fieldValue
 
     # If it's empty and not a field that we allow to be empty, restore to the default value
-    if not fieldValue and canBeEmptyFields.indexOf(fieldName) is -1
+    if (fieldValue is '' or isNaN(fieldValue)) and canBeEmptyFields.indexOf(fieldName) is -1
       bgSettings.clear fieldName
       fieldValue = bgSettings.get(fieldName)
     else
@@ -80,7 +81,7 @@ saveOptions = ->
 # Restores select box state to saved value from localStorage.
 populateOptions = ->
   for field in editableFields
-    val = bgSettings.get(field) or ""
+    val = if bgSettings.get(field)? then bgSettings.get(field) else ""
     setFieldValue $(field), val
   onDataLoaded()
 

--- a/pages/options.html
+++ b/pages/options.html
@@ -118,6 +118,10 @@
         width: 100%;;
         min-height: 100px;
       }
+      input#linkHintDelay {
+        width: 60px;
+        margin-right: 3px;
+      }
       textarea#keyMappings {
         width: 100%;
         min-height: 135px;
@@ -235,6 +239,17 @@ unmapAll
                 </div>
               </div>
               <textarea id="userDefinedLinkHintCss" class="code" type="text"></textarea>
+            </td>
+          </tr>
+          <tr>
+            <td class="caption">Link hint<br/>navigation delay</td>
+            <td verticalAlign="top">
+                <div class="help">
+                  <div class="example">
+                    Having a delay after selecting a link in link hints mode will allow you to see that you have selected the correct link
+                  </div>
+                </div>
+                <input id="linkHintDelay" type="number" />ms
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
Allow link hint delay to be configured on the settings page. Also
include a small fix to the options page that disallows negative numbers
in number fields and allows 0 to be entered as a valid number.
