### PR TITLE
Allow open popups from bookmarklets. Fix #968.

### DIFF
--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -215,15 +215,11 @@ extend BackgroundCompleter,
   completionActions:
     navigateToUrl: (url, openInNewTab) ->
       # If the URL is a bookmarklet prefixed with javascript:, we shouldn't open that in a new tab.
-      if url.startsWith "javascript:"
-        script = document.createElement 'script'
-        script.textContent = decodeURIComponent(url["javascript:".length..])
-        (document.head || document.documentElement).appendChild script
-      else
-        chrome.runtime.sendMessage(
-          handler: if openInNewTab then "openUrlInNewTab" else "openUrlInCurrentTab"
-          url: url,
-          selected: openInNewTab)
+      openInNewTab = false if url.startsWith("javascript:")
+      chrome.runtime.sendMessage(
+        handler: if openInNewTab then "openUrlInNewTab" else "openUrlInCurrentTab"
+        url: url,
+        selected: openInNewTab)
 
     switchToTab: (tabId) -> chrome.runtime.sendMessage({ handler: "selectSpecificTab", id: tabId })
 

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -26,7 +26,7 @@ Utils =
     -> id += 1
 
   hasChromePrefix: (url) ->
-    chromePrefixes = [ 'about', 'view-source', "chrome-extension" ]
+    chromePrefixes = [ 'about', 'view-source', "chrome-extension", "javascript:" ]
     for prefix in chromePrefixes
       return true if url.startsWith prefix
     false


### PR DESCRIPTION
Use the `openUrlInCurrentTab` message to open bookmarklets so they are opened
via `chrome.tabs.update` instead of an injected script element. This allows
bookmarklets to open popups.

This is a pull request for issue #968. Done with help from @mrmr1993's comment on that issue. Let me know if you need something changed before this can be merged.

Thank you.
