### PR TITLE
Stop keyup events from passing to the browser

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -433,7 +433,10 @@ onKeydown = (event) ->
       isValidFirstKey(KeyboardUtils.getKeyChar(event))))
     event.stopPropagation()
 
-onKeyup = (event) -> return unless handlerStack.bubbleEvent('keyup', event)
+onKeyup = (event) -> 
+  return unless handlerStack.bubbleEvent('keyup', event)
+  if (!isInsertMode())
+    event.stopPropagation();
 
 checkIfEnabledForUrl = ->
   url = window.location.toString()


### PR DESCRIPTION
Some websites (like Wired) have an annoying 'feature' which enables j and k keys to navigate to next/prev articles.  This shouldn't happen when vimium is operating in command mode because vimium should be handling the events and not passing them onto the web page.

This was created to address Issue #733 
