### PR TITLE
Fix for accesskeys issue #839

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -141,7 +141,7 @@ LinkHints =
   # of digits needed to enumerate all of the links on screen.
   #
   getVisibleClickableElements: ->
-    resultSet = DomUtils.evaluateXPath(@clickableElementsXPath, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE)
+    resultSet = DomUtils.evaluateXPath(@clickableElementsXPath)
 
     visibleElements = []
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -280,7 +280,7 @@ extend window,
     # Focus the first input element on the page, and create overlays to highlight all the input elements, with
     # the currently-focused element highlighted specially. Tabbing will shift focus to the next input element.
     # Pressing any other key will remove the overlays and the special tab behavior.
-    resultSet = DomUtils.evaluateXPath(textInputXPath, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE)
+    resultSet = DomUtils.evaluateXPath(textInputXPath)
     visibleInputs =
       for i in [0...resultSet.snapshotLength] by 1
         element = resultSet.snapshotItem(i)
@@ -797,7 +797,7 @@ followLink = (linkElement) ->
 #
 findAndFollowLink = (linkStrings) ->
   linksXPath = DomUtils.makeXPath(["a", "*[@onclick or @role='link' or contains(@class, 'button')]"])
-  links = DomUtils.evaluateXPath(linksXPath, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE)
+  links = DomUtils.evaluateXPath(linksXPath)
   candidateLinks = []
 
   # at the end of this loop, candidateLinks will contain all visible links that match our patterns

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -442,6 +442,7 @@ onKeydown = (event) ->
     if (keyChar)
       if (currentCompletionKeys.indexOf(keyChar) != -1)
         DomUtils.suppressEvent event
+        handlerStack.push({ keyup: DomUtils.suppressAccesskeyAction event })
         handledKeydownEvents.push event
 
       keyPort.postMessage({ keyChar:keyChar, frameId:frameId })

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -134,5 +134,39 @@ DomUtils =
     event.preventDefault()
     @suppressPropagation(event)
 
+  # The browser ignores our DomUtils.suppressEvent when activating an element via its accesskey. Removing the
+  # accesskey attribute of all elements which would be triggered is the only way to stop the browser from
+  # doing this.
+  # We return a function to restore all of the accesskeys, to be called at the corresponding keyup function.
+  suppressAccesskeyAction: do ->
+    accesskeyToElems = null # Mapping of accesskey -> [elements]
+
+    # Generate a cache of elements with accesskey set.
+    generateAccesskeyToElems = ->
+      accesskeyToElems = []
+      accesskeyElementList = document.querySelectorAll("*[accesskey]")
+      for element in accesskeyElementList
+        accesskey = element.getAttribute("accesskey").toLowerCase()
+        (accesskeyToElems[accesskey] ?= []).push element
+
+    (event) ->
+      return unless event.type == "keydown"
+
+      # The key combo to activate an accesskey element is a printing character with the modifiers:
+      #  * alt        on Windows/Linux
+      #  * ctrl, alt  on Mac
+      accesskey = KeyboardUtils.getKeyChar(event).toLowerCase()
+      return unless event.ctrlKey == (KeyboardUtils.platform == "Mac") and
+                    event.altKey == true and
+                    accesskey.length == 1
+
+      generateAccesskeyToElems() unless accesskeyToElems?
+      element.removeAttribute("accesskey") for element in accesskeyToElems[accesskey]
+      return ->
+        element.setAttribute("accesskey", accesskey) for element in accesskeyToElems[accesskey]
+        @remove?()
+        true
+
+
 root = exports ? window
 root.DomUtils = DomUtils

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -36,7 +36,7 @@ DomUtils =
       xpath.push("//" + elementArray[i], "//xhtml:" + elementArray[i])
     xpath.join(" | ")
 
-  evaluateXPath: (xpath, resultType) ->
+  evaluateXPath: (xpath, resultType = XPathResult.ORDERED_NODE_SNAPSHOT_TYPE) ->
     namespaceResolver = (namespace) ->
       if (namespace == "xhtml") then "http://www.w3.org/1999/xhtml" else null
     document.evaluate(xpath, document.documentElement, namespaceResolver, resultType, null)
@@ -161,6 +161,7 @@ DomUtils =
                     accesskey.length == 1
 
       generateAccesskeyToElems() unless accesskeyToElems?
+      return unless accesskey of accesskeyToElems # Nothing to do if no elements capture this key
       element.removeAttribute("accesskey") for element in accesskeyToElems[accesskey]
       return ->
         element.setAttribute("accesskey", accesskey) for element in accesskeyToElems[accesskey]


### PR DESCRIPTION
Add the method `DomUtils.suppressAccesskeyAction` to prevent the browser focusing elements with `accesskey` set. We need this since the browser currently ignores `preventDefault` for the `accesskey` action, causing the issue in #839.
