### PR TITLE
Move regex searches to a web worker to stop the browser from hanging

### DIFF
--- a/content_scripts/searchWorker.coffee
+++ b/content_scripts/searchWorker.coffee
@@ -1,0 +1,10 @@
+self.addEventListener "message", (event) ->
+  text = event.data.text
+  regex = event.data.regex
+
+  regexMatches = text.match regex
+
+  postData =
+    regexMatches: regexMatches
+  self.postMessage postData
+, false

--- a/manifest.json
+++ b/manifest.json
@@ -51,6 +51,9 @@
       "run_at": "document_start"
     }
   ],
+  "web_accessible_resources": [
+    "content_scripts/searchWorker.js"
+  ],
   "browser_action": {
     "default_icon": "icons/browser_action_disabled.png",
     "default_popup": "pages/popup.html"

--- a/tests/dom_tests/chrome.coffee
+++ b/tests/dom_tests/chrome.coffee
@@ -18,4 +18,7 @@ root.chrome = {
     sendMessage: ->
     getManifest: ->
   }
+  extension: {
+    getURL: (relativeUrl) -> relativeUrl
+  }
 }


### PR DESCRIPTION
This fixes #957 (currently closed anyway) by asynchronously performing regex searches of the page in a separate thread. It holds two main advantages over performing the regex synchronously:

* The UI doesn't hang while waiting for each search to complete, which is better UX.
* The workers can be terminated before they complete. When the search terms are updated, the previous search with the old terms is terminated and a new one is started, instead of wasting time waiting for the old one to complete first.

This has been tested on the [example](http://build.chromium.org/f/chromium/perf/dashboard/ui/changelog.html?url=/trunk/src&range=217147:224845&mode=html) from #957, and feels like a great improvement over before.