### PR TITLE
Enable link hints across all frames of a tab

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -22,17 +22,21 @@ Commands =
       isBackgroundCommand: options.background
       passCountToFunction: options.passCountToFunction
       noRepeat: options.noRepeat
+      allFrames: options.allFrames
 
   mapKeyToCommand: (key, command) ->
     unless @availableCommands[command]
       console.log(command, "doesn't exist!")
       return
 
+    commandDetails = @availableCommands[command]
+
     @keyToCommandRegistry[key] =
       command: command
-      isBackgroundCommand: @availableCommands[command].isBackgroundCommand
-      passCountToFunction: @availableCommands[command].passCountToFunction
-      noRepeat: @availableCommands[command].noRepeat
+      isBackgroundCommand: commandDetails.isBackgroundCommand
+      passCountToFunction: commandDetails.passCountToFunction
+      noRepeat: commandDetails.noRepeat
+      allFrames: commandDetails.allFrames
 
   unmapKey: (key) -> delete @keyToCommandRegistry[key]
 
@@ -212,7 +216,7 @@ commandDescriptions =
   toggleViewSource: ["View page source"]
 
   copyCurrentUrl: ["Copy the current URL to the clipboard"]
-  'LinkHints.activateModeToCopyLinkUrl': ["Copy a link URL to the clipboard"]
+  'LinkHints.activateModeToCopyLinkUrl': ["Copy a link URL to the clipboard", {allFrames: true}]
   openCopiedUrlInCurrentTab: ["Open the clipboard's URL in the current tab", { background: true }]
   openCopiedUrlInNewTab: ["Open the clipboard's URL in a new tab", { background: true }]
 
@@ -221,12 +225,12 @@ commandDescriptions =
   focusInput: ["Focus the first text box on the page. Cycle between them using tab",
     { passCountToFunction: true }]
 
-  "LinkHints.activateMode": ["Open a link in the current tab"]
-  "LinkHints.activateModeToOpenInNewTab": ["Open a link in a new tab"]
-  "LinkHints.activateModeToOpenInNewForegroundTab": ["Open a link in a new tab & switch to it"]
-  "LinkHints.activateModeWithQueue": ["Open multiple links in a new tab"]
+  "LinkHints.activateMode": ["Open a link in the current tab", {allFrames: true}]
+  "LinkHints.activateModeToOpenInNewTab": ["Open a link in a new tab", {allFrames: true}]
+  "LinkHints.activateModeToOpenInNewForegroundTab": ["Open a link in a new tab & switch to it", {allFrames: true}]
+  "LinkHints.activateModeWithQueue": ["Open multiple links in a new tab", {allFrames: true}]
 
-  "LinkHints.activateModeToOpenIncognito": ["Open a link in incognito window"]
+  "LinkHints.activateModeToOpenIncognito": ["Open a link in incognito window", {allFrames: true}]
 
   enterFindMode: ["Enter find mode"]
   performFind: ["Cycle forward to the next find match"]

