### PR TITLE
Fix some bookmarklets ruining the vomnibar UI.

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -35,12 +35,16 @@ class Suggestion
          <span class="vimiumReset vomnibarTitle">#{@highlightTerms(Utils.escapeHtml(@title))}</span>
        </div>
        <div class="vimiumReset vomnibarBottomHalf">
-        <span class="vimiumReset vomnibarUrl">#{@shortenUrl(@highlightTerms(@url))}</span>
+        <span class="vimiumReset vomnibarUrl">#{@shortenUrl(@highlightTerms(@htmlEntities @url))}</span>
         #{relevancyHtml}
       </div>
       """
 
   shortenUrl: (url) -> @stripTrailingSlash(url).replace(/^https?:\/\//, "")
+
+  # Adapted version of http://css-tricks.com/snippets/javascript/htmlentities-for-javascript
+  htmlEntities: (text) ->
+    text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
 
   stripTrailingSlash: (url) ->
     url = url.substring(url, url.length - 1) if url[url.length - 1] == "/"


### PR DESCRIPTION
If a bookmarklet contains html in a string, then that html is rendered when the
bookmarklet is filtered from the vomnibar. Because of this, some bookmarklets
are causing a mess in the vomnibar's results UI. This fixes it by running
htmlEntities on the url before display. It doesn't affect the dispay of normal
bookmarks.

The htmlEntities should be run before the highlightTerms call, otherwise the
markup added by highlightTerms will also be escaped which is not inteded.

To test this, create a new bookmark with the following in the URL field: `javascript:alert('<img src=dummy>');`. Clicking this bookmarklet from the bookmarks bar works just fine. It gives the expected alert. Now open bookmarks finder vomnibar (hit `b`) and search for this. You can see the img tag rendered and a non-existent broken image showing up.

Without the fix:
![2014-01-03-115220_356x164_scrot](https://f.cloud.github.com/assets/120119/1837718/9a50b8d2-743f-11e3-91fe-507456566dab.png)

With this fix:
![2014-01-03-115316_357x153_scrot](https://f.cloud.github.com/assets/120119/1837719/a12a3994-743f-11e3-9934-148215b97ef8.png)
