### PR TITLE
Add mouseover and mouseout commands

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -106,6 +106,8 @@ Commands =
       "LinkHints.activateModeWithQueue",
       "LinkHints.activateModeToDownloadLink",
       "LinkHints.activateModeToOpenIncognito",
+      "LinkHints.activateModeToHover",
+      "LinkHints.unhoverLast",
       "goPrevious",
       "goNext",
       "nextFrame",
@@ -156,6 +158,8 @@ Commands =
     "Vomnibar.activateEditUrl",
     "Vomnibar.activateEditUrlInNewTab",
     "LinkHints.activateModeToOpenIncognito",
+    "LinkHints.activateModeToHover",
+    "LinkHints.unhoverLast",
     "goNext",
     "goPrevious",
     "Marks.activateCreateMode",
@@ -290,6 +294,8 @@ commandDescriptions =
   "LinkHints.activateModeWithQueue": ["Open multiple links in a new tab", { noRepeat: true }]
   "LinkHints.activateModeToOpenIncognito": ["Open a link in incognito window", { noRepeat: true }]
   "LinkHints.activateModeToDownloadLink": ["Download link url", { noRepeat: true }]
+  "LinkHints.activateModeToHover": ["Hover over a link", { noRepeat: true }]
+  "LinkHints.unhoverLast": ["Stop hovering at last location", { noRepeat: true }]
 
   enterFindMode: ["Enter find mode", { noRepeat: true }]
   performFind: ["Cycle forward to the next find match"]

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -424,10 +424,12 @@ class LinkHintsMode
   #
   # Sends a "mouseout" event to the last "mouseover"-ed element.
   #
-  unhoverLast: (element) ->
-    DomUtils.simulateUnhover(@_lastHoveredElement) if @_lastHoveredElement
-    @_lastHoveredElement = element
-  _lastHoveredElement: null
+  unhoverLast: do ->
+    lastHoveredElement = null
+
+    (nextHoveredElement) ->
+      DomUtils.simulateUnhover(lastHoveredElement) if lastHoveredElement?
+      lastHoveredElement = nextHoveredElement
 
 # Use characters for hints, and do not filter links by their text.
 class AlphabetHints

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -17,6 +17,7 @@ OPEN_WITH_QUEUE = name: "queue"
 COPY_LINK_URL = name: "link"
 OPEN_INCOGNITO = name: "incognito"
 DOWNLOAD_LINK_URL = name: "download"
+HOVER = name: "hover"
 
 LinkHints =
   activateMode: (mode = OPEN_IN_CURRENT_TAB) -> new LinkHintsMode mode
@@ -27,6 +28,9 @@ LinkHints =
   activateModeWithQueue: -> @activateMode OPEN_WITH_QUEUE
   activateModeToOpenIncognito: -> @activateMode OPEN_INCOGNITO
   activateModeToDownloadLink: -> @activateMode DOWNLOAD_LINK_URL
+  activateModeToHover: -> @activateMode HOVER
+
+  unhoverLast: -> LinkHintsMode::unhoverLast()
 
 class LinkHintsMode
   hintMarkerContainingDiv: null
@@ -93,6 +97,7 @@ class LinkHintsMode
       else
         @hintMode.setIndicator "Open multiple links in new tabs."
       @linkActivator = (link) ->
+        @unhoverLast link
         # When "clicking" on a link, dispatch the event with the appropriate meta key (CMD on Mac, CTRL on
         # windows) to open it in a new tab if necessary.
         DomUtils.simulateClick link,
@@ -117,10 +122,17 @@ class LinkHintsMode
     else if @mode is DOWNLOAD_LINK_URL
       @hintMode.setIndicator "Download link URL."
       @linkActivator = (link) ->
+        @unhoverLast link
         DomUtils.simulateClick link, altKey: true, ctrlKey: false, metaKey: false
+    else if @mode is HOVER
+      @linkActivator = (link) ->
+        @unhoverLast link
+        DomUtils.simulateHover link
     else # OPEN_IN_CURRENT_TAB
       @hintMode.setIndicator "Open link in current tab."
-      @linkActivator = (link) -> DomUtils.simulateClick.bind(DomUtils, link)()
+      @linkActivator = (link) ->
+        @unhoverLast link
+        DomUtils.simulateClick link
 
   #
   # Creates a link marker for the given link.
@@ -408,6 +420,14 @@ class LinkHintsMode
       # tested synchronously.
       deactivate()
       callback?()
+
+  #
+  # Sends a "mouseout" event to the last "mouseover"-ed element.
+  #
+  unhoverLast: (element) ->
+    DomUtils.simulateUnhover(@_lastHoveredElement) if @_lastHoveredElement
+    @_lastHoveredElement = element
+  _lastHoveredElement: null
 
 # Use characters for hints, and do not filter links by their text.
 class AlphabetHints

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -235,17 +235,25 @@ DomUtils =
 
 
 
-  simulateClick: (element, modifiers) ->
-    modifiers ||= {}
+  simulateHover: (element, modifiers) ->
+    @simulateMouseEvent("mouseover", element, modifiers)
 
+  simulateUnhover: (element, modifiers) ->
+    @simulateMouseEvent("mouseout", element, modifiers)
+
+  simulateClick: (element, modifiers) ->
     eventSequence = ["mouseover", "mousedown", "mouseup", "click"]
-    for event in eventSequence
-      mouseEvent = document.createEvent("MouseEvents")
-      mouseEvent.initMouseEvent(event, true, true, window, 1, 0, 0, 0, 0, modifiers.ctrlKey, modifiers.altKey,
-      modifiers.shiftKey, modifiers.metaKey, 0, null)
-      # Debugging note: Firefox will not execute the element's default action if we dispatch this click event,
-      # but Webkit will. Dispatching a click on an input box does not seem to focus it; we do that separately
-      element.dispatchEvent(mouseEvent)
+    @simulateMouseEvent event, element, modifiers for event in eventSequence
+
+  simulateMouseEvent: (event, element, modifiers) ->
+    modifiers ||= {}
+    mouseEvent = document.createEvent("MouseEvents")
+    mouseEvent.initMouseEvent(event, true, true, window, 1, 0, 0, 0, 0, modifiers.ctrlKey, modifiers.altKey,
+    modifiers.shiftKey, modifiers.metaKey, 0, null)
+    # Debugging note: Firefox will not execute the element's default action if we dispatch this click event,
+    # but Webkit will. Dispatching a click on an input box does not seem to focus it; we do that separately
+    element.dispatchEvent(mouseEvent)
+
 
   # momentarily flash a rectangular border to give user some visual feedback
   flashRect: (rect) ->


### PR DESCRIPTION
Added LinkHints.activateModeToHover and LinkHints.unhoverLast to
perform hovering. These are unbound by default.

Also call LinkHints.unhoverLast automatically before hovering/
clicking the next link, to avoid permanently showing hover effects
(eg. IMDb watchlist grid view mode).

Fixes #484, #1089.