### PR TITLE
Apply all matching exclusion rules to URLs

### DIFF
--- a/background_scripts/exclusions.coffee
+++ b/background_scripts/exclusions.coffee
@@ -18,9 +18,17 @@ root.Exclusions = Exclusions =
 
   # Return the first exclusion rule matching the URL, or null.
   getRule: (url) ->
+    compoundRule = null
     for rule in @rules
-      return rule if url.match(RegexpCache.get(rule.pattern))
-    return null
+      continue unless url.match(RegexpCache.get(rule.pattern))
+
+      if rule.passKeys == "" # Found a disable rule. This overrides all others.
+        return rule
+      else if compoundRule == null
+        compoundRule = {passKeys: rule.passKeys}
+      else
+        compoundRule.passKeys += rule.passKeys
+    return compoundRule
 
   setRules: (rules) ->
     # Callers map a rule to null to have it deleted, and rules without a pattern are useless.


### PR DESCRIPTION
This PR an implementation of the idea from [this comment](https://github.com/philc/vimium/pull/1154#issuecomment-60097660).

It modifies the exclusion rule URL matching to consider all possible rules, rather than the first rule found. Hopefully this should give better UX, since we aren't ignoring any rules which the user would expect to be applied.