--- a/background_scripts/link_hint_oracle.coffee
+++ b/background_scripts/link_hint_oracle.coffee
@@ -1,0 +1,353 @@
+root = exports ? window
+
+LinkHintOracle =
+  hintInformationFromTabId: {} # Map of tabId => hintInformation.
+  getMarkerMatcher: ->
+    if Settings.get("filterLinkHints") then filterHints else alphabetHints
+
+  manageLinkHints: (request, port) ->
+    switch request.name
+      when "registerLinkHints"
+        LinkHintOracle.registerLinkHints(request, port)
+      when "handleKeyDown"
+        LinkHintOracle.handleKeyDown(request, port)
+
+  registerLinkHints: (request, port) ->
+    tabId = port.sender.tab.id
+
+    # Initialise this tab's hintInformation if we haven't already.
+    hintInformation = @hintInformationFromTabId[tabId] ?=
+      acceptingLinkHintRegistrations: true
+      portsFromFrameIds: {} # Map from frameId => port.
+      frameIds: []
+      hintVisibles: []
+      hintKeystrokeQueue: []
+      numberOfHintsFromFrameId: {}
+      hintIndexInFrame: []
+
+    {portsFromFrameIds, acceptingLinkHintRegistrations, frameIds} = hintInformation
+    portsFromFrameIds[request.frameId] = port
+
+    # If we've already started filtering, just ignore this request, pretend the links don't exist.
+    return unless (acceptingLinkHintRegistrations)
+
+    @getMarkerMatcher().updateHintInformation(hintInformation, request.hintInformation, request.frameId)
+    hintStrings = @getMarkerMatcher().generateHintStrings(hintInformation)
+
+    hintStringsFromFrameId = {}
+    for hintString, i in hintStrings
+      frameHintStrings = hintStringsFromFrameId[frameIds[i]] ?= []
+      frameHintStrings.push(hintString)
+
+    for frameId, port of portsFromFrameIds
+      port.postMessage({name: "setHintStrings", hintStrings: hintStringsFromFrameId[frameId]})
+
+
+  handleKeyDown: (request, port) ->
+    tabId = port.sender.tab.id
+    hintInformation = @hintInformationFromTabId[tabId]
+    {event} = request
+
+    if (event.keyCode == keyCodes.shiftKey or event.keyCode == keyCodes.ctrlKey)
+      # We can't handle this in the background. Tell all the pages to handle these themselves.
+      for frameId, port of portsFromFrameIds
+        port.postMessage({name: "handleKeyDown", event: event})
+      return
+
+    if (KeyboardUtils.isEscape(event))
+      @deactivate(hintInformation, tabId)
+    else
+      # Since the user has pressed a key, we assume that there's already a link hint for the link they want.
+      hintInformation.acceptingLinkHintRegistrations = false
+
+      {delay, matched} = keyResult = @getMarkerMatcher().matchHintsByKey(hintInformation, event)
+      delay ?= 0
+
+      if (matched.length == 0)
+        @deactivate(hintInformation, tabId, delay)
+      else if (matched.length == 1)
+        @activateLink(hintInformation, tabId, matched[0], delay)
+      else
+        @updateVisibleHints(hintInformation, keyResult)
+
+  deactivate: (hintInformation, tabId, delay) ->
+    @activateLink(hintInformation, tabId, -1, delay)
+
+  activateLink: (hintInformation, tabId, match, delay) ->
+    {frameIds, portsFromFrameIds, hintIndexInFrame} = hintInformation
+    matchedFrame = frameIds[match] or -1
+    for frameId, port of portsFromFrameIds
+      message = {
+        name: "linkActivate"
+        delay: delay
+      }
+      if frameId.toString() is matchedFrame.toString()
+        message.match = hintIndexInFrame[match]
+      port.postMessage(message)
+    @cleanup(hintInformation, tabId)
+
+
+  updateVisibleHints: (hintInformation, keyResult) ->
+    {portsFromFrameIds, hintVisibles, frameIds, hintKeystrokeQueue, hintIndexInFrame} = hintInformation
+    {delay, matched, updatedHintStrings} = keyResult
+
+    matchedInfoFromFrameId = {}
+
+    for hintVisible, i in hintVisibles
+      matchedInfo = matchedInfoFromFrameId[frameIds[i]] ?= {
+        currentIndex: -1
+        matched: []
+        updatedHintStrings: []
+        hintVisibles: []
+      }
+      hintVisibles[i] = false
+      matchedInfoFromFrameId[frameIds[i]].hintVisibles.push(false)
+    for match, i in matched
+      {
+        matched: frameMatched
+        updatedHintStrings: frameUpdatedHintStrings
+        hintVisibles: frameHintVisibles
+      } = matchedInfo = matchedInfoFromFrameId[frameIds[i]]
+      idx = hintIndexInFrame[match]
+
+      hintVisibles[match] = true
+      frameUpdatedHintStrings.push(updatedHintStrings[i])
+      frameMatched.push(idx)
+      frameHintVisibles[idx] = true
+
+    for frameId, port of portsFromFrameIds
+      matchedInfo = matchedInfoFromFrameId[frameId]
+      delete matchedInfo.currentIndex
+      port.postMessage({
+        name: "updateVisibleHints"
+        matchedInfo: matchedInfo
+        hintKeystrokeQueue: hintKeystrokeQueue
+      })
+
+  cleanup: (hintInformation, tabId) ->
+    for frameId, port of hintInformation.portsFromFrameIds
+      port.disconnect()
+    delete hintInformation.portsFromFrameIds
+
+    delete @hintInformationFromTabId[tabId]
+
+alphabetHints =
+  logXOfBase: (x, base) -> Math.log(x) / Math.log(base)
+
+  updateHintInformation: (hintInformation, newHintInformation, frameId) ->
+    hintInformation.count ?= 0
+    {hintVisibles, frameIds, hintIndexInFrame} = hintInformation
+    hintInformation.numberOfHintsFromFrameId[frameId] ?= 0
+
+    {count: newCount} = newHintInformation
+
+    hintInformation.count += newCount
+    for i in [1..newCount] by 1
+      hintVisibles.push(true)
+      frameIds.push(frameId)
+      hintIndexInFrame.push(hintInformation.numberOfHintsFromFrameId[frameId]++)
+
+    hintInformation
+
+  generateHintStrings: (hintInformation) ->
+    hintInformation.hintStrings = @hintStrings(hintInformation.count)
+
+  #
+  # Returns a list of hint strings which will uniquely identify the given number of links. The hint strings
+  # may be of different lengths.
+  #
+  hintStrings: (linkCount) ->
+    linkHintCharacters = Settings.get("linkHintCharacters")
+    # Determine how many digits the link hints will require in the worst case. Usually we do not need
+    # all of these digits for every link single hint, so we can show shorter hints for a few of the links.
+    digitsNeeded = Math.ceil(@logXOfBase(linkCount, linkHintCharacters.length))
+    # Short hints are the number of hints we can possibly show which are (digitsNeeded - 1) digits in length.
+    shortHintCount = Math.floor(
+      (Math.pow(linkHintCharacters.length, digitsNeeded) - linkCount) /
+      linkHintCharacters.length)
+    longHintCount = linkCount - shortHintCount
+
+    hintStrings = []
+
+    if (digitsNeeded > 1)
+      for i in [0...shortHintCount] by 1
+        hintStrings.push(numberToHintString(i, linkHintCharacters, digitsNeeded - 1))
+
+    start = shortHintCount * linkHintCharacters.length
+    for i in [start...(start + longHintCount)] by 1
+      hintStrings.push(numberToHintString(i, linkHintCharacters, digitsNeeded))
+
+    @shuffleHints(hintStrings, linkHintCharacters.length)
+
+  #
+  # This shuffles the given set of hints so that they're scattered -- hints starting with the same character
+  # will be spread evenly throughout the array.
+  #
+  shuffleHints: (hints, characterSetLength) ->
+    buckets = ([] for i in [0...characterSetLength] by 1)
+    for hint, i in hints
+      buckets[i % buckets.length].push(hint)
+    result = []
+    for bucket in buckets
+      result = result.concat(bucket)
+    result
+
+  matchHintsByKey: (hintInformation, event) ->
+    {hintKeystrokeQueue, hintStrings} = hintInformation
+
+    # If a shifted-character is typed, treat it as lowerase for the purposes of matching hints.
+    keyChar = KeyboardUtils.getKeyChar(event).toLowerCase()
+
+    if (event.keyCode == keyCodes.backspace || event.keyCode == keyCodes.deleteKey)
+      if (!hintKeystrokeQueue.pop())
+        return { matched: [], updatedHintStrings: []}
+    else if keyChar
+      hintKeystrokeQueue.push(keyChar)
+
+    matchString = hintKeystrokeQueue.join("")
+    matched = (i for i in [0..hintInformation.count-1] by 1 when hintStrings[i].indexOf(matchString) == 0)
+    updatedHintStrings = (hintStrings[i] for i in matched)
+    {
+      matched: matched
+      updatedHintStrings: updatedHintStrings
+    }
+
+
+filterHints =
+  updateHintInformation: (hintInformation, newHintInformation, frameId) ->
+    hintInformation.linkTextKeystrokeQueue ?= []
+    hintInformation.count ?= 0
+    hintInformation.numberOfHintsFromFrameId[frameId] ?= 0
+    {
+      hintVisibles
+      frameIds
+      hintIndexInFrame
+    } = hintInformation
+    hintTexts = hintInformation.hintTexts ?= []
+    linkTexts = hintInformation.linkTexts ?= []
+    showLinkTexts = hintInformation.showLinkTexts ?= []
+
+    {
+      linkTexts: newLinkTexts
+      showLinkTexts: newShowLinkTexts
+    } = newHintInformation
+
+    for newHintText, i in newLinkTexts
+      hintVisibles.push(true)
+      frameIds.push(frameId)
+      hintIndexInFrame.push(hintInformation.numberOfHintsFromFrameId[frameId]++)
+      linkTexts.push(newLinkTexts[i])
+      hintTexts.push(@generateHintText(hintTexts.length))
+      showLinkTexts.push(newShowLinkTexts[i])
+
+    hintInformation
+
+  generateHintText: (linkHintNumber) ->
+    (numberToHintString linkHintNumber + 1, Settings.get "linkHintNumbers").toUpperCase()
+
+  getHintString: (hintText, showLinkText, linkText) ->
+    hintText + (if showLinkText then ": " + linkText else "")
+
+  generateHintStrings: (hintInformation) ->
+    {hintTexts, linkTexts, showLinkTexts} = hintInformation
+    hintStrings = hintInformation.hintStrings = []
+
+    for hintText, i in hintTexts
+      linkText = linkTexts[i]
+      showLinkText = showLinkTexts[i]
+      hintStrings.push(@getHintString(hintText, showLinkText, linkText))
+
+    hintStrings
+
+  matchHintsByKey: (hintInformation, event) ->
+    {hintKeystrokeQueue, hintVisibles, hintStrings, linkTextKeystrokeQueue} = hintInformation
+
+    keyChar = KeyboardUtils.getKeyChar(event)
+    delay = 0
+    userIsTypingLinkText = false
+
+    if (event.keyCode == keyCodes.enter)
+      # activate the lowest-numbered link hint that is visible
+      for hintVisible, i in hintVisibles
+        if (hintVisible)
+          return {matched: [i], updatedHintStrings: [i]}
+    else if (event.keyCode == keyCodes.backspace || event.keyCode == keyCodes.deleteKey)
+      # backspace clears hint key queue first, then acts on link text key queue.
+      # if both queues are empty. exit hinting mode
+      if (!hintKeystrokeQueue.pop() && !linkTextKeystrokeQueue.pop())
+        return {matched: [], updatedHintStrings: []}
+    else if (keyChar)
+      if (Settings.get("linkHintNumbers").indexOf(keyChar) >= 0)
+        hintKeystrokeQueue.push(keyChar)
+      else
+        # since we might renumber the hints, the current hintKeystrokeQueue
+        # should be rendered invalid (i.e. reset).
+        hintKeystrokeQueue = hintInformation.hintKeystrokeQueue = []
+        linkTextKeystrokeQueue.push(keyChar)
+        userIsTypingLinkText = true
+
+    # at this point, linkTextKeystrokeQueue and hintKeystrokeQueue have been updated to reflect the latest
+    # input. use them to filter the link hints accordingly.
+    returnObject = @filterLinkHints(hintInformation)
+
+    if (returnObject.matched.length == 1 && userIsTypingLinkText)
+      # In filter mode, people tend to type out words past the point
+      # needed for a unique match. Hence we should avoid passing
+      # control back to command mode immediately after a match is found.
+      delay = 200
+
+    returnObject.delay = delay
+    returnObject
+
+  #
+  # Marks the links that do not match the linkText search string with the 'filtered' DOM property. Renumbers
+  # the remainder if necessary.
+  #
+  filterLinkHints: (hintInformation) ->
+    {hintKeystrokeQueue, hintStrings, linkTextKeystrokeQueue, linkTexts, showLinkTexts, hintTexts} =
+      hintInformation
+
+    matched = []
+    updatedHintStrings = []
+    linkSearchString = linkTextKeystrokeQueue.join("").toLowerCase()
+    hintSearchString = hintKeystrokeQueue.join("")
+    linkTextMatchCounter = 0
+
+    for linkText, i in linkTexts
+      continue if (linkText.toLowerCase().indexOf(linkSearchString) == -1)
+
+      newHintText = @generateHintText(linkTextMatchCounter)
+      hintTexts[i] = newHintText
+      linkTextMatchCounter++
+      if (newHintText.indexOf(hintSearchString) == 0)
+        matched.push(i)
+        updatedHintStrings.push(@getHintString(newHintText, showLinkTexts[i], linkTexts[i]))
+
+    { matched: matched, updatedHintStrings: updatedHintStrings }
+
+  deactivate: (hintInformation) ->
+
+#
+# Converts a number like "8" into a hint string like "JK". This is used to sequentially generate all of the
+# hint text. The hint string will be "padded with zeroes" to ensure its length is >= numHintDigits.
+#
+numberToHintString = (number, characterSet, numHintDigits = 0) ->
+  base = characterSet.length
+  hintString = []
+  remainder = 0
+  loop
+    remainder = number % base
+    hintString.unshift(characterSet[remainder])
+    number -= remainder
+    number /= Math.floor(base)
+    break unless number > 0
+
+  # Pad the hint string we're returning so that it matches numHintDigits.
+  # Note: the loop body changes hintString.length, so the original length must be cached!
+  hintStringLength = hintString.length
+  for i in [0...(numHintDigits - hintStringLength)] by 1
+    hintString.unshift(characterSet[0])
+
+  hintString.join("")
+
+root.LinkHintOracle = LinkHintOracle

