### PR TITLE
Move options page help text to its own cell.

### DIFF
--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -152,9 +152,13 @@ toggleAdvancedOptions =
         $("advancedOptionsLink").innerHTML = "Hide advanced options"
       advancedMode = !advancedMode
       event.preventDefault()
+      # Prevent the "advanced options" link from retaining the focus.
+      document.activeElement.blur()
 
 activateHelpDialog = ->
   showHelpDialog chrome.extension.getBackgroundPage().helpDialogHtml(true, true, "Command Listing"), frameId
+  # Prevent the "show help" link from retaining the focus.
+  document.activeElement.blur()
 
 #
 # Initialization.

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -42,13 +42,7 @@ class Option
   @saveOptions: ->
     Option.all.map (option) -> option.save()
     $("saveOptions").disabled = true
-
-  # Used by text options. <ctrl-Enter> saves all options.
-  activateCtrlEnterListener: (element) ->
-    element.addEventListener "keyup", (event) ->
-      if event.ctrlKey and event.keyCode == 13
-        element.blur()
-        Option.saveOptions()
+    $("saveOptions").innerHTML = "No Changes"
 
   # Abstract method; only implemented in sub-classes.
   # Populate the option's DOM element (@element) with the setting's current value.
@@ -66,7 +60,6 @@ class TextOption extends Option
   constructor: (field,enableSaveButton) ->
     super(field,enableSaveButton)
     @element.addEventListener "input", enableSaveButton
-    @activateCtrlEnterListener @element
   populateElement: (value) -> @element.value = value
   readValueFromElement: -> @element.value.trim()
 
@@ -74,7 +67,6 @@ class NonEmptyTextOption extends Option
   constructor: (field,enableSaveButton) ->
     super(field,enableSaveButton)
     @element.addEventListener "input", enableSaveButton
-    @activateCtrlEnterListener @element
 
   populateElement: (value) -> @element.value = value
   # If the new value is not empty, then return it. Otherwise, restore the default value.
@@ -89,7 +81,6 @@ class ExclusionRulesOption extends Option
     super(args...)
     $("exclusionAddButton").addEventListener "click", (event) =>
       @appendRule { pattern: "", passKeys: "" }
-      @maintainExclusionMargin()
       # Focus the pattern element in the new rule.
       @element.children[@element.children.length-1].children[0].children[0].focus()
       # Scroll the new rule into view.
@@ -101,7 +92,6 @@ class ExclusionRulesOption extends Option
       @element.removeChild @element.firstChild
     for rule in rules
       @appendRule rule
-    @maintainExclusionMargin()
 
   # Append a row for a new rule.
   appendRule: (rule) ->
@@ -111,7 +101,6 @@ class ExclusionRulesOption extends Option
     for field in ["pattern", "passKeys"]
       element = row.querySelector ".#{field}"
       element.value = rule[field]
-      @activateCtrlEnterListener element
       for event in [ "input", "change" ]
         element.addEventListener event, enableSaveButton
 
@@ -120,7 +109,6 @@ class ExclusionRulesOption extends Option
       row = event.target.parentNode.parentNode
       row.parentNode.removeChild row
       enableSaveButton()
-      @maintainExclusionMargin()
 
     @element.appendChild row
 
@@ -138,20 +126,11 @@ class ExclusionRulesOption extends Option
     flatten = (rule) -> if rule and rule.pattern then rule.pattern + "\n" + rule.passKeys else ""
     a.map(flatten).join("\n") == b.map(flatten).join("\n")
 
-  # Hack.  There has to be a better way than...
-  # The y-axis scrollbar for "exclusionRules" is only displayed if it is needed.  When visible, it appears on
-  # top of the enclosed content (partially obscuring it).  Here, we adjust the margin of the "Remove" button to
-  # compensate.
-  maintainExclusionMargin: ->
-    scrollBox = $("exclusionScrollBox")
-    margin = if scrollBox.clientHeight < scrollBox.scrollHeight then "16px" else "0px"
-    for element in scrollBox.getElementsByClassName "exclusionRemoveButton"
-      element.style["margin-right"] = margin
-
 #
 # Operations for page elements.
 enableSaveButton = ->
   $("saveOptions").removeAttribute "disabled"
+  $("saveOptions").innerHTML = "Save Changes"
 
 # Display either "linkHintNumbers" or "linkHintCharacters", depending upon "filterLinkHints".
 maintainLinkHintsView = ->
@@ -213,4 +192,8 @@ document.addEventListener "DOMContentLoaded", ->
 
   maintainLinkHintsView()
   window.onbeforeunload = -> "You have unsaved changes to options." unless $("saveOptions").disabled
+
+  document.addEventListener "keyup", (event) ->
+    if event.ctrlKey and event.keyCode == 13
+      Option.saveOptions()
 

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -88,8 +88,8 @@ class ExclusionRulesOption extends Option
       exclusionScrollBox.scrollTop = exclusionScrollBox.scrollHeight
 
   populateElement: (rules) ->
-    while @element.firstChild
-      @element.removeChild @element.firstChild
+    # while @element.firstChild.nextSibling
+    #   @element.removeChild @element.firstChild.nextSibling
     for rule in rules
       @appendRule rule
 
