### PR TITLE
Add support for selecting HTML5 inputs, change criterion to a blacklist

### DIFF
--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -93,6 +93,11 @@ DomUtils =
   #
   # Selectable means that we should use the simulateSelect method to activate the element instead of a click.
   #
+  # The html5 input types that should use simulateSelect are:
+  #   ["date", "datetime", "datetime-local", "email", "month", "number", "password", "range", "search",
+  #    "submit", "tel", "text", "time", "url", "week"]
+  # An unknown type will be treated the same as "text", in the same way that the browser does.
+  #
   isSelectable: (element) ->
     unselectableTypes = ["button", "checkbox", "color", "file", "hidden", "image", "radio", "reset"]
     (element.nodeName.toLowerCase() == "input" && unselectableTypes.indexOf(element.type) == -1) ||


### PR DESCRIPTION
This is designed to address several issues:
- `<input type="range" />` elements don't respond well to the simulated
  click; they always reset their value to the minimum.
- The lack of `mouseup` event from the simulated click makes
  `<input type="range />` elements slide when the mouse is moved.
- HTML5 adds a large number of text-based `<input>`s that should be focused
  like the `type="text"` case, for consistency. (Using a blacklist halves
  the number of types we have to list.)
- An `<input>` with a `type` the browser doesn't support is rendered as
  a `type="text"`, so a blacklist ensures that the focusing action is
  consistent on all elements behaving as `type="text"`.

I have been testing with [this demo](http://html5doctor.com/demos/forms/forms-example.html).

This fixes #1201.
