### PR TITLE
Handle contentEditable elements correctly

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -220,6 +220,9 @@ LinkHints =
     if (DomUtils.isSelectable(clickEl))
       DomUtils.simulateSelect(clickEl)
       @deactivateMode(delay, -> LinkHints.delayMode = false)
+    else if clickEl.contentEditable == "true"
+      DomUtils.focusContentEditable(clickEl)
+      @deactivateMode(delay, -> LinkHints.delayMode = false)
     else
       # TODO figure out which other input elements should not receive focus
       if (clickEl.nodeName.toLowerCase() == "input" && clickEl.type != "button")

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -527,11 +527,9 @@ isEmbed = (element) -> ["embed", "object"].indexOf(element.nodeName.toLowerCase(
 
 #
 # Input or text elements are considered focusable and able to receieve their own keyboard events,
-# and will enter enter mode if focused. Also note that the "contentEditable" attribute can be set on
-# any element which makes it a rich text editor, like the notes on jjot.com.
+# and will enter enter mode if focused.
 #
 isEditable = (target) ->
-  return true if target.isContentEditable
   nodeName = target.nodeName.toLowerCase()
   # use a blacklist instead of a whitelist because new form controls are still being implemented for html5
   noFocus = ["radio", "checkbox"]

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -122,6 +122,7 @@ DomUtils =
   isContentEditableFocused: ->
     {type: selType, anchorNode} = document.getSelection()
     return false unless anchorNode?
+    # We need an element. If anchorNode is not an element (eg. a text node) then we take its parentElement.
     anchorElement = if "isContentEditable" of anchorNode then anchorNode else anchorNode.parentElement
 
     (selType == "Caret" or selType == "Range") and anchorElement.isContentEditable

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -103,6 +103,17 @@ DomUtils =
     # When focusing a textbox, put the selection caret at the end of the textbox's contents.
     element.setSelectionRange(element.value.length, element.value.length)
 
+  focusContentEditable: (element) ->
+    range = document.createRange()
+    range.setStartAfter(element.lastChild)
+    range.setEndAfter(element.lastChild)
+
+    sel= window.getSelection()
+    sel.removeAllRanges()
+    sel.addRange(range)
+
+    element.focus()
+
   simulateClick: (element, modifiers) ->
     modifiers ||= {}
 

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -115,6 +115,17 @@ DomUtils =
 
     element.focus()
 
+  isContentEditable: (element) ->
+    element = element.parentElement unless element.contentEditable
+    while element
+      switch element.contentEditable
+        when "true"
+          return true
+        when "inherit"
+          element = element.parentElement
+        else
+          return false
+
   simulateClick: (element, modifiers) ->
     modifiers ||= {}
 

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -103,6 +103,7 @@ DomUtils =
     # When focusing a textbox, put the selection caret at the end of the textbox's contents.
     element.setSelectionRange(element.value.length, element.value.length)
 
+  # For contentEditable elements, we need to explicitly set a caret in them to make sure they are activated.
   focusContentEditable: (element) ->
     range = document.createRange()
     if element.lastChild
@@ -115,6 +116,9 @@ DomUtils =
 
     element.focus()
 
+  # Detect contentEditable elements having focus via the current selection. This avoids issues with tracking
+  # blur/focus events on badly behaved elements.
+  # (See comment isInsertMode in content_scripts/vimium_frontend.coffee for more info.)
   isContentEditableFocused: ->
     {type: selType, anchorNode} = document.getSelection()
     return false unless anchorNode?

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -105,12 +105,13 @@ DomUtils =
 
   focusContentEditable: (element) ->
     range = document.createRange()
-    range.setStartAfter(element.lastChild)
-    range.setEndAfter(element.lastChild)
+    if element.lastChild
+      range.setStartAfter element.lastChild
+      range.setEndAfter element.lastChild
 
     sel= window.getSelection()
     sel.removeAllRanges()
-    sel.addRange(range)
+    sel.addRange range
 
     element.focus()
 

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -109,22 +109,18 @@ DomUtils =
       range.setStartAfter element.lastChild
       range.setEndAfter element.lastChild
 
-    sel= window.getSelection()
+    sel = window.getSelection()
     sel.removeAllRanges()
     sel.addRange range
 
     element.focus()
 
-  isContentEditable: (element) ->
-    element = element.parentElement unless element.contentEditable
-    while element
-      switch element.contentEditable
-        when "true"
-          return true
-        when "inherit"
-          element = element.parentElement
-        else
-          return false
+  isContentEditableFocused: ->
+    {type: selType, anchorNode} = document.getSelection()
+    return false unless anchorNode?
+    anchorElement = if "isContentEditable" of anchorNode then anchorNode else anchorNode.parentElement
+
+    (selType == "Caret" or selType == "Range") and anchorElement.isContentEditable
 
   simulateClick: (element, modifiers) ->
     modifiers ||= {}


### PR DESCRIPTION
Continuation of #1050.

This PR makes link hints handle `contentEditable` elements correctly, and ensures we disable our shortcuts while such elements are active. This

* fixes #888 
* fixes #1136 
* fixes #1245.