### PR TITLE
Handle contentEditable elements correctly, with normal mode

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -220,6 +220,9 @@ LinkHints =
     if (DomUtils.isSelectable(clickEl))
       DomUtils.simulateSelect(clickEl)
       @deactivateMode(delay, -> LinkHints.delayMode = false)
+    else if clickEl.contentEditable == "true"
+      DomUtils.focusContentEditable(clickEl)
+      @deactivateMode(delay, -> LinkHints.delayMode = false)
     else
       # TODO figure out which other input elements should not receive focus
       if (clickEl.nodeName.toLowerCase() == "input" && clickEl.type != "button")

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -545,11 +545,9 @@ isEmbed = (element) -> ["embed", "object"].indexOf(element.nodeName.toLowerCase(
 
 #
 # Input or text elements are considered focusable and able to receieve their own keyboard events,
-# and will enter enter mode if focused. Also note that the "contentEditable" attribute can be set on
-# any element which makes it a rich text editor, like the notes on jjot.com.
+# and will enter enter mode if focused.
 #
 isEditable = (target) ->
-  return true if target.isContentEditable
   nodeName = target.nodeName.toLowerCase()
   # use a blacklist instead of a whitelist because new form controls are still being implemented for html5
   noFocus = ["radio", "checkbox"]

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -478,7 +478,9 @@ onKeydown = (event) ->
       isValidFirstKey(KeyboardUtils.getKeyChar(event))))
     DomUtils.suppressPropagation(event)
     handledKeydownEvents.push event
-  else if contentEditableNormalMode and not KeyboardUtils.isEscape(event)
+  else if (contentEditableNormalMode and not KeyboardUtils.isEscape(event) and not
+           ([keyCodes.shiftKey, keyCodes.ctrlKey, keyCodes.altKey].indexOf(event.keyCode) != -1 or
+            currentCompletionKeys.indexOf(keyChar) != -1 or isValidFirstKey(keyChar)))
     # We've got a key we're not handling, blur the contentEditable element.
     contentEditableNormalMode = false
     document.getSelection().removeAllRanges() # Remove the caret, which blurs the element.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -408,24 +408,24 @@ onKeydown = (event) ->
   if (isInsertMode() and KeyboardUtils.isEscape(event))
     # Note that we can't programmatically blur out of Flash embeds from Javascript.
     if (!isEmbed(event.srcElement))
+      keyHandled = true
       # Remove focus so the user can't just get himself back into insert mode by typing in the same input
       # box.
       if (isEditable(event.srcElement))
         event.srcElement.blur()
       else if (DomUtils.isContentEditableFocused())
-        # If the user presses escape once, retain the selection and only blur if we don't handle the key.
+        # If the user presses escape once with text selected, retain the selection and only blur if we don't
+        # end up handling a key.
         # If the user presses escape again, we blur directly since keyHandled = false.
-        if (contentEditableNormalMode)
-          DomUtils.suppressPropagation(event)
-          handledKeydownEvents.push event
+        if (contentEditableNormalMode or document.getSelection().type == "Caret")
+          # We check these values in order to blur, so make sure we have them set correctly.
+          contentEditableNormalMode = true
           keyHandled = false
         else
           contentEditableNormalMode = true
-          keyHandled = true
       exitInsertMode()
       DomUtils.suppressEvent event
       handledKeydownEvents.push event
-      keyHandled = true
 
   else if (findMode)
     if (KeyboardUtils.isEscape(event))

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -122,6 +122,7 @@ DomUtils =
   isContentEditableFocused: ->
     {type: selType, anchorNode} = document.getSelection()
     return false unless anchorNode?
+    # We need an element. If anchorNode is not an element (eg. a text node) then we take its parentElement.
     anchorElement = if "isContentEditable" of anchorNode then anchorNode else anchorNode.parentElement
 
     (selType == "Caret" or selType == "Range") and anchorElement.isContentEditable

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -103,6 +103,17 @@ DomUtils =
     # When focusing a textbox, put the selection caret at the end of the textbox's contents.
     element.setSelectionRange(element.value.length, element.value.length)
 
