### PR TITLE
Add exitInsertMode, allow binding single keys only

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -40,6 +40,8 @@ Commands =
 
   unmapKey: (key) -> delete @keyToCommandRegistry[key]
 
+  insertExitKeys: null
+
   # Lower-case the appropriate portions of named keys.
   #
   # A key name is one of three forms exemplified by <c-a> <left> or <c-f12>
@@ -81,10 +83,18 @@ Commands =
         @keyToCommandRegistry = {}
 
   clearKeyMappingsAndSetDefaults: ->
+    @insertExitKeys = null
     @keyToCommandRegistry = {}
 
     for key of defaultKeyMappings
       @mapKeyToCommand(key, defaultKeyMappings[key])
+
+  getInsertExitKeys: ->
+    return @insertExitKeys unless @insertExitKeys == null
+
+    @insertExitKeys = []
+    for keys, {command} of @keyToCommandRegistry
+      @insertExitKeys.push(keys) if command == "exitInsertMode"
 
   # An ordered listing of all available commands, grouped by type. This is the order they will
   # be shown in the help page.
@@ -111,6 +121,7 @@ Commands =
       "goUp",
       "goToRoot",
       "enterInsertMode",
+      "exitInsertMode",
       "focusInput",
       "LinkHints.activateMode",
       "LinkHints.activateModeToOpenInNewTab",
@@ -126,9 +137,9 @@ Commands =
       "goPrevious",
       "goNext",
       "nextFrame",
-      "Marks.activateCreateMode",
       "Vomnibar.activateEditUrl",
       "Vomnibar.activateEditUrlInNewTab",
+      "Marks.activateCreateMode",
       "Marks.activateGotoMode"]
     findCommands: ["enterFindMode", "performFind", "performBackwardsFind"]
     historyNavigation:
@@ -195,6 +206,8 @@ defaultKeyMappings =
   "gs": "toggleViewSource"
 
   "i": "enterInsertMode"
+  "<esc>": "exitInsertMode"
+  "<c-[>": "exitInsertMode"
 
   "H": "goBack"
   "L": "goForward"
@@ -283,6 +296,7 @@ commandDescriptions =
   openCopiedUrlInNewTab: ["Open the clipboard's URL in a new tab", { background: true, repeatLimit: 20 }]
 
   enterInsertMode: ["Enter insert mode", { noRepeat: true }]
+  exitInsertMode: ["Exit insert mode", { noRepeat: true }]
 
   focusInput: ["Focus the first text box on the page. Cycle between them using tab",
     { passCountToFunction: true }]

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -41,6 +41,7 @@ Commands =
   unmapKey: (key) -> delete @keyToCommandRegistry[key]
 
   insertExitKeys: null
+  insertExitPassKeys: null
 
   # Lower-case the appropriate portions of named keys.
   #
@@ -84,17 +85,22 @@ Commands =
 
   clearKeyMappingsAndSetDefaults: ->
     @insertExitKeys = null
+    @insertExitPassKeys = null
     @keyToCommandRegistry = {}
 
     for key of defaultKeyMappings
       @mapKeyToCommand(key, defaultKeyMappings[key])
 
   getInsertExitKeys: ->
-    return @insertExitKeys unless @insertExitKeys == null
+    return [@insertExitKeys, @insertExitPassKeys] unless @insertExitKeys == null
 
     @insertExitKeys = []
+    @insertExitPassKeys = []
     for keys, {command} of @keyToCommandRegistry
-      @insertExitKeys.push(keys) if command == "exitInsertMode"
+      if command == "exitInsertMode"
+        @insertExitKeys.push(keys)
+      else if command == "exitInsertModeAndPassKey"
+        @insertExitPassKeys.push(keys)
 
   # An ordered listing of all available commands, grouped by type. This is the order they will
   # be shown in the help page.
@@ -122,6 +128,7 @@ Commands =
       "goToRoot",
       "enterInsertMode",
       "exitInsertMode",
+      "exitInsertModeAndPassKey",
       "focusInput",
       "LinkHints.activateMode",
       "LinkHints.activateModeToOpenInNewTab",
@@ -297,6 +304,7 @@ commandDescriptions =
 
   enterInsertMode: ["Enter insert mode", { noRepeat: true }]
   exitInsertMode: ["Exit insert mode", { noRepeat: true }]
+  exitInsertModeAndPassKey: ["Exit insert mode, but pass the key to the underlying page", { noRepeat: true }]
 
   focusInput: ["Focus the first text box on the page. Cycle between them using tab",
     { passCountToFunction: true }]

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -152,6 +152,7 @@ getCompletionKeysRequest = (request, keysToCheck = "") ->
   name: "refreshCompletionKeys"
   completionKeys: generateCompletionKeys(keysToCheck)
   validFirstKeys: validFirstKeys
+  insertExitKeys: Commands.getInsertExitKeys()
 
 #
 # Opens the url in the current tab.
@@ -548,7 +549,8 @@ checkKeyQueue = (keysToCheck, tabId, frameId) ->
           frameId: frameId,
           count: count,
           passCountToFunction: registryEntry.passCountToFunction,
-          completionKeys: generateCompletionKeys(""))
+          completionKeys: generateCompletionKeys("")
+          insertExitKeys: Commands.getInsertExitKeys())
         refreshedCompletionKeys = true
       else
         if registryEntry.passCountToFunction

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -149,10 +149,12 @@ fetchFileContents = (extensionFileName) ->
 # Returns the keys that can complete a valid command given the current key queue.
 #
 getCompletionKeysRequest = (request, keysToCheck = "") ->
