### PR TITLE
Ensure that we use `for own` rather than `for`

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -1,6 +1,6 @@
 Commands =
   init: ->
-    for command, description of commandDescriptions
+    for own command, description of commandDescriptions
       @addCommand(command, description[0], description[1])
 
   availableCommands: {}
@@ -83,7 +83,7 @@ Commands =
   clearKeyMappingsAndSetDefaults: ->
     @keyToCommandRegistry = {}
 
-    for key of defaultKeyMappings
+    for own key of defaultKeyMappings
       @mapKeyToCommand(key, defaultKeyMappings[key])
 
   # An ordered listing of all available commands, grouped by type. This is the order they will

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -210,7 +210,7 @@ class DomainCompleter
 
   performSearch: (queryTerms, onComplete) ->
     query = queryTerms[0]
-    domainCandidates = (domain for domain of @domains when domain.indexOf(query) >= 0)
+    domainCandidates = (domain for own domain of @domains when domain.indexOf(query) >= 0)
     domains = @sortDomainsByRelevancy(queryTerms, domainCandidates)
     return onComplete([]) if domains.length == 0
     topDomain = domains[0][0]

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -102,12 +102,12 @@ saveHelpDialogSettings = (request) ->
 # This is called by options.coffee.
 root.helpDialogHtml = (showUnboundCommands, showCommandNames, customTitle) ->
   commandsToKey = {}
-  for key of Commands.keyToCommandRegistry
+  for own key of Commands.keyToCommandRegistry
     command = Commands.keyToCommandRegistry[key].command
     commandsToKey[command] = (commandsToKey[command] || []).concat(key)
 
   dialogHtml = fetchFileContents("pages/help_dialog.html")
-  for group of Commands.commandGroups
+  for own group of Commands.commandGroups
     dialogHtml = dialogHtml.replace("{{#{group}}}",
         helpDialogHtmlForCommandGroup(group, commandsToKey, Commands.availableCommands,
                                       showUnboundCommands, showCommandNames))
@@ -412,7 +412,7 @@ chrome.tabs.onRemoved.addListener (tabId) ->
   # a blacklist in the future.
   unless chrome.sessions
     if (/^(chrome|view-source:)[^:]*:\/\/.*/.test(openTabInfo.url))
-      for i of tabQueue[openTabInfo.windowId]
+      for i in tabQueue[openTabInfo.windowId]
         if (tabQueue[openTabInfo.windowId][i].positionIndex > openTabInfo.positionIndex)
           tabQueue[openTabInfo.windowId][i].positionIndex--
       return
@@ -456,12 +456,12 @@ getActualKeyStrokeLength = (key) ->
     key.length
 
 populateValidFirstKeys = ->
-  for key of Commands.keyToCommandRegistry
+  for own key of Commands.keyToCommandRegistry
     if (getActualKeyStrokeLength(key) == 2)
       validFirstKeys[splitKeyIntoFirstAndSecond(key).first] = true
 
 populateSingleKeyCommands = ->
-  for key of Commands.keyToCommandRegistry
+  for own key of Commands.keyToCommandRegistry
     if (getActualKeyStrokeLength(key) == 1)
       singleKeyCommands.push(key)
 
@@ -484,7 +484,7 @@ generateCompletionKeys = (keysToCheck) ->
   completionKeys = singleKeyCommands.slice(0)
 
   if (getActualKeyStrokeLength(command) == 1)
-    for key of Commands.keyToCommandRegistry
+    for own key of Commands.keyToCommandRegistry
       splitKey = splitKeyIntoFirstAndSecond(key)
       if (splitKey.first == command)
         completionKeys.push(splitKey.second)

--- a/background_scripts/marks.coffee
+++ b/background_scripts/marks.coffee
@@ -17,7 +17,7 @@ chrome.tabs.onRemoved.addListener (tabId, removeInfo) ->
   removeMarksForTab tabId
 
 removeMarksForTab = (id) ->
-  for markName, mark of marks
+  for own markName, mark of marks
     if mark.tabId is id
       delete marks[markName]
 

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -156,7 +156,7 @@ String::startsWith = (str) -> @indexOf(str) == 0
 
 globalRoot = window ? global
 globalRoot.extend = (hash1, hash2) ->
-  for key of hash2
+  for own key of hash2
     hash1[key] = hash2[key]
   hash1
 

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -184,7 +184,7 @@ activateHelpDialog = ->
 document.addEventListener "DOMContentLoaded", ->
 
   # Populate options.  The constructor adds each new object to "Option.all".
-  new type(name,enableSaveButton) for name, type of {
+  new type(name,enableSaveButton) for own name, type of {
     exclusionRules: ExclusionRulesOption
     filterLinkHints: CheckBoxOption
     hideHud: CheckBoxOption

--- a/tests/unit_tests/commands_test.coffee
+++ b/tests/unit_tests/commands_test.coffee
@@ -14,15 +14,15 @@ context "Validate commands and options",
   should "have either noRepeat or repeatLimit, but not both", ->
     # TODO(smblott) For this and each following test, is there a way to structure the tests such that the name
     # of the offending command appears in the output, if the test fails?
-    for command, options of Commands.availableCommands
+    for own command, options of Commands.availableCommands
       assert.isTrue not (options.noRepeat and options.repeatLimit)
 
   should "describe each command", ->
-    for command, options of Commands.availableCommands
+    for own command, options of Commands.availableCommands
       assert.equal 'string', typeof options.description
 
   should "define each command in each command group", ->
-    for group, commands of Commands.commandGroups
+    for own group, commands of Commands.commandGroups
       for command in commands
         assert.equal 'string', typeof command
         assert.isTrue Commands.availableCommands[command]
@@ -35,13 +35,13 @@ context "Validate commands and options",
   should "have valid commands for each default key mapping", ->
     count = Object.keys(Commands.keyToCommandRegistry).length
     assert.isTrue (0 < count)
-    for key, command of Commands.keyToCommandRegistry
+    for own key, command of Commands.keyToCommandRegistry
       assert.equal 'object', typeof command
       assert.isTrue Commands.availableCommands[command.command]
 
 context "Validate advanced commands",
   setup ->
-    @allCommands = [].concat.apply [], (commands for group, commands of Commands.commandGroups)
+    @allCommands = [].concat.apply [], (commands for own group, commands of Commands.commandGroups)
 
   should "include each advanced command in a command group", ->
     for command in Commands.advancedCommands

--- a/tests/unit_tests/test_helper.coffee
+++ b/tests/unit_tests/test_helper.coffee
@@ -1,5 +1,5 @@
 require("../shoulda.js/shoulda.js")
 global.extend = (hash1, hash2) ->
-  for key of hash2
+  for own key of hash2
     hash1[key] = hash2[key]
   hash1


### PR DESCRIPTION
This stops us traversing object prototypes when we're only interested in their direct properties. Implementation of the suggested code improvement in [this comment](https://github.com/philc/vimium/pull/1261#issuecomment-64189963).