### PR TITLE
Substantial reworking of favicons (Mark II).

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -24,10 +24,12 @@ class Suggestion
 
   computeRelevancy: -> @relevancy = @computeRelevancyFunction(this)
 
+  @faviconId: 0 # Static.
   generateHtml: ->
     return @html if @html
-    favIconUrl = @tabFavIconUrl or "#{@getUrlRoot(@url)}/favicon.ico"
     relevancyHtml = if @showRelevancy then "<span class='relevancy'>#{@computeRelevancy()}</span>" else ""
+    Suggestion.faviconId += 1
+    @faviconId = "vimium-favicon-id-#{Suggestion.faviconId}"
     # NOTE(philc): We're using these vimium-specific class names so we don't collide with the page's CSS.
     @html =
       """
@@ -35,11 +37,11 @@ class Suggestion
          <span class="vimiumReset vomnibarSource">#{@type}</span>
          <span class="vimiumReset vomnibarTitle">#{@highlightTerms(Utils.escapeHtml(@title))}</span>
        </div>
-       <div class="vimiumReset vomnibarBottomHalf vomnibarIcon"
-            style="background-image: url(#{favIconUrl});">
-        <span class="vimiumReset vomnibarUrl">#{@shortenUrl(@highlightTerms(Utils.escapeHtml(@url)))}</span>
-        #{relevancyHtml}
-      </div>
+       <div class="vimiumReset vomnibarBottomHalf">
+         <img class="vimiumReset vomnibarIcon" id="#{@faviconId}" src=""/><nobr>
+         <span class="vimiumReset vomnibarUrl">#{@shortenUrl(@highlightTerms(Utils.escapeHtml(@url)))}</span>
+         #{relevancyHtml}
+       </div>
       """
 
   # Use neat trick to snatch a domain (http://stackoverflow.com/a/8498668).
@@ -294,7 +296,6 @@ class TabCompleter
       suggestions = results.map (tab) =>
         suggestion = new Suggestion(queryTerms, "tab", tab.url, tab.title, @computeRelevancy)
         suggestion.tabId = tab.id
-        suggestion.tabFavIconUrl = tab.favIconUrl
         suggestion
       onComplete(suggestions)
 

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -353,10 +353,8 @@ body.vimiumFindMode ::selection {
 }
 
 #vomnibar li .vomnibarIcon {
-  background-position-y: center;
-  background-size: 16px;
-  background-repeat: no-repeat;
-  padding-left: 20px;
+  height: 16px;
+  width: 16px;
 }
 
 #vomnibar li .vomnibarSource {

--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -151,11 +151,27 @@ class VomnibarUI
       @populateUiWithCompletions(completions)
       callback() if callback
 