@@ -114,7 +114,7 @@ class ExclusionRulesOption extends Option
 
   readValueFromElement: ->
     rules =
-      for element in @element.children
+      for element in @element.getElementsByClassName "exclusionRuleTemplateInstance"
         pattern = element.children[0].firstChild.value.trim()
         passKeys = element.children[1].firstChild.value.trim()
         { pattern: pattern, passKeys: passKeys }

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -68,6 +68,11 @@ class NonEmptyTextOption extends Option
     super(field,enableSaveButton)
     @element.addEventListener "input", enableSaveButton
 
+    leaveEmptyMessage = document.createElement "div"
+    leaveEmptyMessage.className = "nonEmptyTextOption example info"
+    leaveEmptyMessage.appendChild document.createTextNode "Leave empty to reset this option."
+    @element.parentElement.appendChild(leaveEmptyMessage)
+
   populateElement: (value) -> @element.value = value
   # If the new value is not empty, then return it. Otherwise, restore the default value.
   readValueFromElement: -> if value = @element.value.trim() then value else @restoreToDefault()
@@ -187,10 +192,6 @@ document.addEventListener "DOMContentLoaded", ->
   $("advancedOptionsLink").addEventListener "click", toggleAdvancedOptions
   $("showCommands").addEventListener "click", activateHelpDialog
   $("filterLinkHints").addEventListener "click", maintainLinkHintsView
-
-  for element in document.getElementsByClassName "nonEmptyTextOption"
-    element.className = element.className + " example info"
-    element.innerHTML = "Leave empty to reset this option."
 
   maintainLinkHintsView()
   window.onbeforeunload = -> "You have unsaved changes to options." unless $("saveOptions").disabled

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -88,8 +88,6 @@ class ExclusionRulesOption extends Option
       exclusionScrollBox.scrollTop = exclusionScrollBox.scrollHeight
 
   populateElement: (rules) ->
-    # while @element.firstChild.nextSibling
-    #   @element.removeChild @element.firstChild.nextSibling
     for rule in rules
       @appendRule rule
 
@@ -195,5 +193,6 @@ document.addEventListener "DOMContentLoaded", ->
 
   document.addEventListener "keyup", (event) ->
     if event.ctrlKey and event.keyCode == 13
+      document.activeElement.blur() if document?.activeElement?.blur
       Option.saveOptions()
 

--- a/pages/options.html
+++ b/pages/options.html
@@ -104,6 +104,7 @@
       }
       td.help {
         max-width: 500px;
+        vertical-align: top;
       }
       td.caption, td.option, td.help { padding-top: 0; }
       div#exampleKeyMapping {

--- a/pages/options.html
+++ b/pages/options.html
@@ -210,8 +210,11 @@
         bottom: 0px;
         z-index: 10;
       }
-      #footer, #footerTable, #footerTableData {
+      #footer, #footerTable {
         width: 100%;
+      }
+      #footerTableData {
+        min-width: 40%;
       }
       #endSpace {
         /* Leave space for the fixed footer. */
@@ -222,7 +225,7 @@
         font-size: 12px;
       }
       #saveOptionsTableData {
-        float: right;
+        min-width: 300px;
       }
       #saveOptions {
         white-space: nowrap;

--- a/pages/options.html
+++ b/pages/options.html
@@ -6,12 +6,14 @@
       body {
         font: 14px "DejaVu Sans", "Arial", sans-serif;
         color: #303942;
-        width: 680px;
         margin: 0 auto;
       }
       a, a:visited { color: #15c; }
       a:active { color: #052577; }
-      div#wrapper { width: 500px; }
+      div#wrapper, #footerWrapper {
+        width: 540px;
+        margin-left: 35px;
+      }
       header {
         font-size: 18px;
         font-weight: normal;
@@ -141,20 +143,13 @@
         font-size: 80%;
       }
       /* Make the caption in the settings table as small as possible, to pull the other fields to the right. */
-      td:first-child {
+      .caption {
         width: 1px;
         white-space: nowrap;
       }
       #buttonsPanel { width: 100%; }
       #advancedOptions { display: none; }
       #advancedOptionsLink { line-height: 24px; }
-      #saveOptions { float: right; }
-      #saveOptions { margin-right: 0; }
-      #showHelpDialogMessage {
-        width: 100%;
-        color: #979ca0;
-        font-size: 12px;
-      }
       .help {
         position: absolute;
         right: -320px;
@@ -180,10 +175,6 @@
       }
       /* Boolean options have a tighter form representation than text options. */
       td.booleanOption { font-size: 12px; }
-      footer {
-        padding: 15px 0;
-        border-top: 1px solid #eee;
-      }
       /* Ids and classes for rendering exclusionRules */
       #exclusionScrollBox {
         overflow: scroll;
@@ -193,21 +184,51 @@
         border: 1px solid #bfbfbf;
         border-radius: 2px;
         color: #444;
+        width: 100%
+      }
+      #exclusionRules {
+        width: 100%;
+      }
+      .exclusionRulePassKeys {
+        width: 33%;
+      }
+      .exclusionRemoveButton {
+        width: 1px; /* 1px; smaller than the button itself. */
       }
       input.pattern, input.passKeys {
+        width: 100%;
         font-family: Consolas, "Liberation Mono", Courier, monospace;
         font-size: 14px;
       }
