### PR TITLE
Improve fonts and matching character color in CSS

### DIFF
--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -27,7 +27,7 @@ tr.vimiumReset {
   cursor: auto;
   display: inline;
   float: none;
-  font-family : "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+  font-family: "Helvetica Neue", Calibri, "DejaVu Sans", Arial, sans-serif;
   font-size: inherit;
   font-style: normal;
   font-variant: normal;
@@ -76,14 +76,14 @@ div.internalVimiumHintMarker {
 
 div.internalVimiumHintMarker span {
   color: #302505;
-  font-family: Helvetica, Arial, sans-serif;
+  font-family: "Helvetica Neue", Calibri, "DejaVu Sans", Arial, sans-serif;
   font-weight: bold;
   font-size: 11px;
   text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
 div.internalVimiumHintMarker > .matchingCharacter {
-  color: #D4AC3A;
+  color: #F40C0A;
 }
 
 /* Input hints CSS */
@@ -169,7 +169,9 @@ div#vimiumHelpDialog td.vimiumHelpSectionTitle {
   font-weight:bold;
   padding-top:3px;
 }
-div#vimiumHelpDialog div.commandName { font-family:"courier new"; }
+div#vimiumHelpDialog div.commandName {
+  font-family: Menlo, Consolas, "DejaVu Sans Mono", "Courier New", monospace;
+}
 /* Advanced commands are hidden by default until you show them. */
 div#vimiumHelpDialog div.advanced { display: none; }
 div#vimiumHelpDialog div.advanced td:nth-of-type(3) { color: #555; }
@@ -177,7 +179,7 @@ div#vimiumHelpDialog a.closeButton {
   position:absolute;
   right:7px;
   top:5px;
-  font-family:"courier new";
+  font-family: Menlo, Consolas, "DejaVu Sans Mono", "Courier New", monospace;
   font-weight:bold;
   color:#555;
   text-decoration:none;
@@ -232,7 +234,7 @@ div.vimiumHUD {
   margin: 0;
   border: 1px solid #b3b3b3;
   border-radius: 4px 4px 0 0;
-  font-family: "Lucida Grande", "Arial", "Sans";
+  font-family: "Helvetica Neue", Calibri, "DejaVu Sans", Arial, sans-serif;
   font-size: 12px;
   /* One less than vimium's hint markers, so link hints can be shown e.g. for the panel's close button. */
   z-index: 99999997;
@@ -251,7 +253,7 @@ div.vimiumHUD a:link, div.vimiumHUD a:hover {
 }
 div.vimiumHUD a:link.close-button {
   float:right;
-  font-family:courier new;
+  font-family: Menlo, Consolas, "DejaVu Sans Mono", "Courier New", monospace;
   font-weight:bold;
   color:#9C9A9A;
   text-decoration:none;
@@ -284,7 +286,7 @@ body.vimiumFindMode ::selection {
   top: 70px;
   left: 50%;
   margin: 0 0 0 -40%;
-  font-family: sans-serif;
+  font-family: "Helvetica Neue", Calibri, "DejaVu Sans", Arial, sans-serif;
 
   background: #F1F1F1;
   text-align: left;
@@ -297,7 +299,7 @@ body.vimiumFindMode ::selection {
 
 #vomnibar input {
   color: #000;
-  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-family: "Helvetica Neue", Calibri, "DejaVu Sans", Arial, sans-serif;
   font-size: 20px;
   height: 34px;
   margin-bottom: 0;
@@ -364,7 +366,7 @@ body.vimiumFindMode ::selection {
   padding: 5px;
   background-color: white;
   color: black;
-  font-family: monospace;
+  font-family: Menlo, Consolas, "DejaVu Sans Mono", "Courier New", monospace;
   width: 100px;
   overflow: hidden;
 }


### PR DESCRIPTION
Let's use more thoughtful, modern font stacks. The matching character color can also be more usable.

`font-family: "Helvetica Neue", Calibri, "DejaVu Sans", Arial, sans-serif;` and `font-family: Menlo, Consolas, "DejaVu Sans Mono", "Courier New", monospace;` are used for consistency. Mac OS, Windows, and Linux users will see the first three fonts, respectively, with fallbacks only when required. Windows users don't want to see Helvetica (and won't see Neue), and Courier New is already a hack for the close button that gets hackier with font dependence and without fallback.

The previous matching character color had too little contrast and was somehow extremely disconcerting and confusing to me. (I didn't know if I had hit the first key or not, and I didn't know what I should type next -- seems hard to believe, but it's true!) I tried many color replacements, but most others were too high contrast, again making it difficult to discern what to type next. The color I settled on worked far better than any of the others.

I know fonts and colors can be subjective, so try these changes out for yourself -- I've been using these since early 2013 and love them! We can adjust if necessary based on discussion and feedback.