--- a/background_scripts/link_hint_oracle.coffee
+++ b/background_scripts/link_hint_oracle.coffee
@@ -71,7 +71,12 @@ LinkHintOracle =
         @updateVisibleHints(hintInformation, keyResult)
 
   deactivate: (hintInformation, tabId, delay) ->
-    @activateLink(hintInformation, tabId, -1, delay)
+    for frameId, port of hintInformation.portsFromFrameIds
+      port.postMessage({
+        name: "deactivate"
+        delay: delay
+      })
+    @cleanup(hintInformation, tabId)
 
   activateLink: (hintInformation, tabId, match, delay) ->
     {frameIds, portsFromFrameIds, hintIndexInFrame} = hintInformation

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -533,6 +533,7 @@ checkKeyQueue = (keysToCheck, tabId, frameId) ->
         frameId: frameId,
         count: count,
         passCountToFunction: registryEntry.passCountToFunction,
+        allFrames: registryEntry.allFrames
         completionKeys: generateCompletionKeys(""))
       refreshedCompletionKeys = true
     else

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -607,6 +607,7 @@ portHandlers =
   keyDown: handleKeyDown,
   settings: handleSettings,
   filterCompleter: filterCompleter
+  linkHints: LinkHintOracle.manageLinkHints
 
 sendRequestHandlers =
   getCompletionKeys: getCompletionKeysRequest,

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -654,5 +654,9 @@ chrome.windows.getAll { populate: true }, (windows) ->
         (response) -> updateScrollPosition(tab, response.scrollX, response.scrollY) if response?
       chrome.tabs.sendMessage(tab.id, { name: "getScrollPosition" }, createScrollPositionHandler())
 
