### PR TITLE
Show number of matches in find HUD

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -560,19 +560,9 @@ updateFindModeQuery = ->
   # from the internal representation used by window.find.
   else
     # escape all special characters, so RegExp just parses the string 'as is'.
-    parsedNonRegexQuery = findModeQuery.parsedQuery.replace("\\", "\\\\")
-                                                   .replace("^", "\\^")
-                                                   .replace("$", "\\$")
-                                                   .replace("*", "\\*")
-                                                   .replace("+", "\\+")
-                                                   .replace("?", "\\?")
-                                                   .replace("(", "\\(")
-                                                   .replace(")", "\\)")
-                                                   .replace("|", "\\|")
-                                                   .replace("{", "\\{")
-                                                   .replace("}", "\\}")
-                                                   .replace("[", "\\[")
-                                                   .replace("]", "\\]")
+    # Taken from http://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex
+    escapeRegExp = /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g
+    parsedNonRegexQuery = findModeQuery.parsedQuery.replace(escapeRegExp, (char) -> "\\" + char)
     pattern = new RegExp(parsedNonRegexQuery, "g" + (if findModeQuery.ignoreCase then "i" else ""))
     text = document.body.innerText
     findModeQuery.matchCount = text.match(pattern)?.length


### PR DESCRIPTION
Calculate the number of matches for a find mode query, and show it in the HUD (resolves #969).

This implementation uses the number of text matches on `document.body.innerText` rather than repeated calls to `window.find` for plain text queries (see PR #1021).
