### PR TITLE
New feature: visual mode with keybinding support

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -249,19 +249,19 @@ defaultKeyMappings =
   "`": "Marks.activateGotoMode"
 
 defaultVisualModeKeyMappings =
-  "h": "backwardCharacter"
-  "l": "forwardCharacter"
+  "h": "VisualMode.backwardCharacter"
+  "l": "VisualMode.forwardCharacter"
 
-  "o": "toggleFreeEndOfSelection"
-  "k": "backwardLine"
-  "j": "forwardLine"
-  "b": "backwardWord"
-  "e": "forwardWord"
-  "w": "forwardWord"
-  "0": "backwardLineBoundary"
-  "$": "forwardLineBoundary"
-  "y": "yankSelection"
-  "r": "reload"
+  "o": "VisualMode.toggleFreeEndOfSelection"
+  "k": "VisualMode.backwardLine"
+  "j": "VisualMode.forwardLine"
+  "b": "VisualMode.backwardWord"
+  "e": "VisualMode.forwardWord"
+  "w": "VisualMode.forwardWord"
+  "0": "VisualMode.backwardLineBoundary"
+  "$": "VisualMode.forwardLineBoundary"
+  "y": "VisualMode.yankSelection"
+  "r": "VisualMode.reload"
 
 # This is a mapping of: commandIdentifier => [description, options].
 commandDescriptions =
@@ -338,26 +338,32 @@ commandDescriptions =
   "Marks.activateGotoMode": ["Go to a mark"]
 
 visualModeCommandDescriptions =
-  backwardCharacter: ["extend the current selection backward by one character"]
-  forwardCharacter: ["extend the current selection forward by one character"]
+  "VisualMode.backwardCharacter": [
+    "extend the current selection backward by one character"]
+  "VisualMode.forwardCharacter": [
+    "extend the current selection forward by one character"]
 
-  backwardWord: ["extend the current selection backward by one word"]
-  forwardWord: ["extend the current selection forward by one word"]  
+  "VisualMode.backwardWord": [
+    "extend the current selection backward by one word"]
+  "VisualMode.forwardWord": [
+    "extend the current selection forward by one word"]
 
-  backwardLine: ["extend the current selection backward by one line"]
-  forwardLine: ["extend the current selection forward by one line"]
+  "VisualMode.backwardLine": [
+    "extend the current selection backward by one line"]
+  "VisualMode.forwardLine": [
+    "extend the current selection forward by one line"]
 
