### PR TITLE
Vimium Toggle shortcut

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -329,6 +329,10 @@ updateActiveState = (tabId) ->
       isCurrentlyEnabled = (response? && response.enabled)
       shouldBeEnabled = isEnabledForUrl({url: tab.url}).isEnabledForUrl
 
+      # check if vimium is currently swithced in the tab, and switch souldBeEnabled accordingly
+      isSwitched = (response? && response.switched)
+      shouldBeEnabled = !shouldBeEnabled if (isSwitched)
+
       if (isCurrentlyEnabled)
         if (shouldBeEnabled)
           chrome.browserAction.setIcon({ path: enabledIcon })

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -15,6 +15,7 @@ isShowingHelpDialog = false
 keyPort = null
 # Users can disable Vimium on URL patterns via the settings page.
 isEnabledForUrl = true
+isSwitched = false
 # The user's operating system.
 currentCompletionKeys = null
 validFirstKeys = null
@@ -115,7 +116,7 @@ initializePreDomReady = ->
     getScrollPosition: -> scrollX: window.scrollX, scrollY: window.scrollY
     setScrollPosition: (request) -> setScrollPosition request.scrollX, request.scrollY
     executePageCommand: executePageCommand
-    getActiveState: -> { enabled: isEnabledForUrl }
+    getActiveState: -> { enabled: isEnabledForUrl, switched: isSwitched }
     disableVimium: disableVimium
 
   chrome.runtime.onMessage.addListener (request, sender, sendResponse) ->
@@ -364,7 +365,8 @@ onKeypress = (event) ->
 # The switch is *temporary*, and the configured enabled or disabled Vimium state is restored on page reload.
 #
 onSwitchKeyDown = (event) ->
-  if (event.metaKey && KeyboardUtils.getKeyChar(event))
+  if (event.metaKey && KeyboardUtils.isEscape(event))
+    isSwitched = !isSwitched
     if (isEnabledForUrl)
       disableVimium()
       chrome.runtime.sendMessage({enabled: false, handler: 'iconToggler'})


### PR DESCRIPTION
I know there's an _i_ command to enter insert mode and essentially disable the plugin, until hitting ESC. That's no good for apps like Gmail, where you want Vimium disabled almost always, and if it were enabled but in insert mode, you would constantly hit ESC or shift + ESC to jump back and forth panels.

This PL adds an always present shortcut (Cmd + ESC or Windows + ESC, see below) to enable or disable Vimium regardless of the current configuration. It's a simple switch. As a bonus, it updates the icon in the current tab to indicate the current enabled or disabled state. A small visual bug I didn't find much too important: if you leave a temporarily switched tab and come back, you'll see the icon Vimiums sets without honouring the current switch. Lastly, the switch will remain active until page reload, when it will be set back to enabled or disabled based on your Vimium config.

About the shortcut, I'm not thrilled about it, but it seems to work. I understand that Vimperator uses Shift + ESC to do this kind of switch, but Shift + ESC collides with Gmail's way of leaving panels opened but moving focus back to email list, and I basically did this for Gmail :)

Hope you like it!
Ramiro