+# Reload a tab's settings cache every time the tab receives focus.
+chrome.tabs.onActivated.addListener((activeInfo) ->
+  chrome.tabs.sendMessage(activeInfo.tabId, "forceSettingsUpdate"))
+
 # Start pulling changes from synchronized storage.
 Sync.init()

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -34,6 +34,9 @@ LinkHints =
   port: null
   # Callback for deactivateMode. Set in setOpenLinkMode.
   deactivateModeCallback: null
+  # Show HUD if we are the top frame.
+  # TODO(mrmr1993): Fix this for pages with a top-level frameset.
+  showHUD: -> HUD.show.apply(HUD, arguments) if window.top == window
 
   #
   # To be called after linkHints has been generated from linkHintsBase.
@@ -104,12 +107,12 @@ LinkHints =
     @deactivateModeCallback = null
     if @mode is OPEN_IN_NEW_BG_TAB or @mode is OPEN_IN_NEW_FG_TAB or @mode is OPEN_WITH_QUEUE
       if @mode is OPEN_IN_NEW_BG_TAB
-        HUD.show("Open link in new tab")
+        @showHUD("Open link in new tab")
       else if @mode is OPEN_IN_NEW_FG_TAB
-        HUD.show("Open link in new tab and switch to it")
+        @showHUD("Open link in new tab and switch to it")
       else
         @deactivateModeCallback = (=> @activateModeWithQueue)
-        HUD.show("Open multiple links in a new tab")
+        @showHUD("Open multiple links in a new tab")
       @linkActivator = (link) ->
         # When "clicking" on a link, dispatch the event with the appropriate meta key (CMD on Mac, CTRL on
         # windows) to open it in a new tab if necessary.
@@ -118,18 +121,18 @@ LinkHints =
           metaKey: KeyboardUtils.platform == "Mac",
           ctrlKey: KeyboardUtils.platform != "Mac" })
     else if @mode is COPY_LINK_URL
-      HUD.show("Copy link URL to Clipboard")
+      @showHUD("Copy link URL to Clipboard")
       @linkActivator = (link) ->
         chrome.runtime.sendMessage({handler: "copyToClipboard", data: link.href})
     else if @mode is OPEN_INCOGNITO
-      HUD.show("Open link in incognito window")
+      @showHUD("Open link in incognito window")
 
       @linkActivator = (link) ->
         chrome.runtime.sendMessage(
           handler: 'openUrlInIncognito'
           url: link.href)
     else # OPEN_IN_CURRENT_TAB
-      HUD.show("Open link in current tab")
+      @showHUD("Open link in current tab")
       @linkActivator = (link) -> DomUtils.simulateClick.bind(DomUtils, link)()
 
   #

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -111,7 +111,7 @@ LinkHints =
       else if @mode is OPEN_IN_NEW_FG_TAB
         @showHUD("Open link in new tab and switch to it")
       else
-        @deactivateModeCallback = (=> @activateModeWithQueue)
+        @deactivateModeCallback = (=> @activateModeWithQueue())
         @showHUD("Open multiple links in a new tab")
       @linkActivator = (link) ->
         # When "clicking" on a link, dispatch the event with the appropriate meta key (CMD on Mac, CTRL on
@@ -204,6 +204,9 @@ LinkHints =
         @updateVisibleHints(response, port)
       when "linkActivate"
         @linkActivate(response, port)
+      when "deactivate"
+        @deactivateModeCallback = null
+        @deactivateMode(response.delay)
 
   setHintStrings: (response, port) ->
     @getMarkerMatcher().fillInMarkers(@hintMarkers, response.hintStrings)

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -18,6 +18,7 @@ OPEN_INCOGNITO = {}
 LinkHints =
   hintMarkerContainingDiv: null
   # one of the enums listed at the top of this file
+  hintMarkers: null
   mode: undefined
   # function that does the appropriate action on the selected link
   linkActivator: undefined
@@ -27,8 +28,12 @@ LinkHints =
   # loaded, so that we can retrieve the option setting.
   getMarkerMatcher: ->
     if settings.get("filterLinkHints") then filterHints else alphabetHints
-  # lock to ensure only one instance runs at a time
+  # Lock to ensure only one instance runs at a time.
   isActive: false
+  # Port to communicate with the link hint oracle in the background.
+  port: null
+  # Callback for deactivateMode. Set in setOpenLinkMode.
+  deactivateModeCallback: null
 
   #
   # To be called after linkHints has been generated from linkHintsBase.
@@ -62,35 +67,48 @@ LinkHints =
     @isActive = true
 
     @setOpenLinkMode(mode)
-    hintMarkers = (@createMarkerFor(el) for el in @getVisibleClickableElements())
+    @hintMarkers = (@createMarkerFor(el) for el in @getVisibleClickableElements())
 
-    hintInformation = @getMarkerMatcher().getInformation(hintMarkers)
-    hintInformation.hintKeystrokeQueue = []
-    hintInformation.hintVisibles = (true for marker in hintMarkers)
-    hintStrings = @getMarkerMatcher().generateHintStrings(hintInformation)
-    @getMarkerMatcher().fillInMarkers(hintMarkers, hintStrings)
+    @port = chrome.runtime.connect({ name: "linkHints" })
+    @port.onMessage.addListener((response, port) => @onPortResponse(response, port))
+
+    hintInformation = @getMarkerMatcher().getInformation(@hintMarkers)
+    @port.postMessage({
+      name: "registerLinkHints"
+      hintInformation: hintInformation
+      frameId: frameId
+    })
 
     # Note(philc): Append these markers as top level children instead of as child nodes to the link itself,
     # because some clickable elements cannot contain children, e.g. submit buttons. This has the caveat
     # that if you scroll the page and the link has position=fixed, the marker will not stay fixed.
