### PR TITLE
Add Google Inbox to default exclusion rules

### DIFF
--- a/background_scripts/settings.coffee
+++ b/background_scripts/settings.coffee
@@ -89,7 +89,9 @@ root.Settings = Settings =
     exclusionRules:
       [
         # Disable Vimium on Gmail.
-        { pattern: "http*://mail.google.com/*", passKeys: "" }
+        { pattern: "http*://mail.google.com/*", passKeys: "" },
+        # Disable Vimium on Google Inbox.
+        { pattern: "http*://inbox.google.com/*", passKeys: "" }
       ]
 
     # NOTE: If a page contains both a single angle-bracket link and a double angle-bracket link, then in


### PR DESCRIPTION
This change adds Google inbox to the exclusion rules in background_scripts/settings.coffee.  No other code was modified or added other than lines 92-94 in settings.coffee.  Previous style was maintained regarding spacing and comment formatting.

The decision to add Google Inbox to the exclusion rules stems from the pre-existing keyboard shortcuts used in Google Inbox, similar to those available in Gmail.
