### PR TITLE
Remove Google Reader rule.

### DIFF
--- a/background_scripts/settings.coffee
+++ b/background_scripts/settings.coffee
@@ -48,7 +48,6 @@ root.Settings = Settings =
     excludedUrls:
       """
       http*://mail.google.com/*
-      http*://www.google.com/reader/*
       """
     # NOTE : If a page contains both a single angle-bracket link and a double angle-bracket link, then in
     # most cases the single bracket link will be "prev/next page" and the double bracket link will be


### PR DESCRIPTION
Since Google Reader has been discontinued, there
is no reason to add this rule to the excludedUrls.
