### PR TITLE
Fix minor error with handlerStack in content script

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -176,7 +176,7 @@ LinkHints =
         keyup: (event) =>
           return if (event.keyCode != keyCodes.shiftKey)
           @setOpenLinkMode(prev_mode) if @isActive
-          @remove()
+          handlerStack.remove()
       })
 
     # TODO(philc): Ignore keys that have modifiers.


### PR DESCRIPTION
There is minor error `Uncaught TypeError: Object #<Object> has no method 'remove'` thrown by 

``` coffee
      handlerStack.push({
        keyup: (event) =>
          # ...
          @remove() # this line
      })
```

in `link_hints.coffee` content script. To reproduce, try press `f` and then `Shift` (yep, just `Shift`) on any page with enabled Vimium built from current `master` branch.
