### PR TITLE
Allow blur of embedded objects (e.g. flash) and add an option to enable/disable it

### DIFF
--- a/background_scripts/settings.coffee
+++ b/background_scripts/settings.coffee
@@ -67,6 +67,7 @@ root.Settings = Settings =
     linkHintNumbers: "0123456789"
     filterLinkHints: false
     hideHud: false
+    enableBlurEmbeds: false
     userDefinedLinkHintCss:
       """
       div > .vimiumHintMarker {

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -49,7 +49,7 @@ settings =
   loadedValues: 0
   valuesToLoad: ["scrollStepSize", "linkHintCharacters", "linkHintNumbers", "filterLinkHints", "hideHud",
     "previousPatterns", "nextPatterns", "findModeRawQuery", "regexFindMode", "userDefinedLinkHintCss",
-    "helpDialog_showAdvancedCommands", "smoothScroll"]
+    "helpDialog_showAdvancedCommands", "smoothScroll", "enableBlurEmbeds"]
   isLoaded: false
   eventListeners: {}
 
@@ -436,6 +436,8 @@ onKeydown = (event) ->
         keyChar = "<" + keyChar + ">"
 
   if (isInsertMode() && KeyboardUtils.isEscape(event))
+    # Blurring out of embeds could be dangerous, do nothing unless the user explicitly enables it.
+    return if isEmbed(event.srcElement) and not settings.get "enableBlurEmbeds"
     if isEditable(event.srcElement) or isEmbed(event.srcElement)
       # Remove focus so the user can't just get himself back into insert mode by typing in the same input
       # box.

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -175,6 +175,7 @@ document.addEventListener "DOMContentLoaded", ->
     newTabUrl: NonEmptyTextOption
     nextPatterns: NonEmptyTextOption
     previousPatterns: NonEmptyTextOption
+    enableBlurEmbeds: CheckBoxOption
     regexFindMode: CheckBoxOption
     scrollStepSize: NumberOption
     smoothScroll: CheckBoxOption

--- a/pages/options.html
+++ b/pages/options.html
@@ -391,6 +391,20 @@ unmapAll
             <td verticalAlign="top" class="booleanOption">
               <div class="help">
                 <div class="example">
+                  This is an experimental option, and could break embeds that expect to handle the escape key.
+                </div>
+              </div>
+              <label>
+                <input id="enableBlurEmbeds" type="checkbox"/>
+                Enable blurring embed elements to exit insert mode.
+              </label>
+            </td>
+          </tr>
+          <tr>
+            <td class="caption"></td>
+            <td verticalAlign="top" class="booleanOption">
+              <div class="help">
+                <div class="example">
                   Switch back to plain find mode by using the <code>\R</code> escape sequence.
                 </div>
               </div>


### PR DESCRIPTION
This is an extension of #1194, which adds the feature but toggles it with an option in the options page, and defaults it to off.

@smblott-github does this deal with your concerns?
