### PR TITLE
Add number modifier to `gg' scrollToTop command

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -258,7 +258,7 @@ commandDescriptions =
   scrollLeft: ["Scroll left"]
   scrollRight: ["Scroll right"]
 
-  scrollToTop: ["Scroll to the top of the page", { noRepeat: true }]
+  scrollToTop: ["Scroll to the top of the page", { passCountToFunction: true }]
   scrollToBottom: ["Scroll to the bottom of the page", { noRepeat: true }]
   scrollToLeft: ["Scroll all the way to the left", { noRepeat: true }]
   scrollToRight: ["Scroll all the way to the right", { noRepeat: true }]

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -308,10 +308,9 @@ window.focusThisFrame = ->
 extend window,
   scrollToBottom: ->
     Marks.setPreviousPosition()
-    Scroller.scrollTo "y", "max"
-  scrollToTop: ->
+  scrollToTop: (count) ->
     Marks.setPreviousPosition()
-    Scroller.scrollTo "y", 0
+    Scroller.scrollTo "y", (count - 1) * Settings.get("scrollStepSize")
   scrollToLeft: -> Scroller.scrollTo "x", 0
   scrollToRight: -> Scroller.scrollTo "x", "max"
   scrollUp: -> Scroller.scrollBy "y", -1 * Settings.get("scrollStepSize")


### PR DESCRIPTION
As per issue #175, this implements a number modifier for the `scrollToTop` command, bound to `gg` by default.

Instead of the percentage interpretation suggested in #175, I opted for a multiple of the `scrollStepSize` option, so that it may be thought of as a line number.