### PR TITLE
Change some loops to arrays rather than objects (fixes keys with modifiers)

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -408,16 +408,14 @@ chrome.tabs.onRemoved.addListener (tabId) ->
   # reappear. Pretend they never existed and adjust tab indices accordingly. Could possibly expand this into
   # a blacklist in the future.
   unless chrome.sessions
+    currentWindowTabQueue = tabQueue[openTabInfo.windowId] ?= []
     if (/^(chrome|view-source:)[^:]*:\/\/.*/.test(openTabInfo.url))
-      for i of tabQueue[openTabInfo.windowId]
-        if (tabQueue[openTabInfo.windowId][i].positionIndex > openTabInfo.positionIndex)
-          tabQueue[openTabInfo.windowId][i].positionIndex--
+      for tab in currentWindowTabQueue
+        if (tab.positionIndex > openTabInfo.positionIndex)
+          tab.positionIndex--
       return
 
-    if (tabQueue[openTabInfo.windowId])
-      tabQueue[openTabInfo.windowId].push(openTabInfo)
-    else
-      tabQueue[openTabInfo.windowId] = [openTabInfo]
+    currentWindowTabQueue.push(openTabInfo)
 
   # keep the reference around for a while to wait for the last messages from the closed tab (e.g. for updating
   # scroll position)

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -68,8 +68,8 @@ settings =
   load: ->
     @init() unless @port
 
-    for i of @valuesToLoad
-      @port.postMessage({ operation: "get", key: @valuesToLoad[i] })
+    for key in @valuesToLoad
+      @port.postMessage({ operation: "get", key: key })
 
   receiveMessage: (args) ->
     # not using 'this' due to issues with binding on callback
@@ -83,8 +83,7 @@ settings =
         listener()
 
   addEventListener: (eventName, callback) ->
-    if (!(eventName of @eventListeners))
-      @eventListeners[eventName] = []
+    @eventListeners[eventName] ?= []
     @eventListeners[eventName].push(callback)
 
 #
@@ -402,8 +401,8 @@ onKeydown = (event) ->
       if (event.altKey)
         modifiers.push("a")
 
-      for i of modifiers
-        keyChar = modifiers[i] + "-" + keyChar
+      for modifier in modifiers
+        keyChar = modifier + "-" + keyChar
 
       if (modifiers.length > 0 || keyChar.length > 1)
         keyChar = "<" + keyChar + ">"


### PR DESCRIPTION
This commit seems to have been missed in #1260 when continuing from #1177. Without it, keys with modifiers don't work (since using `for ... in` includes the `rotate` method for array methods). Try `<a-f>` in the default bindings for an example.

Related to this, we should really be using `for own ... in` instead of `for ... in`, since we never (so far) have wanted to traverse an object's prototype while trying to access its members.
