### PR TITLE
Match mixed-case relationship links in goNext/goPrevious

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -811,7 +811,7 @@ findAndFollowRel = (value) ->
   for tag in relTags
     elements = document.getElementsByTagName(tag)
     for element in elements
-      if (element.hasAttribute("rel") && element.rel == value)
+      if (element.hasAttribute("rel") && element.rel.toLowerCase() == value)
         followLink(element)
         return true
 

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -230,6 +230,14 @@ context "Find prev / next links",
     goNext()
     assert.equal '#first', window.location.hash
 
+  should "match mixed case link relation", ->
+    document.getElementById("test-div").innerHTML = """
+    <link rel='Next' href='#first'>
+    """
+    goNext()
+    assert.equal '#first', window.location.hash
+
+
 createLinks = (n) ->
   for i in [0...n] by 1
     link = document.createElement("a")


### PR DESCRIPTION
Also add some unittests for that. This should fix #1115.
