### PR TITLE
Port overlapping link hint rotation by Space from VimFx

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -42,5 +42,6 @@ Contributors:
   Werner Laurensse (github: ab3)
   Timo Sand <timo.j.sand@gmail.com> (github: deiga)
   Shiyong Chen <billbill290@gmail.com> (github: UncleBill)
+  Yury Kartynnik <yury@kartynnik.info> (github: kartynnik)
 
 Feel free to add real names in addition to GitHub usernames.


### PR DESCRIPTION
This commit basically ports the VimFx'es ability to rotate overlapping marker stacks by pressing [Shift-]Space. This is very useful in the cases where many little (e.g. iconic) links are stuffed together. Resolves #757.