### PR TITLE
Enable link hints for all elements with `click` listeners

### DIFF
--- a/content_scripts/inject_script.coffee
+++ b/content_scripts/inject_script.coffee
@@ -1,0 +1,16 @@
+# Inject scripts into the page context before page scripts are executed
+
+fetchFileContents = (extensionFileName) ->
+  req = new XMLHttpRequest()
+  req.open("GET", chrome.runtime.getURL(extensionFileName), false) # false => synchronous
+  req.send()
+  req.responseText
+
+eventName = "reset"
+injectScripts = ["pages/addEventListener_hook.js"]
+
+# Injection method taken from method 3 of this stackoverflow answer http://stackoverflow.com/a/9517879
+for script in injectScripts
+  document.documentElement.setAttribute("on#{eventName}", fetchFileContents script)
+  document.documentElement.dispatchEvent(new CustomEvent(eventName))
+  document.documentElement.removeAttribute("on#{eventName}")

--- a/content_scripts/inject_script.coffee
+++ b/content_scripts/inject_script.coffee
@@ -2,15 +2,28 @@
 
 fetchFileContents = (extensionFileName) ->
   req = new XMLHttpRequest()
-  req.open("GET", chrome.runtime.getURL(extensionFileName), false) # false => synchronous
+  req.open "GET", chrome.runtime.getURL(extensionFileName), false # false => synchronous
   req.send()
   req.responseText
 
 eventName = "reset"
+listenerName = "on#{eventName}"
 injectScripts = ["pages/addEventListener_hook.js"]
+
+# Store the original value of the event listener if one exists, or null otherwise.
+oldValue =
+  if document.documentElement.hasAttribute listenerName
+    document.documentElement.getAttribute listenerName
+  else
+    null
 
 # Injection method taken from method 3 of this stackoverflow answer http://stackoverflow.com/a/9517879
 for script in injectScripts
-  document.documentElement.setAttribute("on#{eventName}", fetchFileContents script)
-  document.documentElement.dispatchEvent(new CustomEvent(eventName))
-  document.documentElement.removeAttribute("on#{eventName}")
+  document.documentElement.setAttribute listenerName, fetchFileContents script
+  document.documentElement.dispatchEvent new CustomEvent eventName
+
+# Clear our event listener and restore the original, if there was one.
+if oldValue?
+  document.documentElement.setAttribute listenerName, oldValue
+else
+  document.documentElement.removeAttribute listenerName

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -44,7 +44,8 @@ LinkHints =
     ["a", "area[@href]", "textarea", "button", "select",
      "input[not(@type='hidden' or @disabled or @readonly)]",
      "*[@onclick or @tabindex or @role='link' or @role='button' or contains(@class, 'button') or " +
-     "@contenteditable='' or translate(@contenteditable, 'TRUE', 'true')='true']"])
+     "@contenteditable='' or translate(@contenteditable, 'TRUE', 'true')='true' or" +
+     "@vimium-has-onclick-listener]"])
 
   # We need this as a top-level function because our command system doesn't yet support arguments.
   activateModeToOpenInNewTab: -> @activateMode(OPEN_IN_NEW_BG_TAB)

--- a/manifest.json
+++ b/manifest.json
@@ -50,10 +50,19 @@
       "css": ["content_scripts/file_urls.css"],
       "run_at": "document_start",
       "all_frames": true
+    },
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content_scripts/inject_script.js"],
+      "run_at": "document_start",
+      "all_frames": true
     }
   ],
   "browser_action": {
     "default_icon": "icons/browser_action_disabled.png",
     "default_popup": "pages/popup.html"
-  }
+  },
+  "web_accessible_resources": [
+    "pages/addEventListener_hook.js"
+  ]
 }

--- a/pages/addEventListener_hook.coffee
+++ b/pages/addEventListener_hook.coffee
@@ -1,0 +1,10 @@
+_addEventListener = Element::addEventListener
+
+Element::addEventListener = (type, listener, useCapture) ->
+  if type == "click"
+    unless @getAttribute("onclick")
+      # Perform this asynchronously; not doing so breaks some of the facebook UI for some unclear reason
+      setTimeout(=>
+        @setAttribute("onclick", "")
+      , 0)
+  _addEventListener.apply(this, arguments)

--- a/pages/addEventListener_hook.coffee
+++ b/pages/addEventListener_hook.coffee
@@ -2,9 +2,6 @@ _addEventListener = Element::addEventListener
 
 Element::addEventListener = (type, listener, useCapture) ->
   if type == "click"
-    unless @getAttribute("vimium-has-onclick-listener")
-      # Perform this asynchronously; not doing so breaks some of the facebook UI for some unclear reason
-      setTimeout(=>
-        @setAttribute("vimium-has-onclick-listener", "")
-      , 0)
+    unless @hasAttribute("vimium-has-onclick-listener")
+      @setAttribute("vimium-has-onclick-listener", "")
   _addEventListener.apply(this, arguments)

--- a/pages/addEventListener_hook.coffee
+++ b/pages/addEventListener_hook.coffee
@@ -2,9 +2,9 @@ _addEventListener = Element::addEventListener
 
 Element::addEventListener = (type, listener, useCapture) ->
   if type == "click"
-    unless @getAttribute("onclick")
+    unless @getAttribute("vimium-has-onclick-listener")
       # Perform this asynchronously; not doing so breaks some of the facebook UI for some unclear reason
       setTimeout(=>
-        @setAttribute("onclick", "")
+        @setAttribute("vimium-has-onclick-listener", "")
       , 0)
   _addEventListener.apply(this, arguments)


### PR DESCRIPTION
This PR implements a hook on `addEventListener`, which marks elements registering a `click` event listener so that Vimium recognises them.

This enables link hint support for clickable elements such as eg. the quiz choices on [this Buzzfeed quiz](http://www.buzzfeed.com/adamellis/this-palm-reading-quiz-will-reveal-your-future#2s6on3d) or the slideshow navigation buttons on the [Mercedes website](http://www5.mercedes-benz.com/en/).

This PR

* fixes #1091 
* fixes #993 
* fixes #861 
* improves the situation for #1157 (some clickable elements still don't receive link hints).