### PR TITLE
Apply search fix on file:// directory entries

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -48,7 +48,8 @@
     {
       "matches": ["file:///", "file:///*/"],
       "css": ["content_scripts/file_urls.css"],
-      "run_at": "document_start"
+      "run_at": "document_start",
+      "all_frames": true
     }
   ],
   "browser_action": {


### PR DESCRIPTION
The search highlighting fix introduced in 20fa345fe5862fd4fb908c4852bc41d0a9f45c55 is applied to all file:// URLs. This patch corrects this behaviour to ensure that only directory listings in file:// urls recieve that fix.
