### PR TITLE
Improve contentEditable support

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -220,6 +220,9 @@ LinkHints =
     if (DomUtils.isSelectable(clickEl))
       DomUtils.simulateSelect(clickEl)
       @deactivateMode(delay, -> LinkHints.delayMode = false)
+    else if clickEl.contentEditable == "true"
+      DomUtils.focusContentEditable(clickEl)
+      @deactivateMode(delay, -> LinkHints.delayMode = false)
     else
       # TODO figure out which other input elements should not receive focus
       if (clickEl.nodeName.toLowerCase() == "input" && clickEl.type != "button")

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -205,14 +205,7 @@ enterInsertModeIfElementIsFocused = ->
   if (document.activeElement && isEditable(document.activeElement) && !findMode)
     enterInsertModeWithoutShowingIndicator(document.activeElement)
 
-onDOMActivate = (event) ->
-  handlerStack.bubbleEvent 'DOMActivate', event
-
-  # If the user blurs a contentEditable element using the mouse (ie. clicks another element), this may be
-  # the first that we know about it, since sometimes it will not fire a blur event. If the contentEditable
-  # element *is* still focused, exitInsertMode will do the right thing and keep us in insert mode.
-  if insertModeLock and DomUtils.isContentEditable insertModeLock
-    exitInsertMode(insertModeLock)
+onDOMActivate = (event) -> handlerStack.bubbleEvent 'DOMActivate', event
 
 executePageCommand = (request) ->
   return unless frameId == request.frameId
@@ -421,6 +414,8 @@ onKeydown = (event) ->
       # box.
       if (isEditable(event.srcElement))
         event.srcElement.blur()
+      else if (DomUtils.isContentEditableFocused())
+        document.getSelection().removeAllRanges() # Remove the caret, which blurs the element.
       exitInsertMode()
       DomUtils.suppressEvent event
       handledKeydownEvents.push event
@@ -570,23 +565,18 @@ window.enterInsertMode = (target) ->
 enterInsertModeWithoutShowingIndicator = (target) -> insertModeLock = target
 
 exitInsertMode = (target) ->
-  if target != undefined
-    # If we have a caret or a selection in a contentEditable element, we don't want to exit insert mode.
-    selection = document.getSelection()
-    if (selection.type == "Caret" or selection.type == "Range") and
-       DomUtils.isContentEditable selection.anchorNode
-      return
-
   if (target == undefined || insertModeLock == target)
     insertModeLock = null
     HUD.hide()
 
 isInsertMode = ->
   return true if insertModeLock != null
-  # Some sites (e.g. inbox.google.com) change the contentEditable attribute on the fly (see #1245); and
-  # unfortunately, isEditable() is called *before* the change is made.  Therefore, we need to re-check whether
-  # the active element is contentEditable.
-  document.activeElement and document.activeElement.isContentEditable and
+  # If the user currently has a caret/selection in a contentEditable element, they should be in insert mode,
+  # but sometimes are not.  This can happen for several reasons:
+  #  - the contentEditable element sets document.designMode when it is focused (which immediately fires a
+  #    blur event).
+  #  - contentEditable is set dynamically (eg. inbox.google.com).
+  document.activeElement and DomUtils.isContentEditableFocused() and
     enterInsertModeWithoutShowingIndicator document.activeElement
 
 # should be called whenever rawQuery is modified.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -205,7 +205,14 @@ enterInsertModeIfElementIsFocused = ->
   if (document.activeElement && isEditable(document.activeElement) && !findMode)
     enterInsertModeWithoutShowingIndicator(document.activeElement)
 
-onDOMActivate = (event) -> handlerStack.bubbleEvent 'DOMActivate', event
+onDOMActivate = (event) ->
+  handlerStack.bubbleEvent 'DOMActivate', event
+
+  # If the user blurs a contentEditable element using the mouse (ie. clicks another element), this may be
+  # the first that we know about it, since sometimes it will not fire a blur event. If the contentEditable
+  # element *is* still focused, exitInsertMode will do the right thing and keep us in insert mode.
+  if insertModeLock and DomUtils.isContentEditable insertModeLock
+    exitInsertMode(insertModeLock)
 
 executePageCommand = (request) ->
   return unless frameId == request.frameId
@@ -563,6 +570,13 @@ window.enterInsertMode = (target) ->
 enterInsertModeWithoutShowingIndicator = (target) -> insertModeLock = target
 
 exitInsertMode = (target) ->
+  if target != undefined
+    # If we have a caret or a selection in a contentEditable element, we don't want to exit insert mode.
+    selection = document.getSelection()
+    if (selection.type == "Caret" or selection.type == "Range") and
+       DomUtils.isContentEditable selection.anchorNode
+      return
+
   if (target == undefined || insertModeLock == target)
     insertModeLock = null
     HUD.hide()

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -414,8 +414,6 @@ onKeydown = (event) ->
       # box.
       if (isEditable(event.srcElement))
         event.srcElement.blur()
