### PR TITLE
Prevent Chrome URLs from being injected with CSS

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -387,10 +387,13 @@ updateScrollPosition = (tab, scrollX, scrollY) ->
 
 chrome.tabs.onUpdated.addListener (tabId, changeInfo, tab) ->
   return unless changeInfo.status == "loading" # only do this once per URL change
-  chrome.tabs.insertCSS tabId,
-    allFrames: true
-    code: Settings.get("userDefinedLinkHintCss")
-    runAt: "document_start"
+  chrome.tabs.get tabId, (tab) ->
+    # Check if tabId can be injected with CSS without errors
+    if !/^chrome(-extension)?:\/\/|https:\/\/chrome\.google\.com\/webstore\//.test(tab.url)
+      chrome.tabs.insertCSS tabId,
+        allFrames: true
+        code: Settings.get("userDefinedLinkHintCss")
+        runAt: "document_start"
   updateOpenTabs(tab)
   updateActiveState(tabId)
 


### PR DESCRIPTION
`chrome://*` and `chrome-extension://*` URLs in addition to URLs on the Chrome Webstore cannot be injected with CSS via the `chrome.tabs.insertCSS` function due to Chrome's security policies. When tabs with these URLs are opened, Vimium's background scripts throw exceptions. This PR checks if a tab's URL matches these locations and avoids the function call if necessary.