-      .pattern {
-        width: 250px;
-      }
-      .passKeys {
-        width: 120px;
-      }
       #exclusionAddButton {
         float: right;
-        margin-top: 5px;
         margin-right: 0px;
+        margin-top: 5px;
+      }
+      #footer {
+        background: #f5f5f5;
+        position: fixed;
+        bottom: 0px;
+        z-index: 10;
+      }
+      #footer, #footerTable, #footerTableData {
+        width: 100%;
+      }
+      #endSpace {
+        /* Leave space for the fixed footer. */
+        min-height: 30px;
+        max-height: 30px;
+      }
+      #helpText {
+        color: #979ca0;
+        font-size: 12px;
+      }
+      #saveOptionsTableData {
+        float: right;
+      }
+      #saveOptions {
+        white-space: nowrap;
+        width: 110px;
       }
     </style>
 
@@ -237,10 +258,10 @@
                <div id="exclusionScrollBox">
                   <table id="exclusionRules"></table>
                   <template id="exclusionRuleTemplate">
-                    <tr>
+                  <tr>
                        <td><input/ type="text" class="pattern" placeholder="URL pattern"></td>
-                       <td><input/ type="text" class="passKeys" placeholder="Exclude keys"></td>
-                       <td><input/ type="button" class="exclusionRemoveButton" tabindex = "-1" value="&#x2716;"></td>
+                       <td class="exclusionRulePassKeys"><input/ type="text" class="passKeys" placeholder="Exclude keys"></td>
+                       <td class="exclusionRemoveButton"><input/ type="button" tabindex = "-1" value="&#x2716;"></td>
                     </tr>
                   </template>
                </div>
@@ -292,8 +313,7 @@ unmapAll
           </td>
         </tr>
         <tr>
-           <td><a href="#" id="advancedOptionsLink">Show advanced options&hellip;</a></td>
-           <td><button id="saveOptions" disabled="true">Save Options</button></td>
+           <td colspan="2"><a href="#" id="advancedOptionsLink">Show advanced options&hellip;</a></td>
         </tr>
         <tbody id='advancedOptions'>
           <tr>
@@ -315,7 +335,7 @@ unmapAll
             </td>
           </tr>
           <tr>
-            <td class="caption">Numbers used<br/> for filtered link hints</td>
+            <td class="caption">Numbers used<br/> for link hints</td>
             <td verticalAlign="top">
                 <div class="help">
                   <div class="example">
@@ -327,7 +347,7 @@ unmapAll
             </td>
           </tr>
           <tr>
-            <td class="caption"></td>
+            <td class="caption">Miscellaneous<br/>toggles</td>
             <td verticalAlign="top" class="booleanOption">
               <div class="help">
                 <div class="example">
@@ -433,14 +453,28 @@ unmapAll
           </tr>
         </tbody>
       </table>
+    </div>
 
-      <br/>
+    <!-- Some extra space which is hidden underneath the footer. -->
+    <div id="endSpace"/>
 
-      <footer id="showHelpDialogMessage">
-        Type <strong>?</strong> to show the Vimium help dialog.
-        <br/>
-        Type <strong>Ctrl-Enter</strong> in text inputs to save all options.
-      </footer>
+    <div id="footer">
+      <div id="footerWrapper">
+        <table id="footerTable">
+          <tr>
+            <td id="footerTableData">
+              <span id="helpText">
+                Type <strong>?</strong> to show the Vimium help dialog.
+                <br/>
+                Type <strong>Ctrl-Enter</strong> to save <i>all</i> options.
+              </span>
+            </td>
+            <td id="saveOptionsTableData">
+              <button id="saveOptions" disabled="true">No Changes</button>
+            </td>
+          </tr>
+        </table>
+      </div>
     </div>
   </body>
 </html>

