### PR TITLE
Check chrome.runtime.lastError to fix error in insertCSS

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -391,6 +391,7 @@ chrome.tabs.onUpdated.addListener (tabId, changeInfo, tab) ->
     allFrames: true
     code: Settings.get("userDefinedLinkHintCss")
     runAt: "document_start"
+  , -> undefined if chrome.runtime.lastError
   updateOpenTabs(tab)
   updateActiveState(tabId)
 


### PR DESCRIPTION
This is proposed as an alternative to #1184, preventing errors in the background page on `chrome://`, `chrome-extension://`, `about:`, `data:`, etc.
