### PR TITLE
[Minor Fix] Ensure we suppress events for all keys we handle

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -502,7 +502,7 @@ refreshCompletionKeys = (response) ->
     chrome.runtime.sendMessage({ handler: "getCompletionKeys" }, refreshCompletionKeys)
 
 isValidFirstKey = (keyChar) ->
-  validFirstKeys[keyChar] || /[1-9]/.test(keyChar)
+  validFirstKeys[keyChar] || /^[1-9]/.test(keyChar)
 
 onFocusCapturePhase = (event) ->
   if (isFocusable(event.target) && !findMode)


### PR DESCRIPTION
The logic in [content_scripts/vimium_frontend.coffee](https://github.com/philc/vimium/blob/master/content_scripts/vimium_frontend.coffee) didn't match up with the [background_scripts/main.coffee](https://github.com/philc/vimium/blob/master/background_scripts/main.coffee) implementation; we were handling keys but not suppressing the events if the user started typing another command midway through typing a multi-key shortcut.