+  fetchFavicons: do ->
+    googleCacheMissFavicon = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAsSAAALEgHS3X78AAACiElEQVQ4EaVTzU8TURCf2tJuS7tQtlRb6UKBIkQwkRRSEzkQgyEc6lkOKgcOph78Y+CgjXjDs2i44FXY9AMTlQRUELZapVlouy3d7kKtb0Zr0MSLTvL2zb75eL838xtTvV6H/xELBptMJojeXLCXyobnyog4YhzXYvmCFi6qVSfaeRdXdrfaU1areV5KykmX06rcvzumjY/1ggkR3Jh+bNf1mr8v1D5bLuvR3qDgFbvbBJYIrE1mCIoCrKxsHuzK+Rzvsi29+6DEbTZz9unijEYI8ObBgXOzlcrx9OAlXyDYKUCzwwrDQx1wVDGg089Dt+gR3mxmhcUnaWeoxwMbm/vzDFzmDEKMMNhquRqduT1KwXiGt0vre6iSeAUHNDE0d26NBtAXY9BACQyjFusKuL2Ry+IPb/Y9ZglwuVscdHaknUChqLF/O4jn3V5dP4mhgRJgwSYm+gV0Oi3XrvYB30yvhGa7BS70eGFHPoTJyQHhMK+F0ZesRVVznvXw5Ixv7/C10moEo6OZXbWvlFAF9FVZDOqEABUMRIkMd8GnLwVWg9/RkJF9sA4oDfYQAuzzjqzwvnaRUFxn/X2ZlmGLXAE7AL52B4xHgqAUqrC1nSNuoJkQtLkdqReszz/9aRvq90NOKdOS1nch8TpL555WDp49f3uAMXhACRjD5j4ykuCtf5PP7Fm1b0DIsl/VHGezzP1KwOiZQobFF9YyjSRYQETRENSlVzI8iK9mWlzckpSSCQHVALmN9Az1euDho9Xo8vKGd2rqooA8yBcrwHgCqYR0kMkWci08t/R+W4ljDCanWTg9TJGwGNaNk3vYZ7VUdeKsYJGFNkfSzjXNrSX20s4/h6kB81/271ghG17l+rPTAAAAAElFTkSuQmCC"
+    cache = new SimpleCache(0)
+    (completions) ->
+      for completion in completions
+        do (completion) =>
+          url = completion.url
+          favicon = document.getElementById completion.faviconId
+          if cachedFavicon = cache.get url
+            favicon.src = cachedFavicon
+          else
+            favicon.src = googleCacheMissFavicon
+            chrome.runtime.sendMessage {handler: "fetchFavicon", url: url}, (response) ->
+              favicon.src = cache.set(url,response.data) if response.data
+
   populateUiWithCompletions: (completions) ->
     # update completion list with the new data
     @completionList.innerHTML = completions.map((completion) -> "<li>#{completion.html}</li>").join("")
     @completionList.style.display = if completions.length > 0 then "block" else "none"
     @selection = Math.min(Math.max(@initialSelectionValue, @selection), @completions.length - 1)
+    @fetchFavicons(completions)
     @updateSelection()
 
   update: (updateSynchronously, callback) ->

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -26,7 +26,7 @@ Utils =
     -> id += 1
 
   hasChromePrefix: do ->
-    chromePrefixes = [ "about:", "view-source:", "extension:", "chrome-extension:", "data:" ]
+    chromePrefixes = [ "about:", "view-source:", "extension:", "chrome-extension:", "data:", "chrome-devtools:" ]
     (url) ->
       if 0 < url.indexOf ":"
         for prefix in chromePrefixes
@@ -136,6 +136,28 @@ Utils =
   # locale-sensitive uppercase detection
   hasUpperCase: (s) -> s.toLowerCase() != s
 
+# A simple synchronous cache. Entries which are used within each timeout period remain cached.  Those that
+# aren't are removed.
+class SimpleCache
+  constructor: (timeout=1000*60*60*24) ->
+    @current = {}
+    @previous = {}
+    setInterval((=> @rotate()), timeout) if timeout
+
+  # NOTE: This returns the new value.
+  set: (key, value) ->
+    delete @previous[key]
+    @current[key] = value
+
+  get: (key) ->
+    return @current[key] if @current[key]
+    return @set(key, @previous[key]) if @previous[key]
+    return null
+
+  rotate: ->
+    @previous = @current
+    @current = {}
+
 # This creates a new function out of an existing function, where the new function takes fewer arguments. This
 # allows us to pass around functions instead of functions + a partial list of arguments.
 Function::curry = ->
@@ -155,3 +177,4 @@ globalRoot.extend = (hash1, hash2) ->
 
 root = exports ? window
 root.Utils = Utils
+root.SimpleCache = SimpleCache

--- a/tests/dom_tests/vomnibar_test.coffee
+++ b/tests/dom_tests/vomnibar_test.coffee
@@ -2,6 +2,8 @@ context "Keep selection within bounds",
 
   setup ->
     @completions = []
+    @faviconId = "1234"
+    @html = '<img id="' + @faviconId + '" src=""/>'
     oldGetCompleter = Vomnibar.getCompleter.bind Vomnibar
     stub Vomnibar, 'getCompleter', (name) =>
       completer = oldGetCompleter name
@@ -19,7 +21,7 @@ context "Keep selection within bounds",
     ui.update(true)
     assert.equal -1, ui.selection
 