--- a/pages/options.html
+++ b/pages/options.html
@@ -10,6 +10,7 @@
       }
       a, a:visited { color: #15c; }
       a:active { color: #052577; }
+      span.monosp { font-family: monospace; }
       div#wrapper, #footerWrapper {
         width: calc(100% - 70px);
         max-width: 888px; /* Same as Chrome settings width */
@@ -260,21 +261,18 @@
                <button id="exclusionAddButton">Add Rule</button>
             </div>
           </td>
-          <td class="help">
-            <div class="example">
+          <td class="help"><div class="example">
               Wholly or partially disable Vimium.  "Patterns" are URL regular expressions;
               additionally, "*" matches any zero or more characters.
               <br/><br/>
               If "Keys" is left empty, then vimium is wholly disabled.
               Otherwise, just the listed keys are disabled (they are passed through).
-            </div>
-          </td>
+          </div></td>
         </tr>
         <tr>
           <td class="caption">Custom key<br/>mappings</td>
           <td class="option"><textarea id="keyMappings" type="text"></textarea></td>
-          <td id="mappingsHelp" class="help">
-            <div class="example">
+          <td id="mappingsHelp" class="help"><div class="example">
               <!-- TODO(ilya/philc): Expand this and style it better. -->
               Enter commands to remap your keys. Available commands:<br/>
               <pre id="exampleKeyMapping">
@@ -284,21 +282,18 @@ unmapAll
 " this is a comment
 # this is also a comment</pre>
               <a href="#" id="showCommands">Show available commands.</a>
-            </div>
-          </td>
+          </div></td>
         </tr>
         <tr>
           <td class="caption">Custom search<br/>engines</td>
           <td class="option"><textarea id="searchEngines"></textarea></td>
-          <td class="help">
-            <div class="example">
+          <td class="help"><div class="example">
               This adds search-engine shortcuts to the Vomnibar.<br/><br/>
               The format is:<br/>
               <pre>your-keyword: http://the-site.com/?q=%s</pre>
               %s will be replaced with your search terms.<br/>
               Lines which start with "#" are comments.
-            </div>
-          </td>
+          </div></td>
         </tr>
         <tr>
           <td class="caption"></td>
@@ -326,25 +321,19 @@ unmapAll
             <td class="caption">Characters used<br/> for link hints</td>
             <td class="option">
                 <input id="linkHintCharacters" type="text" />
-                <div class="nonEmptyTextOption"></div>
             </td>
-            <td class="help">
-              <div class="example">
+            <td class="help"><div class="example">
                 The characters placed next to each link after typing "f" to enter link-hint mode.
-              </div>
-            </td>
+            </div></td>
           </tr>
           <tr>
             <td class="caption">Numbers used<br/> for link hints</td>
             <td class="option">
                 <input id="linkHintNumbers" type="text" />
-                <div class="nonEmptyTextOption"></div>
             </td>
-            <td class="help">
-              <div class="example">
+            <td class="help"><div class="example">
                 The numbers placed next to each link after typing "f" to enter link-hint mode.
-              </div>
-            </td>
+            </div></td>
           </tr>
           <tr>
             <td class="caption">Miscellaneous<br/>options</td>
@@ -354,11 +343,9 @@ unmapAll
                 Use the link's name and numbers for link-hint filtering
               </label>
             </td>
-            <td class="help">
-              <div class="example">
+            <td class="help"><div class="example">
                 In link-hint mode, this option lets you also select a link by typing its text.
-              </div>
-            </td>
+            </div></td>
           </tr>
           <tr>
             <td class="caption"></td>
@@ -368,11 +355,9 @@ unmapAll
                 Hide the Heads Up Display (HUD)
               </label>
             </td>
-            <td class="help">
-              <div class="example">
+            <td class="help"><div class="example">
                 When enabled, the HUD will not be displayed.
-              </div>
-            </td>
+            </div></td>
           </tr>
           <tr>
             <td class="caption"></td>
@@ -382,74 +367,57 @@ unmapAll
                 Treat find queries as regular expressions.
               </label>
             </td>
-            <td class="help">
-              <div class="example">
+            <td class="help"><div class="example">
                 Switch back to plain find mode by using the <code>\R</code> escape sequence.
-              </div>
-            </td>
+            </div></td>
           </tr>
           <tr>
             <td class="caption">Previous patterns</td>
             <td class="option">
                 <input id="previousPatterns" type="text" />
-                <div class="nonEmptyTextOption"></div>
             </td>
-            <td class="help">
-              <div class="example">
+            <td class="help"><div class="example">
                 The "navigate to previous page" command uses these patterns to find the link to follow.
-              </div>
-            </td>
+            </div></td>
           </tr>
           <tr>
             <td class="caption">Next patterns</td>
             <td class="option">
                 <input id="nextPatterns" type="text" />
-                <div class="nonEmptyTextOption"></div>
             </td>
-            <td class="help">
-              <div class="example">
+            <td class="help"><div class="example">
                 The "navigate to next page" command uses these patterns to find the link to follow.
-              </div>
-            </td>
+            </div></td>
           </tr>
           <tr>
             <td class="caption">New tab URL</td>
             <td class="option">
                 <input id="newTabUrl" type="text" />
-                <div class="nonEmptyTextOption"></div>
             </td>
-            <td class="help">
-              <div class="example">
+            <td class="help"><div class="example">
                   The page to open with the "create new tab" command.
-                  Set this to "<tt>pages/blank.html</tt>" for a blank page.<br />
-              </div>
-            </td>
+                  Set this to "<span class="monosp">pages/blank.html</span>" for a blank page.<br />
+            </div></td>
           </tr>
           <tr>
             <td class="caption">Default search<br/>engine</td>
             <td class="option">
                 <input id="searchUrl" type="text" />
-                <div class="nonEmptyTextOption"></div>
             </td>
-            <td class="help">
-              <div class="example">
+            <td class="help"><div class="example">
                  The search engine to use in the Vomnibar <br> (e.g.: "http://duckduckgo.com/?q=").
-              </div>
-            </td>
+            </div></td>
           </tr>
           <tr>
             <td class="caption">CSS for link hints</td>
             <td class="option">
               <textarea id="userDefinedLinkHintCss" class="code" type="text"></textarea>
-              <div class="nonEmptyTextOption"></div>
             </td>
-            <td class="help">
-              <div class="example">
+            <td class="help"><div class="example">
                 The CSS used to style the characters next to each link hint.<br/><br/>
                 These styles are used in addition to and take precedence over Vimium's
                 default styles.
-              </div>
-            </td>
+            </div></td>
           </tr>
         </tbody>
       </table>

--- a/pages/options.html
+++ b/pages/options.html
@@ -114,19 +114,9 @@
         width: 40px;
         margin-right: 3px;
       }
-      textarea#userDefinedLinkHintCss {
+      textarea#userDefinedLinkHintCss, textarea#keyMappings, textarea#searchEngines {
         width: 100%;;
         min-height: 130px;
-        white-space: nowrap;
-      }
-      textarea#keyMappings {
-        width: 100%;
-        min-height: 135px;
-        white-space: nowrap;
-      }
-      textarea#searchEngines {
-        width: 100%;
-        min-height: 135px;
         white-space: nowrap;
       }
       input#previousPatterns, input#nextPatterns {
