### PR TITLE
New feature: edit the current URL in the omnibar

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -95,6 +95,7 @@ Commands =
        "LinkHints.activateMode", "LinkHints.activateModeToOpenInNewTab", "LinkHints.activateModeWithQueue",
        "Vomnibar.activate", "Vomnibar.activateInNewTab", "Vomnibar.activateTabSelection",
        "Vomnibar.activateBookmarks", "Vomnibar.activateBookmarksInNewTab",
+       "Vomnibar.activateEditUrl", "Vomnibar.activateEditUrlInNewTab",
        "goPrevious", "goNext", "nextFrame", "Marks.activateCreateMode", "Marks.activateGotoMode"]
     findCommands: ["enterFindMode", "performFind", "performBackwardsFind"]
     historyNavigation:
@@ -110,6 +111,7 @@ Commands =
   advancedCommands: [
     "scrollToLeft", "scrollToRight", "moveTabToNewWindow",
     "goUp", "goToRoot", "focusInput", "LinkHints.activateModeWithQueue",
+    "Vomnibar.activateEditUrl", "Vomnibar.activateEditUrlInNewTab",
     "LinkHints.activateModeToOpenIncognito", "goNext", "goPrevious", "Marks.activateCreateMode",
     "Marks.activateGotoMode"]
 
@@ -177,6 +179,9 @@ defaultKeyMappings =
 
   "b": "Vomnibar.activateBookmarks"
   "B": "Vomnibar.activateBookmarksInNewTab"
+
+  "ge": "Vomnibar.activateEditUrl"
+  "gE": "Vomnibar.activateEditUrlInNewTab"
 
   "gf": "nextFrame"
 
@@ -251,6 +256,8 @@ commandDescriptions =
   "Vomnibar.activateTabSelection": ["Search through your open tabs"]
   "Vomnibar.activateBookmarks": ["Open a bookmark"]
   "Vomnibar.activateBookmarksInNewTab": ["Open a bookmark in a new tab"]
+  "Vomnibar.activateEditUrl": ["Edit the current URL"]
+  "Vomnibar.activateEditUrlInNewTab": ["Edit the current URL and open in a new tab"]
 
   nextFrame: ["Cycle forward to the next frame on the page", { background: true, passCountToFunction: true }]
 

--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -28,6 +28,8 @@ Vomnibar =
   activateTabSelection: -> @activateWithCompleter("tabs", 0, null, true)
   activateBookmarks: -> @activateWithCompleter("bookmarks", 0, null, true)
   activateBookmarksInNewTab: -> @activateWithCompleter("bookmarks", 0, null, true, true)
+  activateEditUrl: -> @activateWithCompleter("omni", 100, window.location.href)
+  activateEditUrlInNewTab: -> @activateWithCompleter("omni", 100, window.location.href, false, true)
   getUI: -> @vomnibarUI
 
 


### PR DESCRIPTION
Often times when I'm working on sites I want to add a query string or modify the port number. The go up one level or root of the URL commands are nice but they don't alow you to add or remove specifics on the current URL.

This adds two commands that act exactly like the normal onmibar open but populates the bar with the current URL.

I picked `ge` as the default and `gE` as the default for the same in a new tab.
