### PR TITLE
fix for issue #1176

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -410,7 +410,6 @@ onKeydown = (event) ->
       if (isEditable(event.srcElement))
         event.srcElement.blur()
       exitInsertMode()
-      DomUtils.suppressEvent event
       handledKeydownEvents.push event
 
   else if (findMode)


### PR DESCRIPTION
This resolves the issues with Facebook messenger not closing when the escape key is hit. I just removed the DOM suppression call when escape is hit, which shouldn't be called in this case (or at least in any ways I can think of).
