### PR TITLE
Add favicons to vomnibar completions

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -26,6 +26,7 @@ class Suggestion
 
   generateHtml: ->
     return @html if @html
+    favIconUrl = @tabFavIconUrl or "#{@getUrlRoot(@url)}/favicon.ico"
     relevancyHtml = if @showRelevancy then "<span class='relevancy'>#{@computeRelevancy()}</span>" else ""
     # NOTE(philc): We're using these vimium-specific class names so we don't collide with the page's CSS.
     @html =
@@ -34,11 +35,18 @@ class Suggestion
          <span class="vimiumReset vomnibarSource">#{@type}</span>
          <span class="vimiumReset vomnibarTitle">#{@highlightTerms(Utils.escapeHtml(@title))}</span>
        </div>
-       <div class="vimiumReset vomnibarBottomHalf">
+       <div class="vimiumReset vomnibarBottomHalf vomnibarIcon"
+            style="background-image: url(#{favIconUrl});">
         <span class="vimiumReset vomnibarUrl">#{@shortenUrl(@highlightTerms(@url))}</span>
         #{relevancyHtml}
       </div>
       """
+
+  # use neat trick to snatch a domain (http://stackoverflow.com/a/8498668)
+  getUrlRoot: (url) ->
+    a = document.createElement 'a'
+    a.href = url
+    a.protocol + "//" + a.hostname
 
   shortenUrl: (url) -> @stripTrailingSlash(url).replace(/^http:\/\//, "")
 
@@ -241,6 +249,7 @@ class TabCompleter
       suggestions = results.map (tab) =>
         suggestion = new Suggestion(queryTerms, "tab", tab.url, tab.title, @computeRelevancy)
         suggestion.tabId = tab.id
+        suggestion.tabFavIconUrl = tab.favIconUrl
         suggestion
       onComplete(suggestions)
 

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -349,6 +349,13 @@ body.vimiumFindMode ::selection {
   padding: 2px 0;
 }
 
+#vomnibar li .vomnibarIcon {
+  background-position-y: center;
+  background-size: 16px;
+  background-repeat: no-repeat;
+  padding-left: 20px;
+}
+
 #vomnibar li .vomnibarSource {
   color: #777;
   margin-right: 4px;


### PR DESCRIPTION
This commit simply adds favicons as a background-image style next to
urls in similar style to chrome's history page.
The icon is specified by either chrome tab's favIconUrl property for tabs
or else we try protocol://hostname/favicon.ico which usually serves.
(e.g. http://example.com/favicon.ico)
