### PR TITLE
Add coffeelint to check for style guide violations

### DIFF
--- a/.coffeelintignore
+++ b/.coffeelintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *.sublime*
 node_modules/*
 dist
+jscoverage.json
+tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ node_js: 0.10
 before_install:
   - "npm install -g coffee-script"
   - "npm install path"
+  - "npm install -g git://github.com/clutchski/coffeelint.git"
   - "cake build"
-script: "cake test"
+script: "cake test && cake lint"
 notifications:
   email: false
 branches:

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -1,0 +1,494 @@
+# CoffeeScript Style Guide
+
+This guide presents a collection of best-practices and coding conventions for the [CoffeeScript][coffeescript] programming language.
+
+This guide is intended to be community-driven, and contributions are highly encouraged.
+
+Please note that this is a work-in-progress: there is much more that can be specified, and some of the guidelines that have been specified may not be deemed to be idiomatic by the community (in which case, these offending guidelines will be modified or removed, as appropriate).
+
+## Inspiration
+
+The details in this guide have been very heavily inspired by several existing style guides and other resources. In particular:
+
+- [PEP-8][pep8]: Style Guide for Python Code
+- Bozhidar Batsov's [Ruby Style Guide][ruby-style-guide]
+- [Google's JavaScript Style Guide][google-js-styleguide]
+- [Common CoffeeScript Idioms][common-coffeescript-idioms]
+- Thomas Reynolds' [CoffeeScript-specific Style Guide][coffeescript-specific-style-guide]
+- Jeremy Ashkenas' [code review][spine-js-code-review] of [Spine][spine-js]
+- The [CoffeeScript FAQ][coffeescript-faq]
+
+## Table of Contents
+
+* [The CoffeeScript Style Guide](#guide)
+    * [Code Layout](#code_layout)
+        * [Tabs or Spaces?](#tabs_or_spaces)
+        * [Maximum Line Length](#maximum_line_length)
+        * [Blank Lines](#blank_lines)
+        * [Trailing Whitespace](#trailing_whitespace)
+        * [Optional Commas](#optional_commas)
+        * [Encoding](#encoding)
+    * [Module Imports](#module_imports)
+    * [Whitespace in Expressions and Statements](#whitespace)
+    * [Comments](#comments)
+        * [Block Comments](#block_comments)
+        * [Inline Comments](#inline_comments)
+    * [Naming Conventions](#naming_conventions)
+    * [Functions](#functions)
+    * [Strings](#strings)
+    * [Conditionals](#conditionals)
+    * [Looping and Comprehensions](#looping_and_comprehensions)
+    * [Extending Native Objects](#extending_native_objects)
+    * [Exceptions](#exceptions)
+    * [Annotations](#annotations)
+    * [Miscellaneous](#miscellaneous)
+
+<a name="code_layout"/>
+## Code layout
+
+<a name="tabs_or_spaces"/>
+### Tabs or Spaces?
+
+Use **spaces only**, with **2 spaces** per indentation level. Never mix tabs and spaces.
+
+<a name="maximum_line_length"/>
+### Maximum Line Length
+
+Limit all lines to a maximum of 109 characters.
+
+<a name="blank_lines"/>
+### Blank Lines
+
+Separate top-level function and class definitions with a single blank line.
+
+Separate method definitions inside of a class with a single blank line.
+
+Use a single blank line within the bodies of methods or functions in cases where this improves readability (e.g., for the purpose of delineating logical sections).
+
+<a name="trailing_whitespace"/>
+### Trailing Whitespace
+
+Do not include trailing whitespace on any lines.
+
+<a name="optional_commas"/>
+### Optional Commas
+
+Avoid the use of commas before newlines when properties or elements of an Object or Array are listed on separate lines.
+
+```coffeescript
+# Yes
+foo = [
+  'some'
+  'string'
+  'values'
+]
+bar:
+  label: 'test'
+  value: 87
+
+# No
+foo = [
+  'some',
+  'string',
+  'values'
+]
+bar:
+  label: 'test',
+  value: 87
+```
+
+<a name="encoding"/>
+### Encoding
+
+UTF-8 is the preferred source file encoding.
+
+<a name="module_imports"/>
+## Module Imports
+
+If using a module system (CommonJS Modules, AMD, etc.), `require` statements should be placed on separate lines.
+
+```coffeescript
+require 'lib/setup'
+Backbone = require 'backbone'
+```
+These statements should be grouped in the following order:
+
+1. Standard library imports _(if a standard library exists)_
+2. Third party library imports
+3. Local imports _(imports specific to this application or library)_
+
+<a name="whitespace"/>
+## Whitespace in Expressions and Statements
+
+Avoid extraneous whitespace in the following situations:
+
+- Immediately inside parentheses, brackets or braces
+
+    ```coffeescript
+       ($ 'body') # Yes
+       ( $ 'body' ) # No
+    ```
+
+- Immediately before a comma
+
+    ```coffeescript
+       console.log x, y # Yes
+       console.log x , y # No
+    ```
+
+Additional recommendations:
+
+- Always surround these binary operators with a **single space** on either side
+
+    - assignment: `=`
+
+        - _Note that this also applies when indicating default parameter value(s) in a function declaration_
+
+           ```coffeescript
+           test: (param = null) -> # Yes
+           test: (param=null) -> # No
+           ```
+
+    - augmented assignment: `+=`, `-=`, etc.
+    - comparisons: `==`, `<`, `>`, `<=`, `>=`, `unless`, etc.
+    - arithmetic operators: `+`, `-`, `*`, `/`, etc.
+
+    - _(Do not use more than one space around these operators)_
+
+        ```coffeescript
+           # Yes
+           x = 1
+           y = 1
+           fooBar = 3
+
+           # No
+           x      = 1
+           y      = 1
+           fooBar = 3
+        ```
+
+<a name="comments"/>
+## Comments
+
+If modifying code that is described by an existing comment, update the comment such that it accurately reflects the new code. (Ideally, improve the code to obviate the need for the comment, and delete the comment entirely.)
+
+The first word of the comment should be capitalized, unless the first word is an identifier that begins with a lower-case letter.
+
+If a comment is short, the period at the end can be omitted.
+
+<a name="block_comments"/>
+### Block Comments
+
+Block comments apply to the block of code that follows them.
+
+Each line of a block comment starts with a `#` and a single space, and should be indented at the same level of the code that it describes.
+
+Paragraphs inside of block comments are separated by a line containing a single `#`.
+
+```coffeescript
+  # This is a block comment. Note that if this were a real block
+  # comment, we would actually be describing the proceeding code.
+  #
+  # This is the second paragraph of the same block comment. Note
+  # that this paragraph was separated from the previous paragraph
+  # by a line containing a single comment character.
+
+  init()
+  start()
+  stop()
+```
+
+<a name="inline_comments"/>
+### Inline Comments
+
+Inline comments are placed on the line immediately above the statement that they are describing. If the inline comment is sufficiently short, it can be placed on the same line as the statement (separated by a single space from the end of the statement).
+
+All inline comments should start with a `#` and a single space.
+
+The use of inline comments should be limited, because their existence is typically a sign of a code smell.
+
+Do not use inline comments when they state the obvious:
+
+```coffeescript
+  # No
+  x = x + 1 # Increment x
+```
+
+However, inline comments can be useful in certain scenarios:
+
+```coffeescript
+  # Yes
+  x = x + 1 # Compensate for border
+```
+
+<a name="naming_conventions"/>
+## Naming Conventions
+
+Use `camelCase` (with a leading lowercase character) to name all variables, methods, and object properties.
+
+Use `CamelCase` (with a leading uppercase character) to name all classes. _(This style is also commonly referred to as `PascalCase`, `CamelCaps`, or `CapWords`, among [other alternatives][camel-case-variations].)_
+
+_(The **official** CoffeeScript convention is camelcase, because this simplifies interoperability with JavaScript. For more on this decision, see [here][coffeescript-issue-425].)_
+
+For constants, use all uppercase with underscores:
+
+```coffeescript
+CONSTANT_LIKE_THIS
+```
+
+Methods and variables that are intended to be "private" should begin with a leading underscore:
+
+```coffeescript
+_privateMethod: ->
+```
+
+<a name="functions"/>
+## Functions
+
+_(These guidelines also apply to the methods of a class.)_
+
+When declaring a function that takes arguments, always use a single space after the closing parenthesis of the arguments list:
+
+```coffeescript
+foo = (arg1, arg2) -> # Yes
+foo = (arg1, arg2)-> # No
+```
+
+Do not use parentheses when declaring functions that take no arguments:
+
+```coffeescript
+bar = -> # Yes
+bar = () -> # No
+```
+
+In cases where method calls are being chained and the code does not fit on a single line, each call should be placed on a separate line and indented by one level (i.e., two spaces), with a leading `.`.
+
+```coffeescript
+[1..3]
+  .map((x) -> x * x)
+  .concat([10..12])
+  .filter((x) -> x < 11)
+  .reduce((x, y) -> x + y)
+```
+
+When calling functions, choose to omit or include parentheses in such a way that optimizes for readability. Keeping in mind that "readability" can be subjective, the following examples demonstrate cases where parentheses have been omitted or included in a manner that the community deems to be optimal:
+
+```coffeescript
+baz 12
+
+brush.ellipse x: 10, y: 20 # Braces can also be omitted or included for readability
+
+foo(4).bar(8)
+
+obj.value(10, 20) / obj.value(20, 10)
+
+print inspect value
+
+new Tag(new Value(a, b), new Arg(c))
+```
+
+You will sometimes see parentheses used to group functions (instead of being used to group function parameters). Examples of using this style (hereafter referred to as the "function grouping style"):
+
+```coffeescript
+($ '#selektor').addClass 'klass'
+
+(foo 4).bar 8
+```
+
+This is in contrast to:
+
+```coffeescript
+$('#selektor').addClass 'klass'
+
+foo(4).bar 8
+```
+
+In cases where method calls are being chained, some adopters of this style prefer to use function grouping for the initial call only:
+
+```coffeescript
+($ '#selektor').addClass('klass').hide() # Initial call only
+(($ '#selektor').addClass 'klass').hide() # All calls
+```
+
+The function grouping style is not recommended. However, **if the function grouping style is adopted for a particular project, be consistent with its usage.**
+
+<a name="strings"/>
+## Strings
+
+Use string interpolation instead of string concatenation:
+
+```coffeescript
+"this is an #{adjective} string" # Yes
+"this is an " + adjective + " string" # No
+```
+
+Prefer double quoted strings (`""`) instead of single quoted (`''`) strings.
+
+<a name="conditionals"/>
+## Conditionals
+
+Favor `unless` over `if` for negative conditions.
+
+Instead of using `unless...else`, use `if...else`:
+
+```coffeescript
+  # Yes
+  if true
+    ...
+  else
+    ...
+
+  # No
+  unless false
+    ...
+  else
+    ...
+```
+
+Multi-line if/else clauses should use indentation:
+
+```coffeescript
+  # Yes
+  if true
+    ...
+  else
+    ...
+
+  # No
+  if true then ...
+  else ...
+```
+
+<a name="looping_and_comprehensions"/>
+## Looping and Comprehensions
+
+Take advantage of comprehensions whenever possible:
+
+```coffeescript
+  # Yes
+  result = (item.name for item in array)
+
+  # No
+  results = []
+  for item in array
+    results.push item.name
+```
+
+To filter:
+
+```coffeescript
+result = (item for item in array when item.name is "test")
+```
+
+To iterate over the keys and values of objects:
+
+```coffeescript
+object = one: 1, two: 2
+alert("#{key} = #{value}") for key, value of object
+```
+
+<a name="extending_native_objects"/>
+## Extending Native Objects
+
+Do not modify native objects.
+
+For example, do not modify `Array.prototype` to introduce `Array#forEach`.
+
+<a name="exceptions"/>
+## Exceptions
+
+Do not suppress exceptions.
+
+<a name="annotations"/>
+## Annotations
+
+Use annotations when necessary to describe a specific action that must be taken against the indicated block of code.
+
+Write the annotation on the line immediately above the code that the annotation is describing.
+
+The annotation keyword should be followed by a colon and a space, and a descriptive note.
+
+```coffeescript
+  # FIXME: The client's current state should *not* affect payload processing.
+  resetClientState()
+  processPayload()
+```
+
+If multiple lines are required by the description, indent subsequent lines with two spaces:
+
+```coffeescript
+  # TODO: Ensure that the value returned by this call falls within a certain
+  #   range, or throw an exception.
+  analyze()
+```
+
+Annotation types:
+
+- `TODO`: describe missing functionality that should be added at a later date
+- `FIXME`: describe broken code that must be fixed
+- `OPTIMIZE`: describe code that is inefficient and may become a bottleneck
+- `HACK`: describe the use of a questionable (or ingenious) coding practice
+- `REVIEW`: describe code that should be reviewed to confirm implementation
+
+If a custom annotation is required, the annotation should be documented in the project's README.
+
+<a name="miscellaneous"/>
+## Miscellaneous
+
+`and` is preferred over `&&`.
+
+`or` is preferred over `||`.
+
+`is` is preferred over `==`.
+
+`not` is preferred over `!`.
+
+`or=` should be used when possible:
+
+```coffeescript
+temp or= {} # Yes
+temp = temp || {} # No
+```
+
+Prefer shorthand notation (`::`) for accessing an object's prototype:
+
+```coffeescript
+Array::slice # Yes
+Array.prototype.slice # No
+```
+
+Prefer `@property` over `this.property`.
+
+```coffeescript
+return @property # Yes
+return this.property # No
+```
+
+However, avoid the use of **standalone** `@`:
+
+```coffeescript
+return this # Yes
+return @ # No
+```
+
+Avoid `return` where not required, unless the explicit return increases clarity.
+
+Use splats (`...`) when working with functions that accept variable numbers of arguments:
+
+```coffeescript
+console.log args... # Yes
+
+(a, b, c, rest...) -> # Yes
+```
+
+[coffeescript]: http://jashkenas.github.com/coffee-script/
+[coffeescript-issue-425]: https://github.com/jashkenas/coffee-script/issues/425
+[spine-js]: http://spinejs.com/
+[spine-js-code-review]: https://gist.github.com/1005723
+[pep8]: http://www.python.org/dev/peps/pep-0008/
+[ruby-style-guide]: https://github.com/bbatsov/ruby-style-guide
+[google-js-styleguide]: http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml
+[common-coffeescript-idioms]: http://arcturo.github.com/library/coffeescript/04_idioms.html
+[coffeescript-specific-style-guide]: http://awardwinningfjords.com/2011/05/13/coffeescript-specific-style-guide.html
+[coffeescript-faq]: https://github.com/jashkenas/coffee-script/wiki/FAQ
+[camel-case-variations]: http://en.wikipedia.org/wiki/CamelCase#Variations_and_synonyms

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,11 +54,18 @@ reports:
 
 ## Coding Style
 
-  * We follow the recommendations from
-    [this style guide](https://github.com/polarmobile/coffeescript-style-guide).
-  * We follow two major differences from this style guide:
+  * The recommendations for coding style can be found in our [style guide](CODE_STYLE.md)
+  * These are based on the recommendations from
+    [this style guide](https://github.com/polarmobile/coffeescript-style-guide), with two major differences:
     * Wrap lines at 110 characters instead of 80.
     * Use double-quoted strings by default.
+
+There are tests for a subset of the style guide recommendations. To run the tests:
+
+ 1. `npm install -g git://github.com/clutchski/coffeelint.git` to install [CoffeeLint](http://www.coffeelint.org).
+    This installs the version from the github repo, since we need to ignore files under `node_modules`, but
+    this feature hasn't made it to npm yet.
+ 1. `cake lint` to run the tests.
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can install the stable version of Vimium from the
 [Chrome Extensions Gallery](https://chrome.google.com/extensions/detail/dbepggeogbaibhgnhhndojpepiihcmeb).
 
 Please see
-[CONTRIBUTING.md](https://github.com/philc/vimium/blob/master/CONTRIBUTING.md#installing-from-source)
+[CONTRIBUTING.md](CONTRIBUTING.md#installing-from-source)
 for instructions on how you can install Vimium from source.
 
 The Options page can be reached via a link on the help dialog (hit `?`) or via the button next to Vimium on
@@ -134,7 +134,7 @@ Many of the more advanced or involved features are documented on [Vimium's githu
 
 Contributing
 ------------
-Please see [CONTRIBUTING.md](https://github.com/philc/vimium/blob/master/CONTRIBUTING.md) for details.
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 Release Notes
 -------------

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -9,8 +9,8 @@ Commands =
   # Registers a command, making it available to be optionally bound to a key.
   # options:
   #  - background: whether this command needs to be run against the background page.
-  #  - passCountToFunction: true if this command should have any digits which were typed prior to the
-  #    command passed to it. This is used to implement e.g. "closing of 3 tabs".
+  #  - passCountToFunction: true if this command should have any digits which were typed prior to the command
+  #      passed to it. This is used to implement e.g. "closing of 3 tabs".
   addCommand: (command, description, options) ->
     if command of @availableCommands
       console.log(command, "is already defined! Check commands.coffee for duplicates.")
@@ -38,12 +38,11 @@ Commands =
 
   # Lower-case the appropriate portions of named keys.
   #
-  # A key name is one of three forms exemplified by <c-a> <left> or <c-f12>
-  # (prefixed normal key, named key, or prefixed named key). Internally, for
-  # simplicity, we would like prefixes and key names to be lowercase, though
-  # humans may prefer other forms <Left> or <C-a>.
-  # On the other hand, <c-a> and <c-A> are different named keys - for one of
-  # them you have to press "shift" as well.
+  # A key name is one of three forms exemplified by <c-a> <left> or <c-f12> (prefixed normal key, named key,
+  # or prefixed named key). Internally, for simplicity, we would like prefixes and key names to be lowercase,
+  # though humans may prefer other forms <Left> or <C-a>.
+  # On the other hand, <c-a> and <c-A> are different named keys - for one of them you have to press "shift"
+  # as well.
   normalizeKey: (key) ->
     key.replace(/<[acm]-/ig, (match) -> match.toLowerCase())
        .replace(/<([acm]-)?([a-zA-Z0-9]{2,5})>/g, (match, optionalPrefix, keyName) ->
@@ -82,19 +81,19 @@ Commands =
     for key of defaultKeyMappings
       @mapKeyToCommand(key, defaultKeyMappings[key])
 
-  # An ordered listing of all available commands, grouped by type. This is the order they will
-  # be shown in the help page.
+  # An ordered listing of all available commands, grouped by type. This is the order they will be shown in
+  # the help page.
   commandGroups:
     pageNavigation:
-      ["scrollDown", "scrollUp", "scrollLeft", "scrollRight", "scrollToTop", "scrollToBottom", "scrollToLeft",
-      "scrollToRight", "scrollPageDown", "scrollPageUp", "scrollFullPageUp", "scrollFullPageDown", "reload",
-      "toggleViewSource", "copyCurrentUrl", "LinkHints.activateModeToCopyLinkUrl",
-      "openCopiedUrlInCurrentTab", "openCopiedUrlInNewTab", "goUp", "goToRoot", "enterInsertMode",
-      "focusInput", "LinkHints.activateMode", "LinkHints.activateModeToOpenInNewTab",
-      "LinkHints.activateModeToOpenInNewForegroundTab", "LinkHints.activateModeWithQueue", "Vomnibar.activate",
-      "Vomnibar.activateInNewTab", "Vomnibar.activateTabSelection", "Vomnibar.activateBookmarks",
-      "Vomnibar.activateBookmarksInNewTab", "goPrevious", "goNext", "nextFrame", "Marks.activateCreateMode",
-      "Marks.activateGotoMode"]
+      ["scrollDown", "scrollUp", "scrollLeft", "scrollRight", "scrollToTop", "scrollToBottom",
+      "scrollToLeft", "scrollToRight", "scrollPageDown", "scrollPageUp", "scrollFullPageUp",
+      "scrollFullPageDown", "reload", "toggleViewSource", "copyCurrentUrl",
+      "LinkHints.activateModeToCopyLinkUrl", "openCopiedUrlInCurrentTab", "openCopiedUrlInNewTab", "goUp",
+      "goToRoot", "enterInsertMode", "focusInput", "LinkHints.activateMode",
+      "LinkHints.activateModeToOpenInNewTab", "LinkHints.activateModeToOpenInNewForegroundTab",
+      "LinkHints.activateModeWithQueue", "Vomnibar.activate", "Vomnibar.activateInNewTab",
+      "Vomnibar.activateTabSelection", "Vomnibar.activateBookmarks", "Vomnibar.activateBookmarksInNewTab",
+      "goPrevious", "goNext", "nextFrame", "Marks.activateCreateMode", "Marks.activateGotoMode"]
     findCommands: ["enterFindMode", "performFind", "performBackwardsFind"]
     historyNavigation:
       ["goBack", "goForward"]
@@ -109,10 +108,9 @@ Commands =
   # a focused, high-signal set of commands to the new and casual user. Only those truly hungry for more power
   # from Vimium will uncover these gems.
   advancedCommands: [
-    "scrollToLeft", "scrollToRight", "moveTabToNewWindow",
-    "goUp", "goToRoot", "focusInput", "LinkHints.activateModeWithQueue",
-    "LinkHints.activateModeToOpenIncognito", "goNext", "goPrevious", "Marks.activateCreateMode",
-    "Marks.activateGotoMode", "moveTabLeft", "moveTabRight",
+    "scrollToLeft", "scrollToRight", "moveTabToNewWindow", "goUp", "goToRoot", "focusInput",
+    "LinkHints.activateModeWithQueue", "LinkHints.activateModeToOpenIncognito", "goNext", "goPrevious",
+    "Marks.activateCreateMode", "Marks.activateGotoMode", "moveTabLeft", "moveTabRight",
     "closeTabsOnLeft","closeTabsOnRight", "closeOtherTabs"]
 
 defaultKeyMappings =
@@ -142,8 +140,8 @@ defaultKeyMappings =
 
   "gi": "focusInput"
 
-  "f":     "LinkHints.activateMode"
-  "F":     "LinkHints.activateModeToOpenInNewTab"
+  "f": "LinkHints.activateMode"
+  "F": "LinkHints.activateModeToOpenInNewTab"
   "<a-f>": "LinkHints.activateModeWithQueue"
 
   "/": "enterFindMode"

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -258,9 +258,9 @@ BackgroundCommands =
         # Clean out the tabQueue so we don't have unused windows laying about.
         delete tabQueue[window.id] if (tabQueue[window.id].length == 0)
 
-        # We have to chain a few callbacks to set the appropriate scroll position. We can't just wait until the
-        # tab is created because the content script is not available during the "loading" state. We need to
-        # wait until that's over before we can call setScrollPosition.
+        # We have to chain a few callbacks to set the appropriate scroll position. We can't just wait until
+        # the tab is created because the content script is not available during the "loading" state. We need
+        # to wait until that's over before we can call setScrollPosition.
         chrome.tabs.create({ url: tabQueueEntry.url, index: tabQueueEntry.positionIndex }, (tab) ->
           tabLoadedHandlers[tab.id] = ->
             chrome.tabs.sendRequest(tab.id,
@@ -276,7 +276,7 @@ BackgroundCommands =
   showHelp: (callback, frameId) ->
     chrome.tabs.getSelected(null, (tab) ->
       chrome.tabs.sendMessage(tab.id,
-        { name: "toggleHelpDialog", dialogHtml: helpDialogHtml(), frameId:frameId }))
+        { name: "toggleHelpDialog", dialogHtml: helpDialogHtml(), frameId: frameId }))
   moveTabLeft: (count) -> moveTab(null, -count)
   moveTabRight: (count) -> moveTab(null, count)
   nextFrame: (count) ->
@@ -416,8 +416,8 @@ chrome.tabs.onRemoved.addListener (tabId) ->
   else
     tabQueue[openTabInfo.windowId] = [openTabInfo]
 
-  # keep the reference around for a while to wait for the last messages from the closed tab (e.g. for updating
-  # scroll position)
+  # keep the reference around for a while to wait for the last messages from the closed tab (e.g. for
+  # updating scroll position)
   tabInfoMap.deletor = -> delete tabInfoMap[tabId]
   setTimeout tabInfoMap.deletor, 1000
   delete framesForTab[tabId]

--- a/background_scripts/settings.coffee
+++ b/background_scripts/settings.coffee
@@ -47,7 +47,7 @@ root.Settings = Settings =
   parseSearchEngines: (searchEnginesText) ->
     @searchEnginesMap = {}
     # find the split pairs by first splitting by line then splitting on the first `: `
-    split_pairs = ( pair.split( /: (.+)/, 2) for pair in searchEnginesText.split( /\n/ ) when pair[0] != "#" )
+    split_pairs = (pair.split( /: (.+)/, 2) for pair in searchEnginesText.split( /\n/ ) when pair[0] != "#")
     @searchEnginesMap[a[0]] = a[1] for a in split_pairs
     @searchEnginesMap
   getSearchEngines: ->

--- a/background_scripts/sync.coffee
+++ b/background_scripts/sync.coffee
@@ -78,7 +78,7 @@ root.Sync = Sync =
       @log "set scheduled: #{key}=#{value}"
       key_value = {}
       key_value[key] = value
-      @storage.set key_value, =>
+      @storage.set key_value, ->
         # Chrome sets chrome.runtime.lastError if there is an error.
         if chrome.runtime.lastError
           console.log "callback for Sync.set() indicates error: #{key} <- #{value}"
@@ -88,7 +88,7 @@ root.Sync = Sync =
   clear: (key) ->
     if @shouldSyncKey key
       @log "clear scheduled: #{key}"
-      @storage.remove key, =>
+      @storage.remove key, ->
         # Chrome sets chrome.runtime.lastError if there is an error.
         if chrome.runtime.lastError
           console.log "for Sync.clear() indicates error: #{key}"

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,80 @@
+{
+    "arrow_spacing": {
+        "level": "warn"
+    },
+    "camel_case_classes": {
+        "level": "warn"
+    },
+    "coffeescript_error": {
+        "level": "error"
+    },
+    "colon_assignment_spacing": {
+        "level": "warn",
+        "spacing": {
+            "left": 0,
+            "right": 1
+        }
+    },
+    "duplicate_key": {
+        "level": "warn"
+    },
+    "indentation": {
+        "level": "ignore",
+        "value": 2
+    },
+    "line_endings": {
+        "level": "warn",
+        "value": "unix"
+    },
+    "max_line_length": {
+        "level": "warn",
+        "value": 109,
+        "limitComments": true
+    },
+    "missing_fat_arrows": {
+        "level": "ignore"
+    },
+    "newlines_after_classes": {
+        "level": "warn",
+        "value": 3
+    },
+    "no_backticks": {
+        "level": "warn"
+    },
+    "no_debugger": {
+        "level": "warn"
+    },
+    "no_empty_param_list": {
+        "level": "warn"
+    },
+    "no_implicit_braces": {
+        "level": "ignore",
+        "strict": true
+    },
+    "no_interpolation_in_single_quotes": {
+        "level": "warn"
+    },
+    "no_stand_alone_at": {
+        "level": "warn"
+    },
+    "no_tabs": {
+        "level": "warn"
+    },
+    "no_throwing_strings": {
+        "level": "warn"
+    },
+    "no_trailing_semicolons": {
+        "level": "warn"
+    },
+    "no_trailing_whitespace": {
+        "level": "warn",
+        "allowed_in_comments": false,
+        "allowed_in_empty_lines": false
+    },
+    "no_unnecessary_fat_arrows": {
+        "level": "warn"
+    },
+    "space_operators": {
+        "level": "warn"
+    }
+}

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -1,6 +1,7 @@
 #
 # This implements link hinting. Typing "F" will enter link-hinting mode, where all clickable items on the
-# page have a hint marker displayed containing a sequence of letters. Typing those letters will select a link.
+# page have a hint marker displayed containing a sequence of letters. Typing those letters will select a
+# link.
 #
 # In our 'default' mode, the characters we use to show link hints are a user-configurable option. By default
 # they're the home row.  The CSS which is used on the link hints is also a configurable option.
@@ -346,8 +347,8 @@ filterHints =
       if (forElement)
         labelText = label.textContent.trim()
         # remove trailing : commonly found in labels
-        if (labelText[labelText.length-1] == ":")
-          labelText = labelText.substr(0, labelText.length-1)
+        if (labelText[labelText.length - 1] == ":")
+          labelText = labelText.substr(0, labelText.length - 1)
         @labelMap[forElement] = labelText
 
   generateHintString: (linkHintNumber) ->

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -85,7 +85,7 @@ settings =
 #
 # Give this frame a unique id.
 #
-frameId = Math.floor(Math.random()*999999999)
+frameId = Math.floor(Math.random() * 999999999)
 
 hasModifiersRegex = /^<([amc]-)+.>/
 
@@ -223,8 +223,8 @@ extend window,
   scrollToRight: -> Scroller.scrollTo "x", "max"
   scrollUp: -> Scroller.scrollBy "y", -1 * settings.get("scrollStepSize")
   scrollDown: -> Scroller.scrollBy "y", settings.get("scrollStepSize")
-  scrollPageUp: -> Scroller.scrollBy "y", "viewSize", -1/2
-  scrollPageDown: -> Scroller.scrollBy "y", "viewSize", 1/2
+  scrollPageUp: -> Scroller.scrollBy "y", "viewSize", -1 / 2
+  scrollPageDown: -> Scroller.scrollBy "y", "viewSize", 1 / 2
   scrollFullPageUp: -> Scroller.scrollBy "y", "viewSize", -1
   scrollFullPageDown: -> Scroller.scrollBy "y", "viewSize"
   scrollLeft: -> Scroller.scrollBy "x", -1 * settings.get("scrollStepSize")
@@ -246,7 +246,7 @@ extend window,
       urlsplit = urlsplit.slice(0, Math.max(3, urlsplit.length - count))
       window.location.href = urlsplit.join('/')
 
-  goToRoot: () ->
+  goToRoot: ->
     window.location.href = window.location.origin
 
   toggleViewSource: ->
@@ -267,9 +267,9 @@ extend window,
     HUD.showForDuration("Yanked URL", 1000)
 
   focusInput: (count) ->
-    # Focus the first input element on the page, and create overlays to highlight all the input elements, with
-    # the currently-focused element highlighted specially. Tabbing will shift focus to the next input element.
-    # Pressing any other key will remove the overlays and the special tab behavior.
+    # Focus the first input element on the page, and create overlays to highlight all the input elements,
+    # with the currently-focused element highlighted specially. Tabbing will shift focus to the next input
+    # element.  Pressing any other key will remove the overlays and the special tab behavior.
     resultSet = DomUtils.evaluateXPath(textInputXPath, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE)
     visibleInputs =
       for i in [0...resultSet.snapshotLength] by 1
@@ -350,7 +350,7 @@ onKeypress = (event) ->
         if (currentCompletionKeys.indexOf(keyChar) != -1)
           DomUtils.suppressEvent(event)
 
-        keyPort.postMessage({ keyChar:keyChar, frameId:frameId })
+        keyPort.postMessage({ keyChar: keyChar, frameId: frameId })
 
 onKeydown = (event) ->
   return unless handlerStack.bubbleEvent('keydown', event)
@@ -416,10 +416,10 @@ onKeydown = (event) ->
       if (currentCompletionKeys.indexOf(keyChar) != -1)
         DomUtils.suppressEvent(event)
 
-      keyPort.postMessage({ keyChar:keyChar, frameId:frameId })
+      keyPort.postMessage({ keyChar: keyChar, frameId: frameId })
 
     else if (KeyboardUtils.isEscape(event))
-      keyPort.postMessage({ keyChar:"<ESC>", frameId:frameId })
+      keyPort.postMessage({ keyChar: "<ESC>", frameId: frameId })
 
   # Added to prevent propagating this event to other listeners if it's one that'll trigger a Vimium command.
   # The goal is to avoid the scenario where Google Instant Search uses every keydown event to dump us
@@ -859,7 +859,7 @@ window.showHelpDialog = (html, fid) ->
     # This setting is pulled out of local storage. It's false by default.
     getShowAdvancedCommands: -> settings.get("helpDialog_showAdvancedCommands")
 
-    init: () ->
+    init: ->
       this.dialogElement = document.getElementById("vimiumHelpDialog")
       this.dialogElement.getElementsByClassName("toggleAdvancedCommands")[0].addEventListener("click",
         VimiumHelpDialog.toggleAdvancedCommands, false)

--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -52,7 +52,7 @@ class VomnibarUI
   show: ->
     @box.style.display = "block"
     @input.focus()
-    @handlerId = handlerStack.push keydown: @onKeydown.bind @
+    @handlerId = handlerStack.push keydown: @onKeydown
 
   hide: ->
     @box.style.display = "none"
@@ -69,9 +69,9 @@ class VomnibarUI
 
   updateSelection: ->
     # We have taken the option to add some global state here (previousCompletionType) to tell if a search
-    # item has just appeared or disappeared, if that happens we either set the initialSelectionValue to 0 or 1
-    # I feel that this approach is cleaner than bubbling the state up from the suggestion level
-    # so we just inspect it afterwards
+    # item has just appeared or disappeared, if that happens we either set initialSelectionValue to 0 or 1.
+    # I feel that this approach is cleaner than bubbling the state up from the suggestion level so we just
+    # inspect it afterwards
     if @completions[0]
       if @previousCompletionType != "search" && @completions[0].type == "search"
         @selection = 0
@@ -100,7 +100,7 @@ class VomnibarUI
     else if (event.keyCode == keyCodes.enter)
       return "enter"
 
-  onKeydown: (event) ->
+  onKeydown: (event) =>
     action = @actionFromKeyEvent(event)
     return true unless action # pass through
 

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -81,8 +81,8 @@ DomUtils =
       if (clientRect.width == 0 || clientRect.height == 0)
         for child in element.children
           computedStyle = window.getComputedStyle(child, null)
-          # Ignore child elements which are not floated and not absolutely positioned for parent elements with
-          # zero width/height
+          # Ignore child elements which are not floated and not absolutely positioned for parent elements
+          # with zero width/height
           continue if (computedStyle.getPropertyValue('float') == 'none' &&
             computedStyle.getPropertyValue('position') != 'absolute')
           childClientRect = @getVisibleClientRect(child)
@@ -109,10 +109,11 @@ DomUtils =
     eventSequence = ["mouseover", "mousedown", "mouseup", "click"]
     for event in eventSequence
       mouseEvent = document.createEvent("MouseEvents")
-      mouseEvent.initMouseEvent(event, true, true, window, 1, 0, 0, 0, 0, modifiers.ctrlKey, modifiers.altKey,
-      modifiers.shiftKey, modifiers.metaKey, 0, null)
-      # Debugging note: Firefox will not execute the element's default action if we dispatch this click event,
-      # but Webkit will. Dispatching a click on an input box does not seem to focus it; we do that separately
+      mouseEvent.initMouseEvent(event, true, true, window, 1, 0, 0, 0, 0, modifiers.ctrlKey,
+      modifiers.altKey, modifiers.shiftKey, modifiers.metaKey, 0, null)
+      # Debugging note: Firefox will not execute the element's default action if we dispatch this click
+      # event, but Webkit will. Dispatching a click on an input box does not seem to focus it; we do that
+      # separately
       element.dispatchEvent(mouseEvent)
 
   # momentarily flash a rectangular border to give user some visual feedback

--- a/lib/handler_stack.coffee
+++ b/lib/handler_stack.coffee
@@ -23,7 +23,7 @@ class root.HandlerStack
       # of more than one handler.
       if handler && handler[type]
         @currentId = handler.id
-        passThrough = handler[type].call(@, event)
+        passThrough = handler[type].call(this, event)
         if not passThrough
           DomUtils.suppressEvent(event)
           return false

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -125,7 +125,8 @@ Utils =
   # Zip two (or more) arrays:
   #   - Utils.zip([ [a,b], [1,2] ]) returns [ [a,1], [b,2] ]
   #   - Length of result is `arrays[0].length`.
-  #   - Adapted from: http://stackoverflow.com/questions/4856717/javascript-equivalent-of-pythons-zip-function
+  #   - Adapted from:
+  #     http://stackoverflow.com/questions/4856717/javascript-equivalent-of-pythons-zip-function
   zip: (arrays) ->
     arrays[0].map (_,i) ->
       arrays.map( (array) -> array[i] )

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -18,7 +18,8 @@ document.addEventListener "DOMContentLoaded", ->
 
   $("advancedOptionsLink").addEventListener "click", toggleAdvancedOptions, false
   $("showCommands").addEventListener "click", (->
-    showHelpDialog chrome.extension.getBackgroundPage().helpDialogHtml(true, true, "Command Listing"), frameId
+    dialogHtml = chrome.extension.getBackgroundPage().helpDialogHtml(true, true, "Command Listing")
+    showHelpDialog dialogHtml, frameId
   ), false
   document.getElementById("restoreSettings").addEventListener "click", restoreToDefaults
   document.getElementById("saveOptions").addEventListener "click", saveOptions
@@ -92,7 +93,7 @@ setFieldValue = (field, value) ->
   else
     field.checked = value
 
-toggleAdvancedOptions = do (advancedMode=false) -> (event) ->
+toggleAdvancedOptions = do (advancedMode = false) -> (event) ->
   if advancedMode
     $("advancedOptions").style.display = "none"
     $("advancedOptionsLink").innerHTML = "Show advanced options&hellip;"

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -146,9 +146,9 @@ context "Filtered link hints",
 
     setup ->
       testContent = "<input type='text' value='some value'/><input type='password' value='some value'/>
-        <textarea>some text</textarea><label for='test-input'/>a label</label>
+        <textarea>some text</textarea><label for='test-input'>a label</label>
         <input type='text' id='test-input' value='some value'/>
-        <label for='test-input-2'/>a label: </label><input type='text' id='test-input-2' value='some value'/>"
+        <label for='test-input-2'>a label: </label><input type='text' id='test-input-2' value='some value'/>"
       document.getElementById("test-div").innerHTML = testContent
       LinkHints.activateMode()
 
@@ -185,8 +185,8 @@ context "Input focus",
     handlerStack.bubbleEvent 'keydown', mockKeyboardEvent("A")
 
 # TODO: these find prev/next link tests could be refactored into unit tests which invoke a function which has
-# a tighter contract than goNext(), since they test minor aspects of goNext()'s link matching behavior, and we
-# don't need to construct external state many times over just to test that.
+# a tighter contract than goNext(), since they test minor aspects of goNext()'s link matching behavior, and
+# we don't need to construct external state many times over just to test that.
 # i.e. these tests should look something like:
 # assert.equal(findLink(html("<a href=...">))[0].href, "first")
 # These could then move outside of the dom_tests file.

--- a/tests/dom_tests/phantom_runner.coffee
+++ b/tests/dom_tests/phantom_runner.coffee
@@ -14,7 +14,7 @@ page.onConsoleMessage = (msg) ->
   console.log msg
 
 page.onError = (msg, trace) ->
-  console.log(msg);
+  console.log(msg)
   trace.forEach (item) ->
     console.log('  ', item.file, ':', item.line)
 

--- a/tests/dom_tests/test_runner.coffee
+++ b/tests/dom_tests/test_runner.coffee
@@ -3,7 +3,8 @@ Tests.outputMethod = (args...) ->
   # escape html
   newOutput = newOutput.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
   # highlight the source of the error
-  newOutput = newOutput.replace /\/([^:/]+):([0-9]+):([0-9]+)/, "/<span class='errorPosition'>$1:$2</span>:$3"
+  newOutput = newOutput.replace /\/([^:/]+):([0-9]+):([0-9]+)/,
+                                "/<span class='errorPosition'>$1:$2</span>:$3"
   document.getElementById("output-div").innerHTML += "<div class='output-section'>" + newOutput + "</div>"
   console.log.apply console, args
 

--- a/tests/dom_tests/vomnibar_test.coffee
+++ b/tests/dom_tests/vomnibar_test.coffee
@@ -19,7 +19,7 @@ context "Keep selection within bounds",
     ui.update(true)
     assert.equal -1, ui.selection
 
-    @completions = [{html:'foo',type:'tab',url:'http://example.com'}]
+    @completions = [{html: 'foo',type: 'tab',url: 'http://example.com'}]
     ui.update(true)
     assert.equal -1, ui.selection
 
@@ -35,7 +35,7 @@ context "Keep selection within bounds",
     ui.update(true)
     assert.equal -1, ui.selection
 
-    @completions = [{html:'foo',type:'bookmark',url:'http://example.com'}]
+    @completions = [{html: 'foo',type: 'bookmark',url: 'http://example.com'}]
     ui.update(true)
     assert.equal 0, ui.selection
 
@@ -54,7 +54,7 @@ context "Keep selection within bounds",
       preventDefault: ->
       stopPropagation: ->
 
-    @completions = [{html:'foo',type:'tab',url:'http://example.com'}]
+    @completions = [{html: 'foo',type: 'tab',url: 'http://example.com'}]
     ui.update(true)
     stub ui, "actionFromKeyEvent", -> "down"
     ui.onKeydown eventMock

--- a/tests/unit_tests/completion_test.coffee
+++ b/tests/unit_tests/completion_test.coffee
@@ -86,7 +86,7 @@ context "HistoryCache",
       assert.arrayEqual [@history2, @history1], @results
 
     should "add new visits to the history", ->
-      HistoryCache.use () ->
+      HistoryCache.use ->
       newSite = { url: "ab.com" }
       @onVisitedListener(newSite)
       HistoryCache.use (@results) =>
@@ -234,8 +234,9 @@ context "search engines",
     searchEngines = "foo: bar?q=%s\n# comment\nbaz: qux?q=%s"
     Settings.set 'searchEngines', searchEngines
     @completer = new SearchEngineCompleter()
-    # note, I couldn't just call @completer.refresh() here as I couldn't set root.Settings without errors
-    # workaround is below, would be good for someone that understands the testing system better than me to improve
+    # I couldn't just call @completer.refresh() here as I couldn't set root.Settings without errors.
+    # Workaround is below.
+    # TODO: Would be good for someone who understands the testing system better than me to improve
     @completer.searchEngines = Settings.getSearchEngines()
 
   should "return search engine suggestion", ->
@@ -305,27 +306,36 @@ context "RankingUtils.wordRelevancy",
   #   highScore = RankingUtils.wordRelevancy(["bbc"], "http://stackoverflow.com/same", "BBC Radio 4 (BBCr4)")
   #   assert.isTrue highScore > lowScore
 
+equalPairs = (pair1, pair2) ->
+    pair1[0] == pair2[0] and pair1[1] == pair2[1]
+
 context "Suggestion.pushMatchingRanges",
   should "extract ranges matching term (simple case, two matches)", ->
     ranges = []
     [ one, two, three ] = [ "one", "two", "three" ]
     suggestion = new Suggestion([], "", "", "", returns(1))
     suggestion.pushMatchingRanges("#{one}#{two}#{three}#{two}#{one}", two, ranges)
-    assert.equal 2, Utils.zip([ ranges, [ [3,6], [11,14] ] ]).filter((pair) -> pair[0][0] == pair[1][0] and pair[0][1] == pair[1][1]).length
+    assert.equal 2, (Utils.zip([ ranges, [ [3,6], [11,14] ] ])
+                          .filter((pair) -> equalPairs pair[0], pair[1])
+                          .length)
 
   should "extract ranges matching term (two matches, one at start of string)", ->
     ranges = []
     [ one, two, three ] = [ "one", "two", "three" ]
     suggestion = new Suggestion([], "", "", "", returns(1))
     suggestion.pushMatchingRanges("#{two}#{three}#{two}#{one}", two, ranges)
-    assert.equal 2, Utils.zip([ ranges, [ [0,3], [8,11] ] ]).filter((pair) -> pair[0][0] == pair[1][0] and pair[0][1] == pair[1][1]).length
+    assert.equal 2, (Utils.zip([ ranges, [ [0,3], [8,11] ] ])
+                          .filter((pair) -> equalPairs pair[0], pair[1])
+                          .length)
 
   should "extract ranges matching term (two matches, one at end of string)", ->
     ranges = []
     [ one, two, three ] = [ "one", "two", "three" ]
     suggestion = new Suggestion([], "", "", "", returns(1))
     suggestion.pushMatchingRanges("#{one}#{two}#{three}#{two}", two, ranges)
-    assert.equal 2, Utils.zip([ ranges, [ [3,6], [11,14] ] ]).filter((pair) -> pair[0][0] == pair[1][0] and pair[0][1] == pair[1][1]).length
+    assert.equal 2, (Utils.zip([ ranges, [ [3,6], [11,14] ] ])
+                          .filter((pair) -> equalPairs pair[0], pair[1])
+                          .length)
 
   should "extract ranges matching term (no matches)", ->
     ranges = []

--- a/tests/unit_tests/handler_stack_test.coffee
+++ b/tests/unit_tests/handler_stack_test.coffee
@@ -40,7 +40,7 @@ context "handlerStack",
     assert.isFalse @handler1Called
 
   should "handle self-removing handlers correctly", ->
-    ctx = @
+    ctx = this
     @handlerStack.push { keydown: => @handler1Called = true }
     @handlerStack.push { keydown: ->
       ctx.handler2Called = true


### PR DESCRIPTION
This PR attempts to add automatic style guide checking. Specifically, it

* moves the style guide into the repository.
* adds a `coffeelint` configuration to check (a subset of) the style guide recommendations.
* adds `cake lint` to run `coffeelint`.
* integrates `cake lint` into travis-ci.
* makes the changes suggested by `cake lint`.

All code style violations caught by `coffeelint` are currently set to `warn`, so will not fail the travis build. This can be changed if certain violations are deemed unacceptable.