### PR TITLE
Pointer cursor on hover over help modal close button

### DIFF
--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -198,7 +198,6 @@ div#vimiumHelpDialog .optionsPage {
 }
 div#vimiumHelpDialog a.closeButton:hover {
   color:black;
-  cursor:default;
   -webkit-user-select:none;
 }
 div#vimiumHelpDialogFooter {


### PR DESCRIPTION
I think this might have been a mistake. `cursor:default` means use the standard arrow cursor, but since the close button is clickable it should use `cursor:pointer`, the hand pointer. It will already do this by default since it's an `<a>` link so I just removed the line that changed the default behaviour.