@@ -180,7 +170,8 @@
         overflow: scroll;
         overflow-x: hidden;
         overflow-y: auto;
-        height: 170px;
+        min-height: 135px;
+        height: 135px;
         border: 1px solid #bfbfbf;
         border-radius: 2px;
         color: #444;
@@ -195,10 +186,14 @@
       .exclusionRemoveButton {
         width: 1px; /* 1px; smaller than the button itself. */
       }
-      input.pattern, input.passKeys {
+      input.pattern, input.passKeys, .exclusionHeaderText {
         width: 100%;
         font-family: Consolas, "Liberation Mono", Courier, monospace;
         font-size: 14px;
+      }
+      .exclusionHeaderText {
+        padding-left: 3px;
+        color: #979ca0;
       }
       #exclusionAddButton {
         float: right;
@@ -207,6 +202,7 @@
       }
       #footer {
         background: #f5f5f5;
+        border-top: 1px solid #979ca0;
         position: fixed;
         bottom: 0px;
         z-index: 10;
@@ -220,7 +216,6 @@
         max-height: 30px;
       }
       #helpText {
-        color: #979ca0;
         font-size: 12px;
       }
       #saveOptionsTableData {
@@ -245,24 +240,27 @@
           <td>
             <div class="help">
               <div class="example">
-                The left column contains URL patterns.  Vimium will be wholly or partially disabled for URLs
-                matching these patterns.  Patterns are Javascript regular expressions.  Additionally, the
-                character "*" matches any zero or more characters.
+                Wholly or partially disable Vimium.  "Patterns" are URL regular expressions;
+                additionally, "*" matches any zero or more characters.
                 <br/><br/>
-                The right column contains keys which Vimium would would normally handle, but which should
-                instead be passed through to the underlying web page (for pages matching the
-                pattern).  If left empty, then Vimium will be wholly disabled.
+                If "Keys" is left empty, then vimium is wholly disabled.
+                Otherwise, just the listed keys are disabled (they are passed through).
               </div>
             </div>
             <div>
                <div id="exclusionScrollBox">
-                  <table id="exclusionRules"></table>
+                  <table id="exclusionRules">
+                     <tr>
+                        <td><span class="exclusionHeaderText">Patterns</span></td>
+                        <td><span class="exclusionHeaderText">Keys</span></td>
+                     </tr>
+                  </table>
                   <template id="exclusionRuleTemplate">
-                  <tr>
-                       <td><input/ type="text" class="pattern" placeholder="URL pattern"></td>
-                       <td class="exclusionRulePassKeys"><input/ type="text" class="passKeys" placeholder="Exclude keys"></td>
-                       <td class="exclusionRemoveButton"><input/ type="button" tabindex = "-1" value="&#x2716;"></td>
-                    </tr>
+                     <tr class="exclusionRuleTemplateInstance">
+                        <td><input/ type="text" class="pattern" placeholder="URL pattern"></td>
+                        <td class="exclusionRulePassKeys"><input/ type="text" class="passKeys" placeholder="Exclude keys"></td>
+                        <td class="exclusionRemoveButton"><input/ type="button" tabindex = "-1" value="&#x2716;"></td>
+                     </tr>
                   </template>
                </div>
                <button id="exclusionAddButton">Add Rule</button>
@@ -347,7 +345,7 @@ unmapAll
             </td>
           </tr>
           <tr>
-            <td class="caption">Miscellaneous<br/>toggles</td>
+            <td class="caption">Miscellaneous<br/>options</td>
             <td verticalAlign="top" class="booleanOption">
               <div class="help">
                 <div class="example">

--- a/pages/options.html
+++ b/pages/options.html
@@ -94,6 +94,7 @@
       }
       td.caption {
         margin-right: 10px;
+        width: 100px;
         max-width: 150px;
         padding-top: 3px;
         vertical-align: top;
@@ -216,6 +217,7 @@
       }
       #footerTableData {
         min-width: 40%;
+        padding-left: 0px;
       }
       #endSpace {
         /* Leave space for the fixed footer. */
@@ -226,7 +228,8 @@
         font-size: 12px;
       }
       #saveOptionsTableData {
-        min-width: 300px;
+        min-width: 305px;
+        padding-right: 0px;
       }
       #saveOptions {
         white-space: nowrap;

--- a/pages/options.html
+++ b/pages/options.html
@@ -170,12 +170,22 @@
         overflow: scroll;
         overflow-x: hidden;
         overflow-y: auto;
