### PR TITLE
Add moveTabToLeft / Right, moveTab wraparound

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -17,6 +17,7 @@ Contributors:
   ConradIrwin
   Daniel MacDougall <dmacdougall@gmail.com> (github: dmacdougall)
   drizzd
+  elevengu
   gpurkins
   hogelog
   int3
@@ -26,20 +27,20 @@ Contributors:
   Knorkebrot
   lack
   markstos
-  Matthew Cline <matt@nightrealms.com>
   Matt Garriott (github: mgarriott)
+  Matthew Cline <matt@nightrealms.com>
   Michael Hauser-Raspe (github: mijoharas)
   Murph (github: pandeiro)
   Niklas Baumstark <niklas.baumstark@gmail.com> (github: niklasb)
+  R.T. Lechow <rtlechow@gmail.com> (github: rtlechow)
   rodimius
+  Shiyong Chen <billbill290@gmail.com> (github: UncleBill)
   Stephen Blott (github: smblott-github)
   Svein-Erik Larsen <feinom@gmail.com> (github: feinom)
   Tim Morgan <tim@timmorgan.org> (github: seven1m)
+  Timo Sand <timo.j.sand@gmail.com> (github: deiga)
   tsigo
-  R.T. Lechow <rtlechow@gmail.com> (github: rtlechow)
   Wang Ning <daning106@gmail.com> (github:daning)
   Werner Laurensse (github: ab3)
-  Timo Sand <timo.j.sand@gmail.com> (github: deiga)
-  Shiyong Chen <billbill290@gmail.com> (github: UncleBill)
 
 Feel free to add real names in addition to GitHub usernames.

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -256,8 +256,8 @@ commandDescriptions =
 
   moveTabLeft: ["Move tab to the left", { background: true, passCountToFunction: true }]
   moveTabRight: ["Move tab to the right", { background: true, passCountToFunction: true }]
-  moveTabToLeft: ["Move tab all the way to the left", { background: true }]
-  moveTabToRight: ["Move tab all the way to the right", { background: true }]
+  moveTabToLeft: ["Move tab all the way to the left", { background: true, passCountToFunction: true }]
+  moveTabToRight: ["Move tab all the way to the right", { background: true, passCountToFunction: true }]
 
   "Vomnibar.activate": ["Open URL, bookmark, or history entry"]
   "Vomnibar.activateInNewTab": ["Open URL, bookmark, history entry, in a new tab"]

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -100,8 +100,8 @@ Commands =
       ["goBack", "goForward"]
     tabManipulation:
       ["nextTab", "previousTab", "firstTab", "lastTab", "createTab", "duplicateTab", "removeTab",
-       "restoreTab", "moveTabToNewWindow", "togglePinTab", "moveTabLeft", "moveTabRight",
-       "moveTabToLeft", "moveTabToRight"]
+       "restoreTab", "togglePinTab", "moveTabLeft", "moveTabRight", "moveTabToLeft", "moveTabToRight",
+       "moveTabToNewWindow"]
     misc:
       ["showHelp"]
 

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -100,7 +100,8 @@ Commands =
       ["goBack", "goForward"]
     tabManipulation:
       ["nextTab", "previousTab", "firstTab", "lastTab", "createTab", "duplicateTab", "removeTab",
-       "restoreTab", "moveTabToNewWindow", "togglePinTab", "moveTabLeft", "moveTabRight"]
+       "restoreTab", "moveTabToNewWindow", "togglePinTab", "moveTabLeft", "moveTabRight",
+       "moveTabToLeft", "moveTabToRight"]
     misc:
       ["showHelp"]
 
@@ -111,7 +112,7 @@ Commands =
     "scrollToLeft", "scrollToRight", "moveTabToNewWindow",
     "goUp", "goToRoot", "focusInput", "LinkHints.activateModeWithQueue",
     "LinkHints.activateModeToOpenIncognito", "goNext", "goPrevious", "Marks.activateCreateMode",
-    "Marks.activateGotoMode", "moveTabLeft", "moveTabRight"]
+    "Marks.activateGotoMode", "moveTabLeft", "moveTabRight", "moveTabToLeft", "moveTabToRight"]
 
 defaultKeyMappings =
   "?": "showHelp"
@@ -254,7 +255,9 @@ commandDescriptions =
   togglePinTab: ["Pin/unpin current tab", { background: true }]
 
   moveTabLeft: ["Move tab to the left", { background: true, passCountToFunction: true }]