-    @hintMarkerContainingDiv = DomUtils.addElementList(hintMarkers,
+    @hintMarkerContainingDiv = DomUtils.createContainerForElementList(@hintMarkers,
       { id: "vimiumHintMarkerContainer", className: "vimiumReset" })
 
-    # handlerStack is declared by vimiumFrontend.js
+    # handlerStack is declared by vimium_frontend.coffee
     @handlerId = handlerStack.push({
-      keydown: @onKeyDownInMode.bind(this, hintMarkers, hintInformation),
+      keydown: (event) =>
+        return if @delayMode
+        @port.postMessage({
+          name: "handleKeyDown"
+          event: DomUtils.jsonableEvent(event)
+          frameId: frameId
+        })
+        false
       # trap all key events
       keypress: -> false
       keyup: -> false
     })
 
   setOpenLinkMode: (@mode) ->
+    @deactivateModeCallback = null
     if @mode is OPEN_IN_NEW_BG_TAB or @mode is OPEN_IN_NEW_FG_TAB or @mode is OPEN_WITH_QUEUE
       if @mode is OPEN_IN_NEW_BG_TAB
         HUD.show("Open link in new tab")
       else if @mode is OPEN_IN_NEW_FG_TAB
         HUD.show("Open link in new tab and switch to it")
       else
+        @deactivateModeCallback = (=> @activateModeWithQueue)
         HUD.show("Open multiple links in a new tab")
       @linkActivator = (link) ->
         # When "clicking" on a link, dispatch the event with the appropriate meta key (CMD on Mac, CTRL on
@@ -170,76 +188,75 @@ LinkHints =
     visibleElements
 
   #
-  # Handles shift and esc keys. The other keys are passed to getMarkerMatcher().matchHintsByKey.
+  # Handles port responses from the link hint oracle.
   #
-  onKeyDownInMode: (hintMarkers, hintInformation, event) ->
-    return if @delayMode
+  onPortResponse: (response, port) ->
+    handler = null
+    switch response.name
+      when "setHintStrings"
+        @setHintStrings(response, port)
+      when "handleKeyDown"
+        @handleKeyDown(response, port)
+      when "updateVisibleHints"
+        @updateVisibleHints(response, port)
+      when "linkActivate"
+        @linkActivate(response, port)
 
-    if ((event.keyCode == keyCodes.shiftKey or event.keyCode == keyCodes.ctrlKey) and
-        (@mode == OPEN_IN_CURRENT_TAB or
-         @mode == OPEN_IN_NEW_BG_TAB or
-         @mode == OPEN_IN_NEW_FG_TAB))
+  setHintStrings: (response, port) ->
+    @getMarkerMatcher().fillInMarkers(@hintMarkers, response.hintStrings)
+    document.documentElement.appendChild(@hintMarkerContainingDiv)
+
+  #
+  # Handles ctrl and shift keys. The other keys are handled in the background page.
+  #
+  handleKeyDown: (response, port) ->
+    {event} = response
+    if (@mode == OPEN_IN_CURRENT_TAB or
+        @mode == OPEN_IN_NEW_BG_TAB or
+        @mode == OPEN_IN_NEW_FG_TAB)
       # Toggle whether to open link in a new or current tab.
-      prev_mode = @mode
-
       if event.keyCode == keyCodes.shiftKey
         @setOpenLinkMode(if @mode is OPEN_IN_CURRENT_TAB then OPEN_IN_NEW_BG_TAB else OPEN_IN_CURRENT_TAB)
 
       else # event.keyCode == keyCodes.ctrlKey
         @setOpenLinkMode(if @mode is OPEN_IN_NEW_FG_TAB then OPEN_IN_NEW_BG_TAB else OPEN_IN_NEW_FG_TAB)
 
-    # TODO(philc): Ignore keys that have modifiers.
-    if (KeyboardUtils.isEscape(event))
-      @deactivateMode()
-    else
-      keyResult = @getMarkerMatcher().matchHintsByKey(hintInformation, event)
-      {delay, matched, updatedHintStrings} = keyResult
-      delay ||= 0
-      if (matched.length == 0)
-        @deactivateMode()
-      else if (matched.length == 1 and matched.length > 0)
-        @activateLink(hintMarkers[matched[0]], delay)
+  updateVisibleHints: (response, port) ->
+    {hintKeystrokeQueue, matchedInfo: {matched, updatedHintStrings, hintVisibles}} = response
+    matchedMarkers = matched.map((index) => @hintMarkers[index])
+    @getMarkerMatcher().fillInMarkers(matchedMarkers, updatedHintStrings)
+    for marker, idx in @hintMarkers
+      if (hintVisibles[idx])
+        @showMarker(marker, hintKeystrokeQueue.length)
       else
-        for marker, idx in hintMarkers
-          @hideMarker(marker)
-          hintInformation.hintVisibles[idx] = false
-        matchedMarkers = matched.map((index) -> hintMarkers[index])
-        @getMarkerMatcher().fillInMarkers(matchedMarkers, updatedHintStrings)
-        for marker, idx in matchedMarkers
-          @showMarker(marker, hintInformation.hintKeystrokeQueue.length)
-          hintInformation.hintVisibles[matched[idx]] = true
-
-    false # We've handled this key, so prevent propagation.
+        @hideMarker(marker)
 
   #
   # When only one link hint remains, this function activates it in the appropriate way.
   #
-  activateLink: (matchedLink, delay) ->
+  linkActivate: (response, port) ->
+    {delay, match} = response
     @delayMode = true
-    clickEl = matchedLink.clickableItem
-    if (DomUtils.isSelectable(clickEl))
-      DomUtils.simulateSelect(clickEl)
-      @deactivateMode(delay, -> LinkHints.delayMode = false)
-    else
-      # TODO figure out which other input elements should not receive focus
-      if (clickEl.nodeName.toLowerCase() == "input" && clickEl.type != "button")
-        clickEl.focus()
-      DomUtils.flashRect(matchedLink.rect)
-      @linkActivator(clickEl)
-      if @mode is OPEN_WITH_QUEUE
-        @deactivateMode delay, ->
-          LinkHints.delayMode = false
-          LinkHints.activateModeWithQueue()
+    if match? # This is the frame with the match.
+      matchedLink = @hintMarkers[match]
+      clickEl = matchedLink.clickableItem
+      callback = (=> @delayMode = false)
+      if (DomUtils.isSelectable(clickEl))
+        DomUtils.simulateSelect(clickEl)
       else
-        @deactivateMode(delay, -> LinkHints.delayMode = false)
+        # TODO figure out which other input elements should not receive focus
+        if (clickEl.nodeName.toLowerCase() == "input" && clickEl.type != "button")
+          clickEl.focus()
+        DomUtils.flashRect(matchedLink.rect)
+        @linkActivator(clickEl)
+    @deactivateMode(delay, (=> @delayMode = false))
 
   #
   # Shows the marker, highlighting matchingCharCount characters.
   #
   showMarker: (linkMarker, matchingCharCount) ->
     linkMarker.style.display = ""
-    # TODO(philc):
-    for j in [0...linkMarker.childNodes.length]
+    for j in [0...linkMarker.childNodes.length] by 1
       if (j < matchingCharCount)
         linkMarker.childNodes[j].classList.add("matchingCharacter")
       else
@@ -253,37 +270,29 @@ LinkHints =
   #
   deactivateMode: (delay, callback) ->
     deactivate = =>
-      if (LinkHints.getMarkerMatcher().deactivate)
-        LinkHints.getMarkerMatcher().deactivate()
-      if (LinkHints.hintMarkerContainingDiv)
+      if (@getMarkerMatcher().deactivate)
+        @getMarkerMatcher().deactivate()
+      if (@hintMarkerContainingDiv? and @hintMarkerContainingDiv.parentNode?)
         DomUtils.removeElement LinkHints.hintMarkerContainingDiv
       LinkHints.hintMarkerContainingDiv = null
       handlerStack.remove @handlerId
       HUD.hide()
       @isActive = false
+      callback?()
+      @deactivateModeCallback?()
 
     # we invoke the deactivate() function directly instead of using setTimeout(callback, 0) so that
     # deactivateMode can be tested synchronously
     if (!delay)
       deactivate()
-      callback() if (callback)
     else
-      setTimeout(->
-        deactivate()
-        callback() if callback
-      delay)
+      setTimeout(deactivate, delay)
 
 alphabetHints =
-  hintKeystrokeQueue: []
-  logXOfBase: (x, base) -> Math.log(x) / Math.log(base)
-
   getInformation: (hintMarkers) ->
     {
       count: hintMarkers.length
     }
-
-  generateHintStrings: (hintInformation) ->
-    hintInformation.hintStrings = @hintStrings(hintInformation.count)
 
   fillInMarkers: (hintMarkers, hintStrings) ->
     for marker, idx in hintMarkers
@@ -292,71 +301,7 @@ alphabetHints =
 
     hintMarkers
 
-  #
-  # Returns a list of hint strings which will uniquely identify the given number of links. The hint strings
-  # may be of different lengths.
-  #
-  hintStrings: (linkCount) ->
-    linkHintCharacters = settings.get("linkHintCharacters")
-    # Determine how many digits the link hints will require in the worst case. Usually we do not need
-    # all of these digits for every link single hint, so we can show shorter hints for a few of the links.
-    digitsNeeded = Math.ceil(@logXOfBase(linkCount, linkHintCharacters.length))
-    # Short hints are the number of hints we can possibly show which are (digitsNeeded - 1) digits in length.
-    shortHintCount = Math.floor(
-      (Math.pow(linkHintCharacters.length, digitsNeeded) - linkCount) /
-      linkHintCharacters.length)
-    longHintCount = linkCount - shortHintCount
-
-    hintStrings = []
-
-    if (digitsNeeded > 1)
-      for i in [0...shortHintCount]
-        hintStrings.push(numberToHintString(i, linkHintCharacters, digitsNeeded - 1))
-
-    start = shortHintCount * linkHintCharacters.length
-    for i in [start...(start + longHintCount)]
-      hintStrings.push(numberToHintString(i, linkHintCharacters, digitsNeeded))
-
-    @shuffleHints(hintStrings, linkHintCharacters.length)
-
-  #
-  # This shuffles the given set of hints so that they're scattered -- hints starting with the same character
-  # will be spread evenly throughout the array.
-  #
-  shuffleHints: (hints, characterSetLength) ->
-    buckets = ([] for i in [0...characterSetLength] by 1)
-    for hint, i in hints
-      buckets[i % buckets.length].push(hint)
-    result = []
-    for bucket in buckets
-      result = result.concat(bucket)
-    result
-
-  matchHintsByKey: (hintInformation, event) ->
-    {hintKeystrokeQueue, hintStrings} = hintInformation
-
-    # If a shifted-character is typed, treat it as lowerase for the purposes of matching hints.
-    keyChar = KeyboardUtils.getKeyChar(event).toLowerCase()
-
-    if (event.keyCode == keyCodes.backspace || event.keyCode == keyCodes.deleteKey)
-      if (!hintKeystrokeQueue.pop())
-        return { matched: [], updatedHintStrings: []}
-    else if keyChar
-      hintKeystrokeQueue.push(keyChar)
-
-    matchString = hintKeystrokeQueue.join("")
-    matched = (i for i in [0..hintInformation.count-1] by 1 when hintStrings[i].indexOf(matchString) == 0)
-    updatedHintStrings = (hintStrings[i] for i in matched)
-    {
-      matched: matched
-      updatedHintStrings: updatedHintStrings
-    }
-
-  deactivate: -> @hintKeystrokeQueue = []
-
 filterHints =
-  hintKeystrokeQueue: []
-  linkTextKeystrokeQueue: []
   labelMap: {}
 
   #
@@ -372,9 +317,6 @@ filterHints =
         if (labelText[labelText.length-1] == ":")
           labelText = labelText.substr(0, labelText.length-1)
         @labelMap[forElement] = labelText
-
-  generateHintText: (linkHintNumber) ->
-    (numberToHintString linkHintNumber + 1, settings.get "linkHintNumbers").toUpperCase()
 
   generateLinkText: (element) ->
     linkText = ""
@@ -401,46 +343,21 @@ filterHints =
 
     { text: linkText, show: showLinkText }
 
-  renderMarker: (marker) ->
-    marker.innerHTML = spanWrap(marker.hintString +
-        (if marker.showLinkText then ": " + marker.linkText else ""))
-
-
-
-  getHintString: (hintText, showLinkText, linkText) ->
-    hintText + (if showLinkText then ": " + linkText else "")
-
   getInformation: (hintMarkers) ->
     @generateLabelMap()
 
-    hintTexts = []
     linkTexts = []
     showLinkTexts = []
-    linkTextKeystrokeQueue = []
 
     for marker, idx in hintMarkers
       linkTextObject = @generateLinkText(marker.clickableItem)
-      hintTexts.push(@generateHintText(idx))
       linkTexts.push(linkTextObject.text)
       showLinkTexts.push(linkTextObject.show)
 
     {
-      hintTexts: hintTexts
       linkTexts: linkTexts
       showLinkTexts: showLinkTexts
-      linkTextKeystrokeQueue: linkTextKeystrokeQueue
     }
-
-  generateHintStrings: (hintInformation) ->
-    {hintTexts, linkTexts, showLinkTexts} = hintInformation
-    hintStrings = hintInformation.hintStrings = []
-
-    for hintText, idx in hintTexts
-      linkText = linkTexts[idx]
-      showLinkText = showLinkTexts[idx]
-      hintStrings.push(@getHintString(hintText, showLinkText, linkText))
-
-    hintStrings
 
   fillInMarkers: (hintMarkers, hintStrings) ->
     for marker, idx in hintMarkers
@@ -449,77 +366,7 @@ filterHints =
 
     hintMarkers
 
-
-
-  matchHintsByKey: (hintInformation, event) ->
-    {hintKeystrokeQueue, hintVisibles, hintStrings, linkTextKeystrokeQueue} = hintInformation
-
-    keyChar = KeyboardUtils.getKeyChar(event)
-    delay = 0
-    userIsTypingLinkText = false
-
-    if (event.keyCode == keyCodes.enter)
-      # activate the lowest-numbered link hint that is visible
-      for hintVisible, idx in hintVisibles
-        if (hintVisible)
-          return { matched: [ idx ], updatedHintStrings: [ hintStrings[idx] ] }
-    else if (event.keyCode == keyCodes.backspace || event.keyCode == keyCodes.deleteKey)
-      # backspace clears hint key queue first, then acts on link text key queue.
-      # if both queues are empty. exit hinting mode
-      if (!hintKeystrokeQueue.pop() && !linkTextKeystrokeQueue.pop())
-        return { matched: [], updatedHintStrings: [] }
-    else if (keyChar)
-      if (settings.get("linkHintNumbers").indexOf(keyChar) >= 0)
-        hintKeystrokeQueue.push(keyChar)
-      else
-        # since we might renumber the hints, the current hintKeystrokeQueue
-        # should be rendered invalid (i.e. reset).
-        hintKeystrokeQueue = hintInformation.hintKeystrokeQueue = []
-        linkTextKeystrokeQueue.push(keyChar)
-        userIsTypingLinkText = true
-
-    # at this point, linkTextKeystrokeQueue and hintKeystrokeQueue have been updated to reflect the latest
-    # input. use them to filter the link hints accordingly.
-    returnObject = @filterLinkHints(hintInformation)
-
-    if (returnObject.matched.length == 1 && userIsTypingLinkText)
-      # In filter mode, people tend to type out words past the point
-      # needed for a unique match. Hence we should avoid passing
-      # control back to command mode immediately after a match is found.
-      delay = 200
-
-    returnObject.delay = delay
-    returnObject
-
-  #
-  # Marks the links that do not match the linkText search string with the 'filtered' DOM property. Renumbers
-  # the remainder if necessary.
-  #
-  filterLinkHints: (hintInformation) ->
-    {hintKeystrokeQueue, hintStrings, linkTextKeystrokeQueue, linkTexts, showLinkTexts, hintTexts} =
-      hintInformation
-
-    matched = []
-    updatedHintStrings = []
-    linkSearchString = linkTextKeystrokeQueue.join("").toLowerCase()
-    hintSearchString = hintKeystrokeQueue.join("")
-    linkTextMatchCounter = 0
-
-    for linkText, idx in linkTexts
-      continue if (linkText.toLowerCase().indexOf(linkSearchString) == -1)
-
-      newHintText = @generateHintText(linkTextMatchCounter)
-      hintTexts[idx] = newHintText
-      linkTextMatchCounter++
-      if (newHintText.indexOf(hintSearchString) == 0)
-        matched.push(idx)
-        updatedHintStrings.push(@getHintString(newHintText, showLinkTexts[idx], linkTexts[idx]))
-
-    { matched: matched, updatedHintStrings: updatedHintStrings }
-
   deactivate: (delay, callback) ->
-    @hintKeystrokeQueue = []
-    @linkTextKeystrokeQueue = []
     @labelMap = {}
 
 #
@@ -530,30 +377,6 @@ spanWrap = (hintString) ->
   for char in hintString
     innerHTML.push("<span class='vimiumReset'>" + char + "</span>")
   innerHTML.join("")
-
-#
-# Converts a number like "8" into a hint string like "JK". This is used to sequentially generate all of the
-# hint text. The hint string will be "padded with zeroes" to ensure its length is >= numHintDigits.
-#
-numberToHintString = (number, characterSet, numHintDigits = 0) ->
-  base = characterSet.length
-  hintString = []
-  remainder = 0
-  loop
-    remainder = number % base
-    hintString.unshift(characterSet[remainder])
-    number -= remainder
-    number /= Math.floor(base)
-    break unless number > 0
-
-  # Pad the hint string we're returning so that it matches numHintDigits.
-  # Note: the loop body changes hintString.length, so the original length must be cached!
-  hintStringLength = hintString.length
-  for i in [0...(numHintDigits - hintStringLength)] by 1
-    hintString.unshift(characterSet[0])
-
-  hintString.join("")
-
 
 root = exports ? window
 root.LinkHints = LinkHints

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -120,6 +120,7 @@ initializePreDomReady = ->
     getScrollPosition: -> scrollX: window.scrollX, scrollY: window.scrollY
     setScrollPosition: (request) -> setScrollPosition request.scrollX, request.scrollY
     executePageCommand: executePageCommand
+    forceSettingsUpdate: -> settings.load()
     getActiveState: -> { enabled: isEnabledForUrl, passKeys: passKeys }
     setState: setState
     currentKeyQueue: (request) -> keyQueue = request.keyQueue

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -203,7 +203,7 @@ enterInsertModeIfElementIsFocused = ->
 onDOMActivate = (event) -> handlerStack.bubbleEvent 'DOMActivate', event
 
 executePageCommand = (request) ->
-  return unless frameId == request.frameId
+  return unless frameId == request.frameId or request.allFrames
 
   if (request.passCountToFunction)
     Utils.invokeCommandString(request.command, [request.count])

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -127,7 +127,7 @@ initializePreDomReady = ->
   chrome.runtime.onMessage.addListener (request, sender, sendResponse) ->
     # In the options page, we will receive requests from both content and background scripts. ignore those
     # from the former.
-    return if sender.tab and not sender.tab.url.startsWith 'chrome-extension://'
+    return if sender.tab and sender.tab.url.startsWith 'chrome-extension://'
     return unless isEnabledForUrl or request.name == 'getActiveState' or request.name == 'setState'
     # These requests are delivered to the options page, but there are no handlers there.
     return if request.handler == "registerFrame" or request.handler == "frameFocused"

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -310,8 +310,9 @@ extend window,
 
     hints[selectedInputIndex].classList.add 'internalVimiumSelectedInputHint'
 
-    hintContainingDiv = DomUtils.addElementList(hints,
+    hintContainingDiv = DomUtils.createContainerForElementList(hints,
       { id: "vimiumInputMarkerContainer", className: "vimiumReset" })
+    document.documentElement.appendChild(hintContainingDiv)
 
     handlerStack.push keydown: (event) ->
       if event.keyCode == KeyboardUtils.keyCodes.tab

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -8,16 +8,15 @@ DomUtils =
     (callback) -> if loaded then callback() else window.addEventListener("DOMContentLoaded", callback)
 
   #
-  # Adds a list of elements to a page.
+  # Adds a list of elements to a div and returns the div.
   # Note that adding these nodes all at once (via the parent div) is significantly faster than one-by-one.
   #
-  addElementList: (els, overlayOptions) ->
+  createContainerForElementList: (els, overlayOptions) ->
     parent = document.createElement("div")
     parent.id = overlayOptions.id if overlayOptions.id?
     parent.className = overlayOptions.className if overlayOptions.className?
     parent.appendChild(el) for el in els
 
-    document.documentElement.appendChild(parent)
     parent
 
   #
@@ -126,6 +125,14 @@ DomUtils =
     flashEl.style.height = rect.height + "px"
     document.documentElement.appendChild(flashEl)
     setTimeout((-> DomUtils.removeElement flashEl), 400)
+
+  jsonableEvent: (event) ->
+    keysToCopy = ["altKey", "charCode", "ctrlKey", "keyCode", "keyIdentifier", "metaKey", "shiftKey", "type", "which"]
+    jsonEvent = {}
+    for key in keysToCopy
+      jsonEvent[key] = event[key]
+    jsonEvent
+
 
   suppressEvent: (event) ->
     event.preventDefault()

--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,7 @@
   "background": {
     "scripts": [
       "lib/utils.js",
+      "lib/keyboard_utils.js",
       "background_scripts/commands.js",
       "lib/clipboard.js",
       "background_scripts/sync.js",
@@ -16,6 +17,7 @@
       "background_scripts/exclusions.js",
       "background_scripts/completion.js",
       "background_scripts/marks.js",
+      "background_scripts/link_hint_oracle.js",
       "background_scripts/main.js"
     ]
   },

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -133,6 +133,7 @@ enableSaveButton = ->
 
 saveOptions = ->
   Option.all.map (option) -> option.save()
+  settings.load() # Update settings for this tab
   $("saveOptions").disabled = true
 
 restoreToDefaults = ->

--- a/tests/unit_tests/exclusion_test.coffee
+++ b/tests/unit_tests/exclusion_test.coffee
@@ -7,7 +7,7 @@ require "./test_chrome_stubs.js"
 # extend(global, require "../../background_scripts/marks.js")
 # But it looks like marks.coffee has never been included in a test before!
 # Temporary fix...
-root.Marks = 
+root.Marks =
   create: () -> true
   goto:
     bind: () -> true
@@ -19,6 +19,7 @@ extend(global,require "../../background_scripts/settings.js")
 Sync.init()
 extend(global, require "../../background_scripts/exclusions.js")
 extend(global, require "../../background_scripts/commands.js")
+extend(global, require "../../background_scripts/link_hint_oracle.js")
 extend(global, require "../../background_scripts/main.js")
 
 # These tests cover only the most basic aspects of excluded URLs and passKeys.

--- a/tests/unit_tests/test_chrome_stubs.coffee
+++ b/tests/unit_tests/test_chrome_stubs.coffee
@@ -30,6 +30,8 @@ global.chrome =
       addListener: () -> true
     onActiveChanged:
       addListener: () -> true
+    onActivated:
+      addListener: () -> true
     query: () -> true
 
   windows:


### PR DESCRIPTION
This PR enables link hints in all frames of a page simultaneously, managed by a "link hint oracle" in the background page. It fixes #602.

8/32 DOM tests now fail, haven't looked into fixing them yet.

Some examples to test it out on:
* [This frameset demo](http://www.quackit.com/html/templates/frames/frames_example_2.html).
* [/r/videos](http://www.reddit.com/r/videos), clicking on any of the 
![screenshot from 2014-10-24 06 42 16](https://cloud.githubusercontent.com/assets/1847343/4765582/9fec5f10-5b40-11e4-964b-c96175bdca01.png)
buttons to open an iframe, and then using link hints seamlessly between the page and the iframes.
* The w3schools ["iframe try-it-out"](http://www.w3schools.com/tags/tryit.asp?filename=tryhtml_iframe) (you'll probably want to `gf` to the iframe and scroll it down a bit so the links are visible first).