### PR TITLE
First option automatically selected when it becomes available when using...

### DIFF
--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -68,6 +68,7 @@ class VomnibarUI
     @update(true)
 
   updateSelection: ->
+    if @completionList.children.length != 0 && @selection < 0 then @selection = 0
     for i in [0...@completionList.children.length]
       @completionList.children[i].className = (if i == @selection then "vomnibarSelected" else "")
 

--- a/tests/dom_tests/vomnibar_test.coffee
+++ b/tests/dom_tests/vomnibar_test.coffee
@@ -11,7 +11,7 @@ context "Keep selection within bounds",
   tearDown ->
     Vomnibar.vomnibarUI.hide()
 
-  should "set selection to position -1 for omni completion by default", ->
+  should "set selection to position 0 for omni completion if possible", ->
     Vomnibar.activate()
     ui = Vomnibar.vomnibarUI
 
@@ -19,9 +19,9 @@ context "Keep selection within bounds",
     ui.update(true)
     assert.equal -1, ui.selection
 
-    @completions = [{html:'foo',type:'tab',url:'http://example.com'}]
+    @completions = [{html:'foo',type:'bookmark',url:'http://example.com'}]
     ui.update(true)
-    assert.equal -1, ui.selection
+    assert.equal 0, ui.selection
 
     @completions = []
     ui.update(true)


### PR DESCRIPTION
All commands that use the omnibar except "O"/"o" automatically select the first item of their respective list of options.  Since I use 'o' almost exclusively I think it would be nice to automatically select the first item once it becomes available.