-  moveTabRight: ["Move tab to the right", { background: true, passCountToFunction: true  }]
+  moveTabRight: ["Move tab to the right", { background: true, passCountToFunction: true }]
+  moveTabToLeft: ["Move tab all the way to the left", { background: true }]
+  moveTabToRight: ["Move tab all the way to the right", { background: true }]
 
   "Vomnibar.activate": ["Open URL, bookmark, or history entry"]
   "Vomnibar.activateInNewTab": ["Open URL, bookmark, history entry, in a new tab"]

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -111,7 +111,7 @@ Commands =
   advancedCommands: [
     "scrollToLeft", "scrollToRight", "goUp", "goToRoot", "focusInput",
     "LinkHints.activateModeWithQueue", "LinkHints.activateModeToOpenIncognito",
-    "goNext", "goPrevious", "Marks.activateCreateMode", "Marks.activateGotoMode",
+    "goPrevious", "goNext", "Marks.activateCreateMode", "Marks.activateGotoMode",
     "moveTabLeft", "moveTabRight", "moveTabToLeft", "moveTabToRight", "moveTabToNewWindow"]
 
 defaultKeyMappings =

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -93,8 +93,8 @@ Commands =
       "focusInput", "LinkHints.activateMode", "LinkHints.activateModeToOpenInNewTab",
       "LinkHints.activateModeToOpenInNewForegroundTab", "LinkHints.activateModeWithQueue", "Vomnibar.activate",
       "Vomnibar.activateInNewTab", "Vomnibar.activateTabSelection", "Vomnibar.activateBookmarks",
-      "Vomnibar.activateBookmarksInNewTab", "goPrevious", "goNext", "nextFrame", "Marks.activateCreateMode",
-      "Marks.activateGotoMode"]
+      "Vomnibar.activateBookmarksInNewTab", "goPrevious", "goNext",
+      "nextFrame", "Marks.activateCreateMode", "Marks.activateGotoMode"]
     findCommands: ["enterFindMode", "performFind", "performBackwardsFind"]
     historyNavigation:
       ["goBack", "goForward"]
@@ -109,10 +109,10 @@ Commands =
   # a focused, high-signal set of commands to the new and casual user. Only those truly hungry for more power
   # from Vimium will uncover these gems.
   advancedCommands: [
-    "scrollToLeft", "scrollToRight", "moveTabToNewWindow",
-    "goUp", "goToRoot", "focusInput", "LinkHints.activateModeWithQueue",
-    "LinkHints.activateModeToOpenIncognito", "goNext", "goPrevious", "Marks.activateCreateMode",
-    "Marks.activateGotoMode", "moveTabLeft", "moveTabRight", "moveTabToLeft", "moveTabToRight"]
+    "scrollToLeft", "scrollToRight", "goUp", "goToRoot", "focusInput",
+    "LinkHints.activateModeWithQueue", "LinkHints.activateModeToOpenIncognito",
+    "goNext", "goPrevious", "Marks.activateCreateMode", "Marks.activateGotoMode",
+    "moveTabLeft", "moveTabRight", "moveTabToLeft", "moveTabToRight", "moveTabToNewWindow"]
 
 defaultKeyMappings =
   "?": "showHelp"

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -221,9 +221,7 @@ repeatFunction = (func, totalCount, currentCount, frameId) ->
 
 moveTab = (callback, direction) ->
   chrome.tabs.getSelected(null, (tab) ->
-    # Use Math.max to prevent -1 as the new index, otherwise the tab of index n will wrap to the far RHS when
-    # moved left by exactly (n+1) places.
-    chrome.tabs.move(tab.id, {index: Math.max(0, tab.index + direction) }, callback))
+    chrome.tabs.move(tab.id, { index: (tab.index + direction + tabs.length) % tabs.length }, callback))
 
 # Start action functions
 

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -225,13 +225,13 @@ moveTab = (direction, count) ->
     chrome.tabs.getSelected(null, (currentTab) ->
       switch direction
         when "previous"
-          toMove = (currentTab.index - count + tabs.length) % tabs.length
+          toMove = (currentTab.index - count + tabs.length * Math.abs(count)) % tabs.length
         when "next"
-          toMove = (currentTab.index + count + tabs.length) % tabs.length
+          toMove = (currentTab.index + count + tabs.length * Math.abs(count)) % tabs.length
         when "first"
-          toMove = 0
+          toMove = Math.max(0, count - 1)
         when "last"
-          toMove = -1
+          toMove = Math.max(0, tabs.length - count)
       chrome.tabs.move(currentTab.id, { index: toMove })))
 
 # Start action functions
@@ -288,8 +288,8 @@ BackgroundCommands =
         { name: "toggleHelpDialog", dialogHtml: helpDialogHtml(), frameId:frameId }))
   moveTabLeft: (count) -> moveTab("previous", count)
   moveTabRight: (count) -> moveTab("next", count)
-  moveTabToLeft: -> moveTab("first")
-  moveTabToRight: -> moveTab("last")
+  moveTabToLeft: (count) -> moveTab("first", count)
+  moveTabToRight: (count) -> moveTab("last", count)
   nextFrame: (count) ->
     chrome.tabs.getSelected(null, (tab) ->
       frames = framesForTab[tab.id].frames


### PR DESCRIPTION
I've had this in my personal fork since early 2013, and I think it's much better design to match the wraparound behavior of nextTab and previousTab in this way. I've noticed that the vast majority of my use cases involve wrapping.

I also implemented moveTabToLeft and moveTabToRight, but even I don't have them mapped to anything. So I don't think it's necessary to merge that with upstream unless there's actual demand for it.