-  backwardLineBoundary: [
+  "VisualMode.backwardLineBoundary": [
     "extend the current selection back to the beginning of the line"]
-  forwardLineBoundary: [
+  "VisualMode.forwardLineBoundary": [
     "extend the current selection forward to the end of the line"]
 
-  toggleFreeEndOfSelection: [
+  "VisualMode.toggleFreeEndOfSelection": [
     "switch between controlling the beginning or end of the selected area"]
-  reload: ["reload the page"]
-  deactivateModeNow: ["deactivate Visual Mode"]
+  "VisualMode.reload": ["reload the page"]
+  "VisualMode.deactivateModeNow": ["deactivate Visual Mode"]
 
-  yankSelection: [
+  "VisualMode.yankSelection": [
     "copy the selected text to the clipboard and deactivate visual mode"]
 
 Commands.init()

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -101,6 +101,8 @@ Commands =
       ["goBack", "goForward"]
     tabManipulation:
       ["nextTab", "previousTab", "firstTab", "lastTab", "createTab", "duplicateTab", "removeTab", "restoreTab", "moveTabToNewWindow"]
+    visualMode:
+      ["VisualMode.toggleVisualMode"]
     misc:
       ["showHelp"]
 
@@ -129,6 +131,7 @@ defaultKeyMappings =
   "d": "scrollPageDown"
   "u": "scrollPageUp"
   "r": "reload"
+  "v": "VisualMode.toggleVisualMode"
   "gs": "toggleViewSource"
 
   "i": "enterInsertMode"
@@ -203,6 +206,7 @@ commandDescriptions =
   scrollFullPageUp: ["Scroll a full page up"]
 
   reload: ["Reload the page"]
+  'VisualMode.toggleVisualMode': ["Toggle Visual Mode"]
   toggleViewSource: ["View page source"]
 
   copyCurrentUrl: ["Copy the current URL to the clipboard"]

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -54,6 +54,13 @@ Commands =
       if visualMode then @keyToVisualModeCommandRegistry
       else @keyToCommandRegistry
 
+    # the toggleVisualMode command is a special case: if a key is bound to it,
+    # it must ALSO be bound to "deactivateModeNow" in visual mode to ensure
+    # consistent behavior (because visual mode captures keys without sending
+    # them to the global key handler)
+    if not visualMode and command == "VisualMode.toggleVisualMode"
+      @mapKeyToCommand(key, "deactivateModeNow", visualMode = true)
+
     unless availableCommands[command]
       console.log(command, "doesn't exist!")
       return
@@ -129,14 +136,13 @@ Commands =
 
   clearKeyMappingsAndSetDefaults: ->
     @keyToCommandRegistry = {}
-
-    for key of defaultKeyMappings
-      @mapKeyToCommand(key, defaultKeyMappings[key])
-
     @keyToVisualModeCommandRegistry = {}
 
-    for key of defaultVisualModeKeyMappings
-      @mapKeyToCommand(key, defaultVisualModeKeyMappings[key], visualMode=true)
+    for key, command of defaultKeyMappings
+      @mapKeyToCommand(key, command)
+
+    for key, command of defaultVisualModeKeyMappings
+      @mapKeyToCommand(key, command, visualMode=true)
 
   # An ordered listing of all available commands, grouped by type. This is the order they will
   # be shown in the help page.
@@ -255,9 +261,7 @@ defaultVisualModeKeyMappings =
   "0": "backwardLineBoundary"
   "$": "forwardLineBoundary"
   "y": "yankSelection"
-
   "r": "reload"
-  "v": "deactivateModeNow"
 
 # This is a mapping of: commandIdentifier => [description, options].
 commandDescriptions =
@@ -352,6 +356,9 @@ visualModeCommandDescriptions =
     "switch between controlling the beginning or end of the selected area"]
   reload: ["reload the page"]
   deactivateModeNow: ["deactivate Visual Mode"]
+
+  yankSelection: [
+    "copy the selected text to the clipboard and deactivate visual mode"]
 
 Commands.init()
 

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -54,13 +54,6 @@ Commands =
       if visualMode then @keyToVisualModeCommandRegistry
       else @keyToCommandRegistry
 
-    # the toggleVisualMode command is a special case: if a key is bound to it,
-    # it must ALSO be bound to "deactivateModeNow" in visual mode to ensure
-    # consistent behavior (because visual mode captures keys without sending
-    # them to the global key handler)
-    if not visualMode and command == "VisualMode.toggleVisualMode"
-      @mapKeyToCommand(key, "deactivateModeNow", visualMode = true)
-
     unless availableCommands[command]
       console.log(command, "doesn't exist!")
       return
@@ -361,7 +354,7 @@ visualModeCommandDescriptions =
   "VisualMode.toggleFreeEndOfSelection": [
     "switch between controlling the beginning or end of the selected area"]
   "VisualMode.reload": ["reload the page"]
-  "VisualMode.deactivateModeNow": ["deactivate Visual Mode"]
+  "VisualMode.deactivateMode": ["deactivate Visual Mode"]
 
   "VisualMode.yankSelection": [
     "copy the selected text to the clipboard and deactivate visual mode"]

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -64,9 +64,11 @@ Commands =
       passCountToFunction: availableCommands[command].passCountToFunction
       noRepeat: availableCommands[command].noRepeat
 
-  unmapKey: (key) -> delete @keyToCommandRegistry[key]
-
-  unmapVisualModeKey: (key) -> delete @keyToVisualModeCommandRegistry[key]
+  unmapKey: (key, visualMode = false) ->
+    if visualMode
+      delete @keyToVisualModeCommandRegistry[key]
+    else
+      delete @keyToCommandRegistry[key]
 
   # Lower-case the appropriate portions of named keys.
   #
@@ -123,7 +125,7 @@ Commands =
 
         key = @normalizeKey(splitLine[1])
         console.log("Unmapping (visual mode)", key)
-        @unmapVisualModeKey(key)
+        @unmapKey(key, visualMode = true)
       else if (lineCommand == "unmapAll")
         @keyToCommandRegistry = {}
 

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -583,6 +583,11 @@ Commands.clearKeyMappingsAndSetDefaults()
 if Settings.has("keyMappings")
   Commands.parseCustomKeyMappings(Settings.get("keyMappings"))
 
+# make visual mode keys available to visual mode on page via settings
+Settings.set(
+  "keyToVisualModeCommandRegistry",
+  Commands.keyToVisualModeCommandRegistry)
+
 populateValidFirstKeys()
 populateSingleKeyCommands()
 if shouldShowUpgradeMessage()

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -301,6 +301,7 @@ updateOpenTabs = (tab) ->
     scrollX: null
     scrollY: null
     deletor: null
+    visualMode: false
   # Frames are recreated on refresh
   delete framesForTab[tab.id]
 
@@ -470,8 +471,17 @@ checkKeyQueue = (keysToCheck, tabId, frameId) ->
 
   if (Commands.keyToCommandRegistry[command])
     registryEntry = Commands.keyToCommandRegistry[command]
+    visualModeActive = tabInfoMap[tabId].visualMode
+
+    if registryEntry.command == "VisualMode.toggleVisualMode"
+      tabInfoMap[tabId].visualMode = not visualModeActive
+    else if visualModeActive
+      # if we're in visual mode and the command *isn't* toggleVisualMode, look up
+      # the command again in the visual mode registry
+      registryEntry = Commands.keyToVisualModeCommandRegistry[command]
 
     if !registryEntry.isBackgroundCommand
+
       chrome.tabs.sendMessage(tabId,
         name: "executePageCommand",
         command: registryEntry.command,

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -469,11 +469,17 @@ checkKeyQueue = (keysToCheck, tabId, frameId) ->
   return keysToCheck if command.length == 0
   count = 1 if isNaN(count)
 
-  if (Commands.keyToCommandRegistry[command])
-    registryEntry = Commands.keyToCommandRegistry[command]
-    visualModeActive = tabInfoMap[tabId].visualMode
+  visualModeActive = tabInfoMap[tabId].visualMode
+  
 
-    if registryEntry.command == "VisualMode.toggleVisualMode"
+  if (!visualModeActive && Commands.keyToCommandRegistry[command] ||
+      visualModeActive && Commands.keyToVisualModeCommandRegistry[command])
+    #look up the command
+    #we start by looking in the main registry even if we're in visual mode, so
+    #we have a chance to find the toggleVisualMode command
+    registryEntry = Commands.keyToCommandRegistry[command]
+
+    if registryEntry && registryEntry.command == "VisualMode.toggleVisualMode"
       tabInfoMap[tabId].visualMode = not visualModeActive
     else if visualModeActive
       # if we're in visual mode and the command *isn't* toggleVisualMode, look up

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -265,7 +265,8 @@ div.vimiumHUD a.close-button:hover {
   -webkit-user-select:none;
 }
 
-body.vimiumFindMode ::selection {
+body.vimiumFindMode ::selection,
+body.vimiumVisualMode ::selection {
   background: #ff9632;
 };
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -44,7 +44,7 @@ settings =
   loadedValues: 0
   valuesToLoad: ["scrollStepSize", "linkHintCharacters", "linkHintNumbers", "filterLinkHints", "hideHud",
     "previousPatterns", "nextPatterns", "findModeRawQuery", "regexFindMode", "userDefinedLinkHintCss",
-    "helpDialog_showAdvancedCommands"]
+    "helpDialog_showAdvancedCommands", "keyToVisualModeCommandRegistry"]
   isLoaded: false
   eventListeners: {}
 
@@ -101,6 +101,9 @@ initializePreDomReady = ->
   checkIfEnabledForUrl()
 
   refreshCompletionKeys()
+
+  VisualMode.keyToCommandRegistry = settings.get(
+    "keyToVisualModeCommandRegistry")
 
   # Send the key to the key handler in the background page.
   keyPort = chrome.runtime.connect({ name: "keyDown" })

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -94,6 +94,7 @@ hasModifiersRegex = /^<([amc]-)+.>/
 #
 initializePreDomReady = ->
   settings.addEventListener("load", LinkHints.init.bind(LinkHints))
+  settings.addEventListener("load", VisualMode.init.bind(VisualMode))
   settings.load()
 
   Scroller.init()
@@ -101,9 +102,6 @@ initializePreDomReady = ->
   checkIfEnabledForUrl()
 
   refreshCompletionKeys()
-
-  VisualMode.keyToCommandRegistry = settings.get(
-    "keyToVisualModeCommandRegistry")
 
   # Send the key to the key handler in the background page.
   keyPort = chrome.runtime.connect({ name: "keyDown" })

--- a/content_scripts/visual_mode.coffee
+++ b/content_scripts/visual_mode.coffee
@@ -1,0 +1,70 @@
+VisualMode = 
+
+  keyMap: ""
+  isActive: false
+  
+  toggleVisualMode: ->
+    if (@isActive) 
+      @deactivateMode()
+      return
+    
+    @isActive = true
+    HUD.show("Visual Mode")
+    document.body.classList.add("vimiumVisualMode")
+
+    @handlerId = handlerStack.push({
+      keydown: @onKeyDownInMode.bind(this),
+      # trap all key events
+      keypress: -> false
+      keyup: -> false
+    })
+  
+  onKeyDownInMode: (event) ->
+    keyCode = KeyboardUtils.getKeyChar(event)
+
+    if (KeyboardUtils.isEscape(event) || keyCode == "v") 
+      @deactivateMode()
+
+    sel = window.getSelection()
+    switch keyCode
+      when "h" then sel.modify("extend", "backward", "character")
+      when "l" then sel.modify("extend", "forward", "character")
+      
+      when "k" then sel.modify("extend", "backward", "line")
+      when "j" then sel.modify("extend", "forward", "line")
+      when "b" then sel.modify("extend", "backward", "word")
+      when "0" then sel.modify("extend", "backward", "lineboundary")
+      when "e" then sel.modify("extend", "forward", "word")
+      when "w" then sel.modify("extend", "forward", "word")
+      when "$" then sel.modify("extend", "forward", "lineboundary")
+      when "y" then @yankSelection()
+      when "r" then chrome.runtime.reload()
+
+  deactivateMode: (delay, callback) ->
+    deactivate = =>
+      handlerStack.remove @handlerId
+      HUD.hide()
+      @isActive = false
+      document.body.classList.remove("vimiumVisualMode")
+
+    # we invoke the deactivate() function directly instead of using setTimeout(callback, 0) so that
+    # deactivateMode can be tested synchronously
+    if (!delay)
+      deactivate()
+      callback() if (callback)
+    else
+      setTimeout(->
+        deactivate()
+        callback() if callback
+      delay)
+
+  yankSelection: ->
+    sel = window.getSelection()
+    text = sel.toString()
+    @deactivateMode()
+    sel.removeAllRanges()
+    chrome.extension.sendMessage { handler: "copyToClipboard", data: text}
+
+root = exports ? window
+@keymap = root.settings
+root.VisualMode = VisualMode 

--- a/content_scripts/visual_mode.coffee
+++ b/content_scripts/visual_mode.coffee
@@ -2,9 +2,11 @@ VisualMode =
 
   keyMap: ""
   isActive: false
-  
+  freeEndToggled: false
+
   toggleVisualMode: ->
-    if (@isActive) 
+    @freeEndToggled = false
+    if (@isActive)
       @deactivateMode()
       return
     
@@ -30,6 +32,7 @@ VisualMode =
       when "h" then sel.modify("extend", "backward", "character")
       when "l" then sel.modify("extend", "forward", "character")
       
+      when "o" then @toggleFreeEndOfSelection()
       when "k" then sel.modify("extend", "backward", "line")
       when "j" then sel.modify("extend", "forward", "line")
       when "b" then sel.modify("extend", "backward", "word")
@@ -39,6 +42,27 @@ VisualMode =
       when "$" then sel.modify("extend", "forward", "lineboundary")
       when "y" then @yankSelection()
       when "r" then chrome.runtime.reload()
+
+  toggleFreeEndOfSelection: ->
+    sel = window.getSelection()
+    range = sel.getRangeAt(0)
+    startOffset = range.startOffset
+    startContainer = range.startContainer
+    endOffset = range.endOffset
+    endContainer = range.endContainer
+
+    if (@freeEndToggled)
+      range.setStart(startContainer, startOffset)
+      sel.removeAllRanges()
+      sel.addRange(range)
+      sel.extend(endContainer, endOffset)
+    else
+      range.setStart(endContainer, endOffset)
+      sel.removeAllRanges()
+      sel.addRange(range)
+      sel.extend(startContainer, startOffset)
+
+    @freeEndToggled = !@freeEndToggled
 
   deactivateMode: (delay, callback) ->
     deactivate = =>

--- a/content_scripts/visual_mode.coffee
+++ b/content_scripts/visual_mode.coffee
@@ -1,11 +1,17 @@
 VisualMode = 
 
-  #keyToCommandRegistry will be populated on pageload by vimium_frontend, which
-  #retrieves keyToVisualModeCommandRegistry from settings
+  #keyToCommandRegistry will be populated on mode activation, when we can
+  #retrieve keyToVisualModeCommandRegistry from settings
   keyToCommandRegistry: {}
 
   isActive: false
   freeEndToggled: false
+
+  #
+  # To be called once settings hsa been loaded, so we can get the keybindings
+  #
+  init: ->
+    @keyToCommandRegistry = settings.get("keyToVisualModeCommandRegistry")
 
   backwardCharacter: (sel) -> sel.modify("extend", "backward", "character")
   forwardCharacter: (sel) -> sel.modify("extend", "forward", "character")

--- a/content_scripts/visual_mode.coffee
+++ b/content_scripts/visual_mode.coffee
@@ -58,7 +58,8 @@ VisualMode =
       this[commandName](sel)
 
   toggleFreeEndOfSelection: ->
-    range = window.getSelection().getRangeAt(0)
+    sel = window.getSelection()
+    range = sel.getRangeAt(0)
     startOffset = range.startOffset
     startContainer = range.startContainer
     endOffset = range.endOffset
@@ -96,9 +97,10 @@ VisualMode =
       delay)
 
   yankSelection: ->
-    text = window.getSelection().toString()
+    sel = window.getSelection()
+    text = sel.toString()
     @deactivateMode()
-    window.getSelection().removeAllRanges()
+    sel.removeAllRanges()
     chrome.extension.sendMessage { handler: "copyToClipboard", data: text}
 
 root = exports ? window

--- a/content_scripts/visual_mode.coffee
+++ b/content_scripts/visual_mode.coffee
@@ -29,10 +29,6 @@ VisualMode =
   
   reload: (sel) -> chrome.runtime.reload()
 
-  #wrap deactivateMode so that we can use the (sel) -> call signature without
-  #the selection being mistaken for the delay
-  deactivateModeNow: (sel) -> @deactivateMode()
-
   toggleVisualMode: ->
     @freeEndToggled = false
     if (@isActive)
@@ -53,19 +49,18 @@ VisualMode =
   onKeyDownInMode: (event) ->
     keyCode = KeyboardUtils.getKeyChar(event)
 
-    if (KeyboardUtils.isEscape(event) || keyCode == "v") 
-      @deactivateMode()
+    if (KeyboardUtils.isEscape(event)) 
+      @deactivateModeNow()
 
     #To prevent unexpected behavior, we're going to limit visual mode keybindings
     #to only triggering functions defined on the VisualMode object
 
     sel = window.getSelection()
     commandName = @keyToCommandRegistry[keyCode].command
-    command = this[commandName]
 
     #find the command we want to run and run it, passing the current selection
-    if typeof(command) == "function"
-      command(sel)
+    if typeof(this[commandName]) == "function"
+      this[commandName](sel)
 
   toggleFreeEndOfSelection: (sel) ->
     range = sel.getRangeAt(0)
@@ -104,6 +99,10 @@ VisualMode =
         deactivate()
         callback() if callback
       delay)
+
+  # wrap deactivateMode so that we can use the (sel) -> call signature without
+  # the selection being mistaken for the delay
+  deactivateModeNow: (sel) -> @deactivateMode()
 
   yankSelection: (sel) ->
     text = sel.toString()

--- a/content_scripts/visual_mode.coffee
+++ b/content_scripts/visual_mode.coffee
@@ -13,21 +13,23 @@ VisualMode =
   init: ->
     @keyToCommandRegistry = settings.get("keyToVisualModeCommandRegistry")
 
-  backwardCharacter: (sel) -> sel.modify("extend", "backward", "character")
-  forwardCharacter: (sel) -> sel.modify("extend", "forward", "character")
+  backwardCharacter: ->
+    window.getSelection().modify("extend", "backward", "character")
+  forwardCharacter: ->
+    window.getSelection().modify("extend", "forward", "character")
 
-  backwardWord: (sel) -> sel.modify("extend", "backward", "word")
-  forwardWord: (sel) -> sel.modify("extend", "forward", "word")
+  backwardWord: -> window.getSelection().modify("extend", "backward", "word")
+  forwardWord: -> window.getSelection().modify("extend", "forward", "word")
   
-  backwardLine: (sel) -> sel.modify("extend", "backward", "line")
-  forwardLine: (sel) -> sel.modify("extend", "forward", "line")
+  backwardLine: -> window.getSelection().modify("extend", "backward", "line")
+  forwardLine: -> window.getSelection().modify("extend", "forward", "line")
   
-  backwardLineBoundary: (sel) -> sel.modify(
+  backwardLineBoundary: -> window.getSelection().modify(
     "extend", "backward", "lineboundary")
-  forwardLineBoundary: (sel) -> sel.modify(
+  forwardLineBoundary: -> window.getSelection().modify(
     "extend", "forward", "lineboundary")
   
-  reload: (sel) -> chrome.runtime.reload()
+  reload: -> chrome.runtime.reload()
 
   toggleVisualMode: ->
     @freeEndToggled = false
@@ -38,13 +40,6 @@ VisualMode =
     @isActive = true
     HUD.show("Visual Mode")
     document.body.classList.add("vimiumVisualMode")
-
-    @handlerId = handlerStack.push({
-      keydown: @onKeyDownInMode.bind(this),
-      # trap all key events
-      keypress: -> false
-      keyup: -> false
-    })
   
   onKeyDownInMode: (event) ->
     keyCode = KeyboardUtils.getKeyChar(event)
@@ -62,8 +57,8 @@ VisualMode =
     if typeof(this[commandName]) == "function"
       this[commandName](sel)
 
-  toggleFreeEndOfSelection: (sel) ->
-    range = sel.getRangeAt(0)
+  toggleFreeEndOfSelection: ->
+    range = window.getSelection().getRangeAt(0)
     startOffset = range.startOffset
     startContainer = range.startContainer
     endOffset = range.endOffset
@@ -100,14 +95,10 @@ VisualMode =
         callback() if callback
       delay)
 
-  # wrap deactivateMode so that we can use the (sel) -> call signature without
-  # the selection being mistaken for the delay
-  deactivateModeNow: (sel) -> @deactivateMode()
-
-  yankSelection: (sel) ->
-    text = sel.toString()
+  yankSelection: ->
+    text = window.getSelection().toString()
     @deactivateMode()
-    sel.removeAllRanges()
+    window.getSelection().removeAllRanges()
     chrome.extension.sendMessage { handler: "copyToClipboard", data: text}
 
 root = exports ? window

--- a/manifest.json
+++ b/manifest.json
@@ -34,6 +34,7 @@
              "lib/handler_stack.js",
              "lib/clipboard.js",
              "content_scripts/link_hints.js",
+             "content_scripts/visual_mode.js",
              "content_scripts/vomnibar.js",
              "content_scripts/scroller.js",
              "content_scripts/marks.js",

--- a/pages/help_dialog.html
+++ b/pages/help_dialog.html
@@ -26,6 +26,8 @@
       {{historyNavigation}}
       <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Manipulating tabs</td></tr>
       {{tabManipulation}}
+      <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Visual Mode</td></tr>
+      {{visualMode}}
       <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Miscellaneous</td></tr>
       {{misc}}
       </tbody>

--- a/pages/options.html
+++ b/pages/options.html
@@ -7,6 +7,7 @@
     <script src="../lib/handler_stack.js"></script>
     <script src="../lib/clipboard.js"></script>
     <script src="../content_scripts/link_hints.js"></script>
+    <script src="../content_scripts/visual_mode.js"></script>
     <script src="../content_scripts/vomnibar.js"></script>
     <script src="../content_scripts/scroller.js"></script>
     <script src="../content_scripts/vimium_frontend.js"></script>

--- a/pages/options.html
+++ b/pages/options.html
@@ -215,7 +215,9 @@
                   Enter commands to remap your keys. Available commands:<br/>
                   <pre id="exampleKeyMapping">
 map j scrollDown
+mapVisualMode j forwardLine
 unmap j
+unmapVisualMode j
 unmapAll
 " this is a comment
 # this is also a comment</pre>

--- a/tests/unit_tests/commands_test.coffee
+++ b/tests/unit_tests/commands_test.coffee
@@ -8,3 +8,15 @@ context "Key mappings",
     assert.equal (Commands.normalizeKey '<C-A>'), '<c-A>'
     assert.equal (Commands.normalizeKey '<F12>'), '<f12>'
     assert.equal (Commands.normalizeKey '<C-F12>'), '<c-f12>'
+
+  should "place visual mode mappings in a separate dict", ->
+    Commands.addCommand(
+      "VisualMode.someCommand",
+      "Does something in visual mode.",
+      undefined, # options
+      visualMode = true)
+
+    Commands.parseCustomKeyMappings("mapVisualMode x VisualMode.someCommand")
+
+    assert.equal Commands.keyToVisualModeCommandRegistry["x"].command,
+      "VisualMode.someCommand"


### PR DESCRIPTION
Starting with @saminiir's and @ramiroaraujo's work on visual mode, added:

- Rebindable keys (use "mapVisualMode key VisualMode.nameOfVisualModeCommand")
- The ability to use browser key commands while in visual mode (i.e. visual mode now *ignores* commands it doesn't recognize and gives Chrome the opportunity to handle them)
- Visual mode automatically disabling if you click the screen
- One simple unit test (most of the functionality would belong in dom tests, but they're not running right now)

Most of this was accomplished by adding visual mode switches to parts of the Commands system. Visual mode is a weird feature by vimium standards: "modes" are expected to have their own key handling (a la link hints or Vomnibar), but visual mode needs essentially the same key binding behavior as the normal mode, just with an entirely different set of key-to-command bindings. Visual mode commands are actually handled in vimium_frontend, with the exception of Escape to deactivate the mode (which can't be rebound).

So, the approach I've taken is essentially to treat visual mode bindings as a one-off "special case" of normal keybindings. If vimium were to have more modes that *also* needed their own bindings, this could become cumbersome, but for just two I think it's pretty straightforward. I'd welcome anyone's thoughts on that.

Again, thanks to saminiir and ramiroaraujo for getting the ball rolling on this awesome feature!