### PR TITLE
Hint markers with flat styling

### DIFF
--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -67,23 +67,24 @@ div.internalVimiumHintMarker {
   white-space: nowrap;
   overflow: hidden;
   font-size: 11px;
-  padding: 1px 3px 0px 3px;
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#FFF785), color-stop(100%,#FFC542));
-  border: solid 1px #C38A22;
-  border-radius: 3px;
-  box-shadow: 0px 3px 7px 0px rgba(0, 0, 0, 0.3);
+  padding: 2px 3px;
+  background-color: #feda31;
+  border: 0;
+  border-radius: 2px;
+  box-shadow: inset 0 -2px 0 #b39922;
+  background-image: none;
 }
 
 div.internalVimiumHintMarker span {
-  color: #302505;
-  font-family: Helvetica, Arial, sans-serif;
-  font-weight: bold;
   font-size: 11px;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6);
+  font-weight: bold;
+  text-shadow: none;
+  color: #4a400e;
+  font-family: Helvetica, Arial, sans-serif;
 }
 
 div.internalVimiumHintMarker > .matchingCharacter {
-  color: #D4AC3A;
+  color: #dcbc2a;
 }
 
 /* Input hints CSS */


### PR DESCRIPTION
I :heart: that users have the ability to customize the hint markers in Vimium and I have been using this look which I'm really liking.

![](https://camo.githubusercontent.com/6e164c42becc71f33d22eee30cc972f6c3b95f6e/687474703a2f2f636c2e6c792f696d6167652f3144336732513041313733492f636f6e74656e74/content)

@philc Would you be interested in using something like this as the default style? No worries if not – I can keep rocking my custom version.
