### PR TITLE
Implement cursor hiding on scroll

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -1075,7 +1075,8 @@ CursorHider =
   cursorHideStyle: null
   isScrolling: false
 
-  showCursor: -> @cursorHideStyle.remove()
+  showCursor: ->
+    @cursorHideStyle.remove() if @cursorHideStyle.parentElement
   hideCursor: ->
     document.head.appendChild @cursorHideStyle unless @cursorHideStyle.parentElement
 


### PR DESCRIPTION
This begins to address #662, by hiding the cursor when the page is
scrolled to prevent a distracting cursor and accidentally triggering
hover effects.