-        min-height: 135px;
-        height: 135px;
-        border: 1px solid #bfbfbf;
+        max-height: 135px;
         border-radius: 2px;
         color: #444;
         width: 100%
+      }
+      #exclusionScrollBox::-webkit-scrollbar {
+        width: 12px;
+      }
+      #exclusionScrollBox::-webkit-scrollbar-track {
+        -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
+        border-radius: 2px;
+      }
+
+      #exclusionScrollBox::-webkit-scrollbar-thumb {
+        border-radius: 2px;
+        -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.5);
       }
       #exclusionRules {
         width: 100%;
@@ -185,6 +195,14 @@
       }
       .exclusionRemoveButton {
         width: 1px; /* 1px; smaller than the button itself. */
+      }
+      .exclusionRemoveButtonButton {
+        border: none;
+        background-color: #fff;
+        color: #979ca0;
+      }
+      .exclusionRemoveButtonButton:hover {
+        color: #444;
       }
       input.pattern, input.passKeys, .exclusionHeaderText {
         width: 100%;
@@ -259,7 +277,8 @@
                      <tr class="exclusionRuleTemplateInstance">
                         <td><input/ type="text" class="pattern" placeholder="URL pattern"></td>
                         <td class="exclusionRulePassKeys"><input/ type="text" class="passKeys" placeholder="Exclude keys"></td>
-                        <td class="exclusionRemoveButton"><input/ type="button" tabindex = "-1" value="&#x2716;"></td>
+                        <td class="exclusionRemoveButton">
+                          <input/ type="button" tabindex = "-1" class="exclusionRemoveButtonButton" value="&#x2716;"></td>
                      </tr>
                   </template>
                </div>

--- a/pages/options.html
+++ b/pages/options.html
@@ -11,7 +11,8 @@
       a, a:visited { color: #15c; }
       a:active { color: #052577; }
       div#wrapper, #footerWrapper {
-        width: 540px;
+        width: calc(100% - 70px);
+        max-width: 888px; /* Same as Chrome settings width */
         margin-left: 35px;
       }
       header {
@@ -90,67 +91,49 @@
       .info {
         margin-left: 0px;
       }
-      .caption {
+      td.caption {
         margin-right: 10px;
-        min-width: 130px;
+        max-width: 150px;
         padding-top: 3px;
         vertical-align: top;
+        /*white-space: nowrap;*/
       }
-      td { padding: 0; }
+      td.option {
+        min-width: calc(50% - 130px);
+      }
+      td.help {
+        max-width: 500px;
+      }
+      td.caption, td.option, td.help { padding-top: 0; }
       div#exampleKeyMapping {
         margin-left: 10px;
         margin-top: 5px;
       }
-      input#linkHintCharacters {
-        width: 100%;
-      }
-      input#linkHintNumbers {
-        width: 100%;
-      }
-      input#linkHintCharacters {
+      td.option > input[type="text"], td.option > textarea {
         width: 100%;
       }
       input#scrollStepSize {
         width: 40px;
         margin-right: 3px;
       }
-      textarea#userDefinedLinkHintCss, textarea#keyMappings, textarea#searchEngines {
-        width: 100%;;
+      textarea#userDefinedLinkHintCss {
         min-height: 130px;
         white-space: nowrap;
       }
-      input#previousPatterns, input#nextPatterns {
-        width: 100%;
+      textarea#keyMappings {
+        min-height: 135px;
+        white-space: nowrap;
       }
-      input#newTabUrl {
-        width: 100%;
-      }
-      input#searchUrl {
-        width: 100%;
+      textarea#searchEngines {
+        min-height: 135px;
+        white-space: nowrap;
       }
       #status {
         margin-left: 10px;
         font-size: 80%;
       }
-      /* Make the caption in the settings table as small as possible, to pull the other fields to the right. */
-      .caption {
-        width: 1px;
-        white-space: nowrap;
-      }
-      #buttonsPanel { width: 100%; }
       #advancedOptions { display: none; }
       #advancedOptionsLink { line-height: 24px; }