+  focusContentEditable: (element) ->
+    range = document.createRange()
+    range.setStartAfter(element.lastChild)
+    range.setEndAfter(element.lastChild)
+
+    sel= window.getSelection()
+    sel.removeAllRanges()
+    sel.addRange(range)
+
+    element.focus()
+
   simulateClick: (element, modifiers) ->
     modifiers ||= {}
 

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -127,6 +127,15 @@ DomUtils =
 
     (selType == "Caret" or selType == "Range") and anchorElement.isContentEditable
 
+  getFocusedContentEditable: ->
+    {anchorNode} = document.getSelection()
+    ceElement = if "isContentEditable" of anchorNode then anchorNode else anchorNode.parentElement
+
+    return null unless ceElement.isContentEditable
+
+    ceElement = ceElement.parentElement while ceElement.parentElement.isContentEditable
+    ceElement
+
   simulateClick: (element, modifiers) ->
     modifiers ||= {}
 

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -115,6 +115,17 @@ DomUtils =
 
     element.focus()
 
+  isContentEditable: (element) ->
+    element = element.parentElement unless element.contentEditable
+    while element
+      switch element.contentEditable
+        when "true"
+          return true
+        when "inherit"
+          element = element.parentElement
+        else
+          return false
+
   simulateClick: (element, modifiers) ->
     modifiers ||= {}
 

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -103,6 +103,7 @@ DomUtils =
     # When focusing a textbox, put the selection caret at the end of the textbox's contents.
     element.setSelectionRange(element.value.length, element.value.length)
 
+  # For contentEditable elements, we need to explicitly set a caret in them to make sure they are activated.
   focusContentEditable: (element) ->
     range = document.createRange()
     if element.lastChild
@@ -115,6 +116,9 @@ DomUtils =
 
     element.focus()
 
+  # Detect contentEditable elements having focus via the current selection. This avoids issues with tracking
+  # blur/focus events on badly behaved elements.
+  # (See comment isInsertMode in content_scripts/vimium_frontend.coffee for more info.)
   isContentEditableFocused: ->
     {type: selType, anchorNode} = document.getSelection()
     return false unless anchorNode?

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -105,12 +105,13 @@ DomUtils =
 
   focusContentEditable: (element) ->
     range = document.createRange()
-    range.setStartAfter(element.lastChild)
-    range.setEndAfter(element.lastChild)
+    if element.lastChild
+      range.setStartAfter element.lastChild
+      range.setEndAfter element.lastChild
 
     sel= window.getSelection()
     sel.removeAllRanges()
-    sel.addRange(range)
+    sel.addRange range
 
     element.focus()
 

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -109,22 +109,18 @@ DomUtils =
       range.setStartAfter element.lastChild
       range.setEndAfter element.lastChild
 
-    sel= window.getSelection()
+    sel = window.getSelection()
     sel.removeAllRanges()
     sel.addRange range
 
     element.focus()
 
-  isContentEditable: (element) ->
-    element = element.parentElement unless element.contentEditable
-    while element
-      switch element.contentEditable
-        when "true"
-          return true
-        when "inherit"
-          element = element.parentElement
-        else
-          return false
+  isContentEditableFocused: ->
+    {type: selType, anchorNode} = document.getSelection()
+    return false unless anchorNode?
+    anchorElement = if "isContentEditable" of anchorNode then anchorNode else anchorNode.parentElement
+
+    (selType == "Caret" or selType == "Range") and anchorElement.isContentEditable
 
   simulateClick: (element, modifiers) ->
     modifiers ||= {}

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -1,7 +1,7 @@
 KeyboardUtils =
   keyCodes:
-    { ESC: 27, backspace: 8, deleteKey: 46, enter: 13, space: 32, shiftKey: 16, ctrlKey: 17, f1: 112,
-    f12: 123, tab: 9 }
+    { ESC: 27, backspace: 8, deleteKey: 46, enter: 13, space: 32, shiftKey: 16, ctrlKey: 17, altKey: 18,
+    f1: 112, f12: 123, tab: 9 }
 
   keyNames:
     { 37: "left", 38: "up", 39: "right", 40: "down" }


### PR DESCRIPTION
Continuation of #1246.

This adds the ability to execute commands with text selected in a `contentEditable` element (which technically is still selected) after pressing `<esc>` once. Pressing `<esc>` again or pressing a key not bound by Vimium fully blurs the element, by removing its selection.