### PR TITLE
Some events don't have `keyIdentifier`

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -359,8 +359,8 @@ onKeydown = (event) ->
 
   # handle special keys, and normal input keys with modifiers being pressed. don't handle shiftKey alone (to
   # avoid / being interpreted as ?
-  if (((event.metaKey || event.ctrlKey || event.altKey) && event.keyCode > 31) ||
-      event.keyIdentifier.slice(0, 2) != "U+")
+  if (((event.metaKey || event.ctrlKey || event.altKey) && event.keyCode > 31) || (
+      event.keyIdentifier && event.keyIdentifier.slice(0, 2) != "U+"))
     keyChar = KeyboardUtils.getKeyChar(event)
     # Again, ignore just modifiers. Maybe this should replace the keyCode>31 condition.
     if (keyChar != "")


### PR DESCRIPTION
This was throwing an error for me on some events.
