### PR TITLE
Force our key event handlers to have the highest possible priority

### DIFF
--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -139,7 +139,7 @@ class VomnibarUI
           @hide()
 
     # It seems like we have to manually suppress the event here and still return true.
-    event.stopPropagation()
+    event.stopImmediatePropagation()
     event.preventDefault()
     true
 

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -129,7 +129,7 @@ DomUtils =
 
   suppressEvent: (event) ->
     event.preventDefault()
-    event.stopPropagation()
+    event.stopImmediatePropagation()
 
 root = exports ? window
 root.DomUtils = DomUtils

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -8,7 +8,7 @@ mockKeyboardEvent = (keyChar) ->
   event.charCode = (if keyCodes[keyChar] isnt undefined then keyCodes[keyChar] else keyChar.charCodeAt(0))
   event.keyIdentifier = "U+00" + event.charCode.toString(16)
   event.keyCode = event.charCode
-  event.stopPropagation = ->
+  event.stopImmediatePropagation = ->
   event.preventDefault = ->
   event
 

--- a/tests/dom_tests/vomnibar_test.coffee
+++ b/tests/dom_tests/vomnibar_test.coffee
@@ -52,7 +52,7 @@ context "Keep selection within bounds",
 
     eventMock =
       preventDefault: ->
-      stopPropagation: ->
+      stopImmediatePropagation: ->
 
     @completions = [{html:'foo',type:'tab',url:'http://example.com'}]
     ui.update(true)


### PR DESCRIPTION
- The `window` object receives key events before the `document` object,
  and so any event listeners on `window` get priority. This commit
  switches from binding `keydown`, `keypress`, `keyup` on `document` to
  on `window`.
- We were using `event.stopPropagation()` to prevent other event
  listeners from firing if we had handled an event. This stopped the event
  from propagating to other elements/objects and triggering their event
  listeners, but didn't block event listeners registered on the same
  object as ours. Switching to `event.stopImmediatePropagation()` ensures
  that our event listener is the last to run for the event.

Fixing these issues allows Vimium to regain control over key events in Google Groups (eg. the [vimium-dev group](https://groups.google.com/forum/vimium-dev)).

This fixes #1218.
