### PR TITLE
Command tests - validate advanced commands

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -117,6 +117,7 @@ Commands =
       "LinkHints.activateModeToOpenInNewForegroundTab",
       "LinkHints.activateModeWithQueue",
       "LinkHints.activateModeToDownloadLink",
+      "LinkHints.activateModeToOpenIncognito",
       "Vomnibar.activate",
       "Vomnibar.activateInNewTab",
       "Vomnibar.activateTabSelection",

--- a/tests/unit_tests/commands_test.coffee
+++ b/tests/unit_tests/commands_test.coffee
@@ -15,14 +15,16 @@ context "Key mappings",
 
 context "Validate commands and options",
   should "have either noRepeat or repeatLimit, but not both", ->
+    # TODO(smblott) For this and each following test, is there a way to structure the tests such that the name
+    # of the offending command appears in the output, if the test fails?
     for command, options of Commands.availableCommands
       assert.isTrue not (options.noRepeat and options.repeatLimit)
 
-  should "have a description for each command", ->
+  should "describe each command", ->
     for command, options of Commands.availableCommands
       assert.equal 'string', typeof options.description
 
-  should "have valid commands for each command in each command group", ->
+  should "define each command in each command group", ->
     for group, commands of Commands.commandGroups
       for command in commands
         assert.equal 'string', typeof command
@@ -33,14 +35,17 @@ context "Validate commands and options",
       assert.equal 'string', typeof command
       assert.isTrue Commands.availableCommands[command]
 
-  should "have each advanced command listed in a command group", ->
-    allCommands = [].concat.apply [], (commands for group, commands of Commands.commandGroups)
-    for command in Commands.advancedCommands
-      assert.isTrue 0 <= allCommands.indexOf command
-
   should "have valid commands for each default key mapping", ->
     count = Object.keys(Commands.keyToCommandRegistry).length
     assert.isTrue (0 < count)
     for key, command of Commands.keyToCommandRegistry
       assert.equal 'object', typeof command
       assert.isTrue Commands.availableCommands[command.command]
+
+context "Validate advanced commands",
+  setup ->
+    @allCommands = [].concat.apply [], (commands for group, commands of Commands.commandGroups)
+
+  should "include each advanced command in a command group", ->
+    for command in Commands.advancedCommands
+      assert.isTrue 0 <= @allCommands.indexOf command


### PR DESCRIPTION
It turns out that `LinkHints.activateModeToOpenIncognito` wasn't in a command group.

Let me know if that was intentional.
