### PR TITLE
Add a label to advanced commands in the help dialog

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -132,6 +132,9 @@ helpDialogHtmlForCommandGroup = (group, commandsToKey, availableCommands,
       if (showCommandNames)
         html.push("<span class='vimiumReset commandName'>(#{command})</span>")
 
+      if (isAdvanced)
+        html.push("<span class='vimiumReset advancedText'>Advanced</span>")
+
       html.push("</td></tr>")
   html.join("\n")
 

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -57,6 +57,13 @@ tr.vimiumReset {
   z-index: 99999999;
 }
 
+span.vimiumReset.advancedText {
+  font-variant: small-caps;
+  border: solid 1px #C38A22;
+  border-radius: 3px;
+  color: #633A22;
+}
+
 /* Linkhints CSS */
 
 div.internalVimiumHintMarker {


### PR DESCRIPTION
This adds a label to advanced commands which are shown in the help dialog, to help distinguish them from normal commands, as per issue #963. The style isn't at all right, but hopefully this is a step in the right direction.