### PR TITLE
Fix options link in help dialog

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -869,8 +869,10 @@ window.showHelpDialog = (html, fid) ->
 
   VimiumHelpDialog.init()
 
-  container.getElementsByClassName("optionsPage")[0].addEventListener("click",
-    -> chrome.runtime.sendMessage({ handler: "openOptionsPageInNewTab" })
+  container.getElementsByClassName("optionsPage")[0].addEventListener("click", (clickEvent) ->
+      chrome.runtime.sendMessage({handler: "openOptionsPageInNewTab"})
+      if clickEvent
+        clickEvent.preventDefault()
     false)
 
 


### PR DESCRIPTION
This makes the options link in the help dialog cancel the default event
action, so the link (`href="#"`) isn't followed. The former behaviour
was most obvious when using the `LinkHints.activateModeToOpenInNewTab`
command, which would open a new tab with the current URL in addition to the
options page.
