### PR TITLE
Add command to show link URL without opening it (related to issues #601 and #603)

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -17,6 +17,7 @@ Contributors:
   ConradIrwin
   Daniel MacDougall <dmacdougall@gmail.com> (github: dmacdougall)
   drizzd
+  Eric Hansander (github: ehdr)
   gpurkins
   hogelog
   int3

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -89,12 +89,12 @@ Commands =
       ["scrollDown", "scrollUp", "scrollLeft", "scrollRight", "scrollToTop", "scrollToBottom", "scrollToLeft",
       "scrollToRight", "scrollPageDown", "scrollPageUp", "scrollFullPageUp", "scrollFullPageDown", "reload",
       "toggleViewSource", "copyCurrentUrl", "LinkHints.activateModeToCopyLinkUrl",
-      "openCopiedUrlInCurrentTab", "openCopiedUrlInNewTab", "goUp", "goToRoot", "enterInsertMode",
-      "focusInput", "LinkHints.activateMode", "LinkHints.activateModeToOpenInNewTab",
-      "LinkHints.activateModeToOpenInNewForegroundTab", "LinkHints.activateModeWithQueue", "Vomnibar.activate",
-      "Vomnibar.activateInNewTab", "Vomnibar.activateTabSelection", "Vomnibar.activateBookmarks",
-      "Vomnibar.activateBookmarksInNewTab", "goPrevious", "goNext", "nextFrame", "Marks.activateCreateMode",
-      "Marks.activateGotoMode"]
+      "LinkHints.activateModeToShowLinkUrl", "openCopiedUrlInCurrentTab", "openCopiedUrlInNewTab", "goUp",
+      "goToRoot", "enterInsertMode", "focusInput", "LinkHints.activateMode",
+      "LinkHints.activateModeToOpenInNewTab", "LinkHints.activateModeToOpenInNewForegroundTab",
+      "LinkHints.activateModeWithQueue", "Vomnibar.activate", "Vomnibar.activateInNewTab",
+      "Vomnibar.activateTabSelection", "Vomnibar.activateBookmarks", "Vomnibar.activateBookmarksInNewTab",
+      "goPrevious", "goNext", "nextFrame", "Marks.activateCreateMode", "Marks.activateGotoMode"]
     findCommands: ["enterFindMode", "performFind", "performBackwardsFind"]
     historyNavigation:
       ["goBack", "goForward"]
@@ -157,6 +157,8 @@ defaultKeyMappings =
   "p": "openCopiedUrlInCurrentTab"
   "P": "openCopiedUrlInNewTab"
 
+  "sf": "LinkHints.activateModeToShowLinkUrl"
+
   "K": "nextTab"
   "J": "previousTab"
   "gt": "nextTab"
@@ -209,6 +211,7 @@ commandDescriptions =
 
   copyCurrentUrl: ["Copy the current URL to the clipboard"]
   'LinkHints.activateModeToCopyLinkUrl': ["Copy a link URL to the clipboard"]
+  'LinkHints.activateModeToShowLinkUrl': ["Show a link URL, without opening it"]
   openCopiedUrlInCurrentTab: ["Open the clipboard's URL in the current tab", { background: true }]
   openCopiedUrlInNewTab: ["Open the clipboard's URL in a new tab", { background: true }]
 


### PR DESCRIPTION
Hi @philc!

Implemented a command for showing the link URL (in the HUD) without opening it, possibly solving issues #601 and #603.

Useful when you want to check the target URL of a link before clicking, yet don't want to reach for the trackpad to hover it with the pointer.

Implemented as LinkHints.activateModeToShowLinkUrl. Also had to modify the HUD handling slightly in LinkHints, to support keeping the message visible after deactivating the mode.

Mapped to `sf` by default.