-      .help {
-        position: absolute;
-        right: -320px;
-        width: 320px;
-      }
-      input:read-only {
-        background-color: #eee;
-        color: #666;
-        pointer-events: none;
-        -webkit-user-select: none;
-      }
       input[type="text"], textarea {
         border: 1px solid #bfbfbf;
         border-radius: 2px;
@@ -256,16 +239,7 @@
       <table id="options">
         <tr>
           <td class="caption">Excluded URLs<br/>and keys</td>
-          <td>
-            <div class="help">
-              <div class="example">
-                Wholly or partially disable Vimium.  "Patterns" are URL regular expressions;
-                additionally, "*" matches any zero or more characters.
-                <br/><br/>
-                If "Keys" is left empty, then vimium is wholly disabled.
-                Otherwise, just the listed keys are disabled (they are passed through).
-              </div>
-            </div>
+          <td class="option">
             <div>
                <div id="exclusionScrollBox">
                   <table id="exclusionRules">
@@ -286,39 +260,44 @@
                <button id="exclusionAddButton">Add Rule</button>
             </div>
           </td>
+          <td class="help">
+            <div class="example">
+              Wholly or partially disable Vimium.  "Patterns" are URL regular expressions;
+              additionally, "*" matches any zero or more characters.
+              <br/><br/>
+              If "Keys" is left empty, then vimium is wholly disabled.
+              Otherwise, just the listed keys are disabled (they are passed through).
+            </div>
+          </td>
         </tr>
         <tr>
           <td class="caption">Custom key<br/>mappings</td>
-          <td id="mappingsHelp" verticalAlign="top">
-            <div class="help">
-              <div class="example">
-                <!-- TODO(ilya/philc): Expand this and style it better. -->
-                Enter commands to remap your keys. Available commands:<br/>
-                <pre id="exampleKeyMapping">
+          <td class="option"><textarea id="keyMappings" type="text"></textarea></td>
+          <td id="mappingsHelp" class="help">
+            <div class="example">
+              <!-- TODO(ilya/philc): Expand this and style it better. -->
+              Enter commands to remap your keys. Available commands:<br/>
+              <pre id="exampleKeyMapping">
 map j scrollDown
 unmap j
 unmapAll
 " this is a comment
 # this is also a comment</pre>
-                <a href="#" id="showCommands">Show available commands.</a>
-              </div>
+              <a href="#" id="showCommands">Show available commands.</a>
             </div>
-            <textarea id="keyMappings" type="text"></textarea>
           </td>
         </tr>
         <tr>
           <td class="caption">Custom search<br/>engines</td>
-          <td verticalAlign="top">
-              <div class="help">
-                <div class="example">
-                  This adds search-engine shortcuts to the Vomnibar.<br/><br/>
-                  The format is:<br/>
-                  <pre>your-keyword: http://the-site.com/?q=%s</pre>
-                  %s will be replaced with your search terms.<br/>
-                  Lines which start with "#" are comments.
-                </div>
-              </div>
-              <textarea id="searchEngines"></textarea>
+          <td class="option"><textarea id="searchEngines"></textarea></td>
+          <td class="help">
+            <div class="example">
+              This adds search-engine shortcuts to the Vomnibar.<br/><br/>
+              The format is:<br/>
+              <pre>your-keyword: http://the-site.com/?q=%s</pre>
+              %s will be replaced with your search terms.<br/>
+              Lines which start with "#" are comments.
+            </div>
           </td>
         </tr>
         <tr>
@@ -336,142 +315,140 @@ unmapAll
         <tbody id='advancedOptions'>
           <tr>
             <td class="caption">Scroll step size</td>
-            <td>
-                <div class="help">
-                  <div class="example">
-                    The size for basic movements (usually j/k/h/l).
-                  </div>
-                </div>
-              <input id="scrollStepSize" type="number" />px
+            <td class="option"><input id="scrollStepSize" type="number" />px</td>
+            <td class="help">
+              <div class="example">
+                The size for basic movements (usually j/k/h/l).
+              </div>
             </td>
           </tr>
           <tr>
             <td class="caption">Characters used<br/> for link hints</td>
-            <td verticalAlign="top">
-                <div class="help">
-                  <div class="example">
-                    The characters placed next to each link after typing "f" to enter link-hint mode.
-                  </div>
-                </div>
+            <td class="option">
                 <input id="linkHintCharacters" type="text" />
-                <div class="nonEmptyTextOption">
+                <div class="nonEmptyTextOption"></div>
+            </td>
+            <td class="help">
+              <div class="example">
+                The characters placed next to each link after typing "f" to enter link-hint mode.
+              </div>
             </td>
           </tr>
           <tr>
             <td class="caption">Numbers used<br/> for link hints</td>
-            <td verticalAlign="top">
-                <div class="help">
-                  <div class="example">
-                    The numbers placed next to each link after typing "f" to enter link-hint mode.
-                  </div>
-                </div>
+            <td class="option">
                 <input id="linkHintNumbers" type="text" />
-                <div class="nonEmptyTextOption">
+                <div class="nonEmptyTextOption"></div>
+            </td>
+            <td class="help">
+              <div class="example">
+                The numbers placed next to each link after typing "f" to enter link-hint mode.
+              </div>
             </td>
           </tr>
           <tr>
             <td class="caption">Miscellaneous<br/>options</td>
-            <td verticalAlign="top" class="booleanOption">
-              <div class="help">
-                <div class="example">
-                  In link-hint mode, this option lets you also select a link by typing its text.
-                </div>
-              </div>
+            <td class="option booleanOption">
               <label>
                 <input id="filterLinkHints" type="checkbox"/>
                 Use the link's name and numbers for link-hint filtering
               </label>
             </td>
+            <td class="help">
+              <div class="example">
+                In link-hint mode, this option lets you also select a link by typing its text.
+              </div>
+            </td>
           </tr>
           <tr>
             <td class="caption"></td>
-            <td verticalAlign="top" class="booleanOption">
-              <div class="help">
-                <div class="example">
-                  When enabled, the HUD will not be displayed.
-                </div>
-              </div>
+            <td class="option booleanOption">
               <label>
                 <input id="hideHud" type="checkbox"/>
                 Hide the Heads Up Display (HUD)
               </label>
             </td>
+            <td class="help">
+              <div class="example">
+                When enabled, the HUD will not be displayed.
+              </div>
+            </td>
           </tr>
           <tr>
             <td class="caption"></td>
-            <td verticalAlign="top" class="booleanOption">
-              <div class="help">
-                <div class="example">
-                  Switch back to plain find mode by using the <code>\R</code> escape sequence.
-                </div>
-              </div>
+            <td class="option booleanOption">
               <label>
                 <input id="regexFindMode" type="checkbox"/>
                 Treat find queries as regular expressions.
               </label>
             </td>
+            <td class="help">
+              <div class="example">
+                Switch back to plain find mode by using the <code>\R</code> escape sequence.
+              </div>
+            </td>
           </tr>
           <tr>
             <td class="caption">Previous patterns</td>
-            <td verticalAlign="top">
-                <div class="help">
-                  <div class="example">
-                    The "navigate to previous page" command uses these patterns to find the link to follow.
-                  </div>
-                </div>
+            <td class="option">
                 <input id="previousPatterns" type="text" />
-                <div class="nonEmptyTextOption">
+                <div class="nonEmptyTextOption"></div>
+            </td>
+            <td class="help">
+              <div class="example">
+                The "navigate to previous page" command uses these patterns to find the link to follow.
+              </div>
             </td>
           </tr>
           <tr>
             <td class="caption">Next patterns</td>
-            <td verticalAlign="top">
-                <div class="help">
-                  <div class="example">
-                    The "navigate to next page" command uses these patterns to find the link to follow.
-                  </div>
-                </div>
+            <td class="option">
                 <input id="nextPatterns" type="text" />
-                <div class="nonEmptyTextOption">
+                <div class="nonEmptyTextOption"></div>
+            </td>
+            <td class="help">
+              <div class="example">
+                The "navigate to next page" command uses these patterns to find the link to follow.
+              </div>
             </td>
           </tr>
           <tr>
             <td class="caption">New tab URL</td>
-            <td verticalAlign="top">
-                <div class="help">
-                  <div class="example">
-                      The page to open with the "create new tab" command.
-                      Set this to "<tt>pages/blank.html</tt>" for a blank page.<br />
-                  </div>
-                </div>
+            <td class="option">
                 <input id="newTabUrl" type="text" />
-                <div class="nonEmptyTextOption">
+                <div class="nonEmptyTextOption"></div>
+            </td>
+            <td class="help">
+              <div class="example">
+                  The page to open with the "create new tab" command.
+                  Set this to "<tt>pages/blank.html</tt>" for a blank page.<br />
+              </div>
             </td>
           </tr>
           <tr>
             <td class="caption">Default search<br/>engine</td>
-            <td verticalAlign="top">
-                <div class="help">
-                  <div class="example">
-                     The search engine to use in the Vomnibar <br> (e.g.: "http://duckduckgo.com/?q=").
-                  </div>
-                </div>
+            <td class="option">
                 <input id="searchUrl" type="text" />
-                <div class="nonEmptyTextOption">
+                <div class="nonEmptyTextOption"></div>
+            </td>
+            <td class="help">
+              <div class="example">
+                 The search engine to use in the Vomnibar <br> (e.g.: "http://duckduckgo.com/?q=").
+              </div>
             </td>
           </tr>
           <tr>
             <td class="caption">CSS for link hints</td>
-            <td verticalAlign="top">
-              <div class="help">
-                <div class="example">
-                  The CSS used to style the characters next to each link hint.<br/><br/>
-                  These styles are used in addition to and take precedence over Vimium's
-                  default styles.
-                </div>
-              </div>
+            <td class="option">
               <textarea id="userDefinedLinkHintCss" class="code" type="text"></textarea>
-              <div class="nonEmptyTextOption">
+              <div class="nonEmptyTextOption"></div>
+            </td>
+            <td class="help">
+              <div class="example">
+                The CSS used to style the characters next to each link hint.<br/><br/>
+                These styles are used in addition to and take precedence over Vimium's
+                default styles.
+              </div>
             </td>
           </tr>
         </tbody>

--- a/pages/options.html
+++ b/pages/options.html
@@ -317,6 +317,11 @@ unmapAll
           <tr>
             <td class="caption">Scroll step size</td>
             <td>
+                <div class="help">
+                  <div class="example">
+                    The size for basic movements (usually j/k/h/l).
+                  </div>
+                </div>
               <input id="scrollStepSize" type="number" />px
             </td>
           </tr>

--- a/pages/options.html
+++ b/pages/options.html
@@ -171,6 +171,7 @@
         overflow-x: hidden;
         overflow-y: auto;
         max-height: 135px;
+        min-height: 75px;
         border-radius: 2px;
         color: #444;
         width: 100%

--- a/pages/popup.html
+++ b/pages/popup.html
@@ -76,7 +76,7 @@
       <div id="popupMenu">
         <ul>
           <li>
-             <span id="helpText">Type <strong>Ctrl-ENTER</strong> to save and close.</span>
+             <span id="helpText">Type <strong>Ctrl-Enter</strong> to save and close.</span>
              <a id="optionsLink" target="_blank">Options</a>
           </li>
         </ul>


### PR DESCRIPTION
This is a continuation of #1244. It

* moves the help text for each option to its own cell in the row
* fixes styling for narrow window widths
* refactors some of the styles