+  [insertExitKeys, insertExitPassKeys] = Commands.getInsertExitKeys()
   name: "refreshCompletionKeys"
   completionKeys: generateCompletionKeys(keysToCheck)
   validFirstKeys: validFirstKeys
-  insertExitKeys: Commands.getInsertExitKeys()
+  insertExitKeys: insertExitKeys
+  insertExitPassKeys: insertExitPassKeys
 
 #
 # Opens the url in the current tab.
@@ -543,6 +545,7 @@ checkKeyQueue = (keysToCheck, tabId, frameId) ->
 
     if runCommand
       if not registryEntry.isBackgroundCommand
+        [insertExitKeys, insertExitPassKeys] = Commands.getInsertExitKeys()
         chrome.tabs.sendMessage(tabId,
           name: "executePageCommand",
           command: registryEntry.command,
@@ -550,7 +553,8 @@ checkKeyQueue = (keysToCheck, tabId, frameId) ->
           count: count,
           passCountToFunction: registryEntry.passCountToFunction,
           completionKeys: generateCompletionKeys("")
-          insertExitKeys: Commands.getInsertExitKeys())
+          insertExitKeys: insertExitKeys
+          insertExitPassKeys: insertExitPassKeys)
         refreshedCompletionKeys = true
       else
         if registryEntry.passCountToFunction

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -22,6 +22,7 @@ passKeys = null
 keyQueue = null
 # The user's operating system.
 currentCompletionKeys = null
+insertExitKeys = null
 validFirstKeys = null
 
 # The types in <input type="..."> that we consider for focusInput command. Right now this is recalculated in
@@ -435,8 +436,14 @@ onKeydown = (event) ->
       if (modifiers.length > 0 || keyChar.length > 1)
         keyChar = "<" + keyChar + ">"
 
-  if (isInsertMode() && KeyboardUtils.isEscape(event))
-    # Note that we can't programmatically blur out of Flash embeds from Javascript.
+  rawKeyChar = keyChar
+  if (KeyboardUtils.isEscape(event))
+    rawKeyChar = "<esc>"
+
+  rawKeyChar ||= KeyboardUtils.getKeyChar(event)
+
+  if (isInsertMode() and insertExitKeys.indexOf(rawKeyChar) != -1)
+    # We don't want to programmatically blur out of Flash embeds from Javascript.
     if (!isEmbed(event.srcElement))
       # Remove focus so the user can't just get himself back into insert mode by typing in the same input
       # box.
@@ -519,6 +526,7 @@ checkIfEnabledForUrl = ->
 refreshCompletionKeys = (response) ->
   if (response)
     currentCompletionKeys = response.completionKeys
+    insertExitKeys = response.insertExitKeys
 
     if (response.validFirstKeys)
       validFirstKeys = response.validFirstKeys

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -530,8 +530,8 @@ checkIfEnabledForUrl = ->
 refreshCompletionKeys = (response) ->
   if (response)
     currentCompletionKeys = response.completionKeys
-    insertExitKeys = response.insertExitKeys
-    insertExitPassKeys = response.insertExitPassKeys
+    insertExitKeys = response.insertExitKeys || []
+    insertExitPassKeys = response.insertExitPassKeys || []
 
     if (response.validFirstKeys)
       validFirstKeys = response.validFirstKeys

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -23,6 +23,7 @@ keyQueue = null
 # The user's operating system.
 currentCompletionKeys = null
 insertExitKeys = null
+insertExitPassKeys = null
 validFirstKeys = null
 
 # The types in <input type="..."> that we consider for focusInput command. Right now this is recalculated in
@@ -442,7 +443,9 @@ onKeydown = (event) ->
 
   rawKeyChar ||= KeyboardUtils.getKeyChar(event)
 
-  if (isInsertMode() and insertExitKeys.indexOf(rawKeyChar) != -1)
+  isInsertExitPassKey = (rawKeyChar in insertExitPassKeys)
+
+  if (isInsertMode() and (isInsertExitPassKey or rawKeyChar in insertExitKeys))
     # We don't want to programmatically blur out of Flash embeds from Javascript.
     if (!isEmbed(event.srcElement))
       # Remove focus so the user can't just get himself back into insert mode by typing in the same input
@@ -450,8 +453,9 @@ onKeydown = (event) ->
       if (isEditable(event.srcElement))
         event.srcElement.blur()
       exitInsertMode()
-      DomUtils.suppressEvent event
-      KeydownEvents.push event
+      unless isInsertExitPassKey
+        DomUtils.suppressEvent event
+        KeydownEvents.push event
 
   else if (findMode)
     if (KeyboardUtils.isEscape(event))
@@ -527,6 +531,7 @@ refreshCompletionKeys = (response) ->
   if (response)
     currentCompletionKeys = response.completionKeys
     insertExitKeys = response.insertExitKeys
+    insertExitPassKeys = response.insertExitPassKeys
 
     if (response.validFirstKeys)
       validFirstKeys = response.validFirstKeys


### PR DESCRIPTION
This creates the command `exitInsertMode`. The command only responds to single key mappings, so that all keys except those which explicitly exit insert mode are passed to the underlying page.

This fixes #301.