-      else if (DomUtils.isContentEditableFocused())
-        document.getSelection().removeAllRanges() # Remove the caret, which blurs the element.
       exitInsertMode()
       DomUtils.suppressEvent event
       handledKeydownEvents.push event

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -532,12 +532,9 @@ isEmbed = (element) -> ["embed", "object"].indexOf(element.nodeName.toLowerCase(
 
 #
 # Input or text elements are considered focusable and able to receieve their own keyboard events,
-# and will enter enter mode if focused. Also note that the "contentEditable" attribute can be set on
-# any element which makes it a rich text editor, like the notes on jjot.com.
+# and will enter enter mode if focused.
 #
 isEditable = (target) ->
-  # Note: document.activeElement.isContentEditable is also rechecked in isInsertMode() dynamically.
-  return true if target.isContentEditable
   nodeName = target.nodeName.toLowerCase()
   # use a blacklist instead of a whitelist because new form controls are still being implemented for html5
   noFocus = ["radio", "checkbox"]

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -122,6 +122,7 @@ DomUtils =
   isContentEditableFocused: ->
     {type: selType, anchorNode} = document.getSelection()
     return false unless anchorNode?
+    # We need an element. If anchorNode is not an element (eg. a text node) then we take its parentElement.
     anchorElement = if "isContentEditable" of anchorNode then anchorNode else anchorNode.parentElement
 
     (selType == "Caret" or selType == "Range") and anchorElement.isContentEditable

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -103,6 +103,17 @@ DomUtils =
     # When focusing a textbox, put the selection caret at the end of the textbox's contents.
     element.setSelectionRange(element.value.length, element.value.length)
 
+  focusContentEditable: (element) ->
+    range = document.createRange()
+    range.setStartAfter(element.lastChild)
+    range.setEndAfter(element.lastChild)
+
+    sel= window.getSelection()
+    sel.removeAllRanges()
+    sel.addRange(range)
+
+    element.focus()
+
   simulateClick: (element, modifiers) ->
     modifiers ||= {}
 

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -115,6 +115,17 @@ DomUtils =
 
     element.focus()
 
+  isContentEditable: (element) ->
+    element = element.parentElement unless element.contentEditable
+    while element
+      switch element.contentEditable
+        when "true"
+          return true
+        when "inherit"
+          element = element.parentElement
+        else
+          return false
+
   simulateClick: (element, modifiers) ->
     modifiers ||= {}
 

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -103,6 +103,7 @@ DomUtils =
     # When focusing a textbox, put the selection caret at the end of the textbox's contents.
     element.setSelectionRange(element.value.length, element.value.length)
 
+  # For contentEditable elements, we need to explicitly set a caret in them to make sure they are activated.
   focusContentEditable: (element) ->
     range = document.createRange()
     if element.lastChild
@@ -115,6 +116,9 @@ DomUtils =
 
     element.focus()
 
+  # Detect contentEditable elements having focus via the current selection. This avoids issues with tracking
+  # blur/focus events on badly behaved elements.
+  # (See comment isInsertMode in content_scripts/vimium_frontend.coffee for more info.)
   isContentEditableFocused: ->
     {type: selType, anchorNode} = document.getSelection()
     return false unless anchorNode?

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -105,12 +105,13 @@ DomUtils =
 
   focusContentEditable: (element) ->
     range = document.createRange()
-    range.setStartAfter(element.lastChild)
-    range.setEndAfter(element.lastChild)
+    if element.lastChild
+      range.setStartAfter element.lastChild
+      range.setEndAfter element.lastChild
 
     sel= window.getSelection()
     sel.removeAllRanges()
-    sel.addRange(range)
+    sel.addRange range
 
     element.focus()
 

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -109,22 +109,18 @@ DomUtils =
       range.setStartAfter element.lastChild
       range.setEndAfter element.lastChild
 
-    sel= window.getSelection()
+    sel = window.getSelection()
     sel.removeAllRanges()
     sel.addRange range
 
     element.focus()
 
-  isContentEditable: (element) ->
-    element = element.parentElement unless element.contentEditable
-    while element
-      switch element.contentEditable
-        when "true"
-          return true
-        when "inherit"
-          element = element.parentElement
-        else
-          return false
+  isContentEditableFocused: ->
+    {type: selType, anchorNode} = document.getSelection()
+    return false unless anchorNode?
+    anchorElement = if "isContentEditable" of anchorNode then anchorNode else anchorNode.parentElement
+
+    (selType == "Caret" or selType == "Range") and anchorElement.isContentEditable
 
   simulateClick: (element, modifiers) ->
     modifiers ||= {}


### PR DESCRIPTION
Rebase of #1253 onto current master. From #1253:

> #1246, less the functionality which blurs `contentEditable` elements when `esc` is pressed (by clearing the document selection).

>This is functionally the same as #1247 except
* it detects a wider range of `contentEditable` elements.
* it fixes link hints for `contentEditable` elements.

>This
* fixes #888 
* fixes #1136