### PR TITLE
Draw overlays for input elements before focusing in focusInput

### DIFF
--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -93,6 +93,7 @@ div.internalVimiumInputHint {
   display: block;
   background-color: rgba(255, 247, 133, 0.3);
   border: solid 1px #C38A22;
+  pointer-events: none;
 }
 
 div.internalVimiumSelectedInputHint {

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -292,44 +292,44 @@ extend window,
 
     selectedInputIndex = Math.min(count - 1, visibleInputs.length - 1)
 
+    # Only give visial feedback of what are inputs and which is selected if there are several to choose from.
+    unless visibleInputs.length == 1
+
+      hints = for tuple in visibleInputs
+        hint = document.createElement("div")
+        hint.className = "vimiumReset internalVimiumInputHint vimiumInputHint"
+
+        # minus 1 for the border
+        hint.style.left = (tuple.rect.left - 1) + window.scrollX + "px"
+        hint.style.top = (tuple.rect.top - 1) + window.scrollY  + "px"
+        hint.style.width = tuple.rect.width + "px"
+        hint.style.height = tuple.rect.height + "px"
+
+        hint
+
+      hints[selectedInputIndex].classList.add 'internalVimiumSelectedInputHint'
+
+      hintContainingDiv = DomUtils.addElementList(hints,
+        { id: "vimiumInputMarkerContainer", className: "vimiumReset" })
+
+      handlerStack.push keydown: (event) ->
+        if event.keyCode == KeyboardUtils.keyCodes.tab
+          hints[selectedInputIndex].classList.remove 'internalVimiumSelectedInputHint'
+          if event.shiftKey
+            if --selectedInputIndex == -1
+              selectedInputIndex = hints.length - 1
+          else
+            if ++selectedInputIndex == hints.length
+              selectedInputIndex = 0
+          hints[selectedInputIndex].classList.add 'internalVimiumSelectedInputHint'
+          visibleInputs[selectedInputIndex].element.focus()
+        else unless event.keyCode == KeyboardUtils.keyCodes.shiftKey
+          DomUtils.removeElement hintContainingDiv
+          @remove()
+          return true
+
     visibleInputs[selectedInputIndex].element.focus()
-
-    return if visibleInputs.length == 1
-
-    hints = for tuple in visibleInputs
-      hint = document.createElement("div")
-      hint.className = "vimiumReset internalVimiumInputHint vimiumInputHint"
-
-      # minus 1 for the border
-      hint.style.left = (tuple.rect.left - 1) + window.scrollX + "px"
-      hint.style.top = (tuple.rect.top - 1) + window.scrollY  + "px"
-      hint.style.width = tuple.rect.width + "px"
-      hint.style.height = tuple.rect.height + "px"
-
-      hint
-
-    hints[selectedInputIndex].classList.add 'internalVimiumSelectedInputHint'
-
-    hintContainingDiv = DomUtils.addElementList(hints,
-      { id: "vimiumInputMarkerContainer", className: "vimiumReset" })
-
-    handlerStack.push keydown: (event) ->
-      if event.keyCode == KeyboardUtils.keyCodes.tab
-        hints[selectedInputIndex].classList.remove 'internalVimiumSelectedInputHint'
-        if event.shiftKey
-          if --selectedInputIndex == -1
-            selectedInputIndex = hints.length - 1
-        else
-          if ++selectedInputIndex == hints.length
-            selectedInputIndex = 0
-        hints[selectedInputIndex].classList.add 'internalVimiumSelectedInputHint'
-        visibleInputs[selectedInputIndex].element.focus()
-      else unless event.keyCode == KeyboardUtils.keyCodes.shiftKey
-        DomUtils.removeElement hintContainingDiv
-        @remove()
-        return true
-
-      false
+    false
 
 # Decide whether this keyChar should be passed to the underlying page.
 # Keystrokes are *never* considered passKeys if the keyQueue is not empty.  So, for example, if 't' is a

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -295,15 +295,21 @@ extend window,
     # Only give visial feedback of what are inputs and which is selected if there are several to choose from.
     unless visibleInputs.length == 1
 
-      hints = for tuple in visibleInputs
+      hints = for {rect} in visibleInputs
         hint = document.createElement("div")
         hint.className = "vimiumReset internalVimiumInputHint vimiumInputHint"
 
+        hintRect =
+          left: rect.oldLeft ? rect.left
+          top: rect.oldTop ? rect.top
+          width: rect.oldWidth ? rect.width
+          height: rect.oldHeight ? rect.height
+
         # minus 1 for the border
-        hint.style.left = (tuple.rect.left - 1) + window.scrollX + "px"
-        hint.style.top = (tuple.rect.top - 1) + window.scrollY  + "px"
-        hint.style.width = tuple.rect.width + "px"
-        hint.style.height = tuple.rect.height + "px"
+        hint.style.left = (hintRect.left - 1) + window.scrollX + "px"
+        hint.style.top = (hintRect.top - 1) + window.scrollY  + "px"
+        hint.style.width = hintRect.width + "px"
+        hint.style.height = hintRect.height + "px"
 
         hint
 

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -53,10 +53,14 @@ DomUtils =
 
     for clientRect in clientRects
       if (clientRect.top < 0)
+        clientRect.oldTop = clientRect.top
+        clientRect.oldHeight = clientRect.height
         clientRect.height += clientRect.top
         clientRect.top = 0
 
       if (clientRect.left < 0)
+        clientRect.oldLeft = clientRect.left
+        clientRect.oldWidth = clientRect.width
         clientRect.width += clientRect.left
         clientRect.left = 0
 


### PR DESCRIPTION
This prevents us from drawing the overlays in the wrong place if the window scrolls to focus the chosen input (eg. when it is on the boundary of the page). Fixes #1257.