### PR TITLE
Replace `sendRequest()` calls with `sendMessage()` ones in marks.coffee

### DIFF
--- a/background_scripts/marks.coffee
+++ b/background_scripts/marks.coffee
@@ -24,11 +24,11 @@ removeMarksForTab = (id) ->
 root.goto = (req, sender) ->
   mark = marks[req.markName]
   chrome.tabs.update mark.tabId, selected: true
-  chrome.tabs.sendRequest mark.tabId,
+  chrome.tabs.sendMessage mark.tabId,
     name: "setScrollPosition"
     scrollX: mark.scrollX
     scrollY: mark.scrollY
-  chrome.tabs.sendRequest mark.tabId,
+  chrome.tabs.sendMessage mark.tabId,
     name: "showHUDforDuration",
     text: "Jumped to global mark '#{req.markName}'"
     duration: 1000

--- a/content_scripts/marks.coffee
+++ b/content_scripts/marks.coffee
@@ -6,7 +6,7 @@ root.activateCreateMode = ->
     return unless keyChar isnt ""
 
     if /[A-Z]/.test keyChar
-      chrome.extension.sendRequest {
+      chrome.extension.sendMessage {
         handler: 'createMark',
         markName: keyChar
         scrollX: window.scrollX,
@@ -29,7 +29,7 @@ root.activateGotoMode = ->
     return unless keyChar isnt ""
 
     if /[A-Z]/.test keyChar
-      chrome.extension.sendRequest
+      chrome.extension.sendMessage
         handler: 'gotoMark'
         markName: keyChar
     else if /[a-z]/.test keyChar


### PR DESCRIPTION
Fixing my incomplete commit 9403692e51, with moving from old `sendRequest` API to the new `sendMessage` in two more files: `marks.coffee`, both background and content scripts.

I'm sorry, I don't know how I could possibly miss these four calls.
Thanks for spotting this, @harry313!

So, merging this change will resolve #849.