-    @completions = [{html:'foo',type:'tab',url:'http://example.com'}]
+    @completions = [{html:@html,type:'tab',url:'http://example.com',faviconId:@faviconId}]
     ui.update(true)
     assert.equal -1, ui.selection
 
@@ -35,7 +37,7 @@ context "Keep selection within bounds",
     ui.update(true)
     assert.equal -1, ui.selection
 
-    @completions = [{html:'foo',type:'bookmark',url:'http://example.com'}]
+    @completions = [{html:@html,type:'bookmark',url:'http://example.com',faviconId:@faviconId}]
     ui.update(true)
     assert.equal 0, ui.selection
 
@@ -54,7 +56,7 @@ context "Keep selection within bounds",
       preventDefault: ->
       stopImmediatePropagation: ->
 
-    @completions = [{html:'foo',type:'tab',url:'http://example.com'}]
+    @completions = [{html:@html,type:'tab',url:'http://example.com',faviconId:@faviconId}]
     ui.update(true)
     stub ui, "actionFromKeyEvent", -> "down"
     ui.onKeydown eventMock

--- a/tests/unit_tests/test_chrome_stubs.coffee
+++ b/tests/unit_tests/test_chrome_stubs.coffee
@@ -95,3 +95,9 @@ exports.chrome =
         callback() if callback
         # Now, generate (supposedly asynchronous) notification for listeners.
         global.chrome.storage.onChanged.callEmpty(key)
+
+class XMLHttpRequest
+  open: -> true
+  send: -> true
+
+exports.XMLHttpRequest = XMLHttpRequest

--- a/tests/unit_tests/utils_test.coffee
+++ b/tests/unit_tests/utils_test.coffee
@@ -81,3 +81,37 @@ context "compare versions",
     assert.equal -1, Utils.compareVersions("1.40.1", "1.40.2")
     assert.equal -1, Utils.compareVersions("1.40.1", "1.41")
     assert.equal 1, Utils.compareVersions("1.41", "1.40")
+
+context "SimpleCache",
+  setup ->
+    @cache = new SimpleCache()
+    @cache.set "a", 1
+    @cache.set "b", 2
+
+  should "cache values", ->
+    assert.equal 1, @cache.get "a"
+    assert.equal 2, @cache.get "b"
+
+  should "return value from set", ->
+    assert.equal @cache.set("z", 123), 123
+
+  should "keep cached values when rotated once", ->
+    assert.equal 1, @cache.get "a"
+    assert.equal 2, @cache.get "b"
+    @cache.rotate()
+    assert.equal 1, @cache.get "a"
+    assert.equal 2, @cache.get "b"
+
+  should "keep cached values when rotated twice and entries are re-used", ->
+    @cache.rotate()
+    assert.equal 1, @cache.get "a"
+    assert.equal 2, @cache.get "b"
+    @cache.rotate()
+    assert.equal 1, @cache.get "a"
+    assert.equal 2, @cache.get "b"
+
+  should "not keep cached values when rotated twice and entries not are re-used", ->
+    @cache.rotate()
+    @cache.rotate()
+    assert.isFalse @cache.get "a"
+    assert.isFalse @cache.get "b"


### PR DESCRIPTION
Continuation of #1210.  Fixes favicons.

The good:
- Favicons look good.
- Favicons are fetched on the background page (so no CSP issues).
- Uses Google's little globe if no other favicon is found (and every suggestion gets at least this favicon).
- Only uses `chrome://favicon/` to fetch favicons.  So we only get a custom favicon if chrome has one cached.
- _No guessing favicon URLs!_  Guessing is a poor approach.
- Caches favicons in both the content page and the background page.  Both caches make a noticable difference to how quickly the favicons are populated.

The bad:
- This is a _whopping_ amount of code for such a basic feature.

You could argue that the two core functions (`getFavicons` on the content page and `getFavicon` on the background page) are actually quite concise.  And the rest of the code is tests, utilities and infrastructure (which we just happen not to have needed before).

Fixes #1208.
