### PR TITLE
Implement visual mode with mappable commands

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -103,7 +103,8 @@ Commands =
 
     for mode, defaultKeyMappings of defaultKeyMappingsForModes
       for key, command of defaultKeyMappings
-        @mapKeyToCommand(key, mode, command)
+        [commandName, args...] = command.split(/\s+/)
+        @mapKeyToCommand(key, mode, commandName, args)
 
   # An ordered listing of all available commands, grouped by type. This is the order they will
   # be shown in the help page.
@@ -279,6 +280,15 @@ defaultKeyMappingsForModes =
 
   visual:
     "<ESC>": "exitVisualMode"
+    "h": "VisualMode.extendFocus backward"
+    "l": "VisualMode.extendFocus forward"
+    "k": "VisualMode.extendFocus backward line"
+    "j": "VisualMode.extendFocus forward line"
+    "e": "VisualMode.extendFocus backward word"
+    "w": "VisualMode.extendFocus forward word"
+    "0": "VisualMode.extendFocus backward lineboundary"
+    "$": "VisualMode.extendFocus forward lineboundary"
+    "y": "VisualMode.yank"
 
 
 # This is a mapping of: commandIdentifier => [description, options].

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -379,6 +379,7 @@ commandDescriptionsForMode =
     "VisualMode.extendBack": ["Extend the current selection from the back"]
     "VisualMode.extendFocus": ["Extend the current selection from its endpoint"]
     "VisualMode.extendAnchor": ["Extend the current selection from its startpoint"]
+    "VisualMode.yank": ["Copy the currently selected text to the clipboard"]
     exitVisualMode: ["Exit visual mode", { noRepeat: true }]
 
 Commands.init()

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -375,6 +375,10 @@ commandDescriptionsForMode =
     "Marks.activateGotoMode": ["Go to a mark", { noRepeat: true }]
 
   visual:
+    "VisualMode.extendFront": ["Extend the current selection from the front"]
+    "VisualMode.extendBack": ["Extend the current selection from the back"]
+    "VisualMode.extendFocus": ["Extend the current selection from its endpoint"]
+    "VisualMode.extendAnchor": ["Extend the current selection from its startpoint"]
     exitVisualMode: ["Exit visual mode", { noRepeat: true }]
 
 Commands.init()

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -392,10 +392,10 @@ commandDescriptionsForMode =
     "Marks.activateGotoMode": ["Go to a mark", { noRepeat: true }]
 
   visual:
-    "VisualMode.extendFront": ["Extend the current selection from the front"]
-    "VisualMode.extendBack": ["Extend the current selection from the back"]
-    "VisualMode.extendFocus": ["Extend the current selection from its endpoint"]
-    "VisualMode.extendAnchor": ["Extend the current selection from its startpoint"]
+    "VisualMode.extendFront": ["Extend the current selection\\{ \\1} from the front\\{ by \\2}"]
+    "VisualMode.extendBack": ["Extend the current selection\\{ \\1} from the back\\{ by \\2}"]
+    "VisualMode.extendFocus": ["Extend the current selection\\{ \\1} from its endpoint\\{ by \\2}"]
+    "VisualMode.extendAnchor": ["Extend the current selection\\{ \\1} from its startpoint\\{ by \\2}"]
     "VisualMode.yank": ["Copy the currently selected text to the clipboard"]
     exitVisualMode: ["Exit visual mode", { noRepeat: true }]
 

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -131,7 +131,6 @@ Commands =
       "goUp",
       "goToRoot",
       "enterInsertMode",
-      "enterVisualMode",
       "focusInput",
       "LinkHints.activateMode",
       "LinkHints.activateModeToOpenInNewTab",
@@ -171,6 +170,14 @@ Commands =
       "moveTabRight"]
     misc:
       ["showHelp"]
+    visualMode: [
+      "enterVisualMode",
+      "exitVisualMode"
+      "VisualMode.extendFront",
+      "VisualMode.extendBack",
+      "VisualMode.extendFocus",
+      "VisualMode.extendAnchor",
+      "VisualMode.yank"]
 
   # Rarely used commands are not shown by default in the help dialog or in the README. The goal is to present
   # a focused, high-signal set of commands to the new and casual user. Only those truly hungry for more power

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -26,7 +26,7 @@ Commands =
       noRepeat: options.noRepeat
       repeatLimit: options.repeatLimit
 
-  mapKeyToCommand: (key, mode, command) ->
+  mapKeyToCommand: (key, mode, command, args) ->
     availableCommands = @availableCommandsForMode[mode] ?= {}
     unless availableCommands[command]
       console.log("#{command} doesn't exist for mode #{mode}!")
@@ -36,6 +36,7 @@ Commands =
     keyToCommandRegistry = @keyToCommandRegistries[mode] ?= {}
 
     keyToCommandRegistry[key] =
+      args: args
       command: command
       isBackgroundCommand: commandDetails.isBackgroundCommand
       passCountToFunction: commandDetails.passCountToFunction
@@ -79,14 +80,14 @@ Commands =
         [parseCommand, modes] = lineCommandToCommandAndModes[lineCommand] ? ["", []]
 
         if (parseCommand == "map")
-          continue if (splitLine.length != 3)
-          key = @normalizeKey(splitLine[1])
-          vimiumCommand = splitLine[2]
+          continue if (splitLine.length < 3)
+          [key, vimiumCommand, args...] = splitLine[1...]
+          key = @normalizeKey(key)
 
           for mode in modes
             continue unless @availableCommandsForMode[mode][vimiumCommand]
             console.log("Mapping #{key} to #{vimiumCommand} in #{mode} mode")
-            @mapKeyToCommand(key, mode, vimiumCommand)
+            @mapKeyToCommand(key, mode, vimiumCommand, args)
         else if (parseCommand == "unmap")
           continue if (splitLine.length != 2)
 

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -101,7 +101,7 @@ root.helpDialogHtml = (showUnboundCommands, showCommandNames, customTitle) ->
   dialogHtml = fetchFileContents("pages/help_dialog.html")
   for group of Commands.commandGroups
     dialogHtml = dialogHtml.replace("{{#{group}}}",
-        helpDialogHtmlForCommandGroup(group, commandsToKey, Commands.availableCommands,
+        helpDialogHtmlForCommandGroup(group, commandsToKey, Commands.availableCommandsForMode["normal"],
                                       showUnboundCommands, showCommandNames))
   dialogHtml = dialogHtml.replace("{{version}}", currentVersion)
   dialogHtml = dialogHtml.replace("{{title}}", customTitle || "Help")
@@ -147,7 +147,7 @@ getKeyToCommandRegistryRequest = (request, sender) ->
         passCountToFunction: commandDetails.passCountToFunction
         noRepeat: commandDetails.noRepeat
         repeatLimit: commandDetails.repeatLimit
-        description: Commands.availableCommands[commandDetails.command].description
+        description: Commands.availableCommandsForMode[mode][commandDetails.command].description
 
   name: "refreshKeyToCommandRegistry"
   keyToCommandRegistries: keyToCommandRegistries

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -94,14 +94,18 @@ saveHelpDialogSettings = (request) ->
 # This is called by options.coffee.
 root.helpDialogHtml = (showUnboundCommands, showCommandNames, customTitle) ->
   commandsToKey = {}
-  for key of Commands.keyToCommandRegistries.normal
-    command = Commands.keyToCommandRegistries.normal[key].command
-    commandsToKey[command] = (commandsToKey[command] || []).concat(key)
+  for mode, keyToCommandRegistry of Commands.keyToCommandRegistries
+    for key, {command} of keyToCommandRegistry
+      commandsToKey[command] = (commandsToKey[command] || []).concat(key)
 
   dialogHtml = fetchFileContents("pages/help_dialog.html")
+  availableCommands = {}
+  for mode, modedAvailableCommands of Commands.availableCommandsForMode
+    extend availableCommands, modedAvailableCommands
+
   for group of Commands.commandGroups
     dialogHtml = dialogHtml.replace("{{#{group}}}",
-        helpDialogHtmlForCommandGroup(group, commandsToKey, Commands.availableCommandsForMode["normal"],
+        helpDialogHtmlForCommandGroup(group, commandsToKey, availableCommands,
                                       showUnboundCommands, showCommandNames))
   dialogHtml = dialogHtml.replace("{{version}}", currentVersion)
   dialogHtml = dialogHtml.replace("{{title}}", customTitle || "Help")

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -502,6 +502,7 @@ portHandlers =
 
 sendRequestHandlers =
   executeBackgroundCommand: executeBackgroundCommand,
+  log: (request, sender) -> console.log "(tab #{sender.tab.id}, frame #{request.frameId}): #{request.data}"
   getKeyToCommandRegistry: getKeyToCommandRegistryRequest,
   getCurrentTabUrl: getCurrentTabUrl,
   openUrlInNewTab: openUrlInNewTab,

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -141,13 +141,9 @@ getKeyToCommandRegistryRequest = (request, sender) ->
   keyToCommandRegistries = {}
   for mode, keyToCommandRegistry of Commands.keyToCommandRegistries
     for key, commandDetails of keyToCommandRegistry
-      (keyToCommandRegistries[mode] ?= {})[key] =
-        command: commandDetails.command
-        isBackgroundCommand: commandDetails.isBackgroundCommand
-        passCountToFunction: commandDetails.passCountToFunction
-        noRepeat: commandDetails.noRepeat
-        repeatLimit: commandDetails.repeatLimit
-        description: Commands.availableCommandsForMode[mode][commandDetails.command].description
+      details = extend {}, commandDetails # Copy commandDetails by property
+      details.description = Commands.availableCommandsForMode[mode][commandDetails.command].description
+      (keyToCommandRegistries[mode] ?= {})[key] = details
 
   name: "refreshKeyToCommandRegistry"
   keyToCommandRegistries: keyToCommandRegistries

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -94,8 +94,8 @@ saveHelpDialogSettings = (request) ->
 # This is called by options.coffee.
 root.helpDialogHtml = (showUnboundCommands, showCommandNames, customTitle) ->
   commandsToKey = {}
-  for key of Commands.keyToCommandRegistry
-    command = Commands.keyToCommandRegistry[key].command
+  for key of Commands.keyToCommandRegistries.normal
+    command = Commands.keyToCommandRegistries.normal[key].command
     commandsToKey[command] = (commandsToKey[command] || []).concat(key)
 
   dialogHtml = fetchFileContents("pages/help_dialog.html")
@@ -138,18 +138,19 @@ fetchFileContents = (extensionFileName) ->
   req.responseText
 
 getKeyToCommandRegistryRequest = (request, sender) ->
-  keyToCommandRegistry = {}
-  for key, commandDetails of Commands.keyToCommandRegistry
-    keyToCommandRegistry[key] =
-      command: commandDetails.command
-      isBackgroundCommand: commandDetails.isBackgroundCommand
-      passCountToFunction: commandDetails.passCountToFunction
-      noRepeat: commandDetails.noRepeat
-      repeatLimit: commandDetails.repeatLimit
-      description: Commands.availableCommands[commandDetails.command].description
+  keyToCommandRegistries = {}
+  for mode, keyToCommandRegistry of Commands.keyToCommandRegistries
+    for key, commandDetails of keyToCommandRegistry
+      (keyToCommandRegistries[mode] ?= {})[key] =
+        command: commandDetails.command
+        isBackgroundCommand: commandDetails.isBackgroundCommand
+        passCountToFunction: commandDetails.passCountToFunction
+        noRepeat: commandDetails.noRepeat
+        repeatLimit: commandDetails.repeatLimit
+        description: Commands.availableCommands[commandDetails.command].description
 
   name: "refreshKeyToCommandRegistry"
-  keyToCommandRegistry: keyToCommandRegistry
+  keyToCommandRegistries: keyToCommandRegistries
 
 #
 # Opens the url in the current tab.

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -4,16 +4,8 @@ currentVersion = Utils.getCurrentVersion()
 
 tabQueue = {} # windowId -> Array
 tabInfoMap = {} # tabId -> object with various tab properties
-keyQueue = "" # Queue of keys typed
-validFirstKeys = {}
-singleKeyCommands = []
 focusedFrame = null
 frameIdsForTab = {}
-
-# Keys are either literal characters, or "named" - for example <a-b> (alt+b), <left> (left arrow) or <f12>
-# This regular expression captures two groups: the first is a named key, the second is the remainder of
-# the string.
-namedKeyRegex = /^(<(?:[amc]-.|(?:[amc]-)?[a-z0-9]{2,5})>)(.*)$/
 
 # Event handlers
 selectionChangedHandlers = []
@@ -145,13 +137,19 @@ fetchFileContents = (extensionFileName) ->
   req.send()
   req.responseText
 
-#
-# Returns the keys that can complete a valid command given the current key queue.
-#
-getCompletionKeysRequest = (request, keysToCheck = "") ->
-  name: "refreshCompletionKeys"
-  completionKeys: generateCompletionKeys(keysToCheck)
-  validFirstKeys: validFirstKeys
+getKeyToCommandRegistryRequest = (request, sender) ->
+  keyToCommandRegistry = {}
+  for key, commandDetails of Commands.keyToCommandRegistry
+    keyToCommandRegistry[key] =
+      command: commandDetails.command
+      isBackgroundCommand: commandDetails.isBackgroundCommand
+      passCountToFunction: commandDetails.passCountToFunction
+      noRepeat: commandDetails.noRepeat
+      repeatLimit: commandDetails.repeatLimit
+      description: Commands.availableCommands[commandDetails.command].description
+
+  name: "refreshKeyToCommandRegistry"
+  keyToCommandRegistry: keyToCommandRegistry
 
 #
 # Opens the url in the current tab.
@@ -444,138 +442,18 @@ updatePositionsAndWindowsForAllTabsInWindow = (windowId) ->
         openTabInfo.positionIndex = tab.index
         openTabInfo.windowId = tab.windowId)
 
-splitKeyIntoFirstAndSecond = (key) ->
-  if (key.search(namedKeyRegex) == 0)
-    { first: RegExp.$1, second: RegExp.$2 }
-  else
-    { first: key[0], second: key.slice(1) }
-
-getActualKeyStrokeLength = (key) ->
-  if (key.search(namedKeyRegex) == 0)
-    1 + getActualKeyStrokeLength(RegExp.$2)
-  else
-    key.length
-
-populateValidFirstKeys = ->
-  for key of Commands.keyToCommandRegistry
-    if (getActualKeyStrokeLength(key) == 2)
-      validFirstKeys[splitKeyIntoFirstAndSecond(key).first] = true
-
-populateSingleKeyCommands = ->
-  for key of Commands.keyToCommandRegistry
-    if (getActualKeyStrokeLength(key) == 1)
-      singleKeyCommands.push(key)
-
 # Invoked by options.coffee.
 root.refreshCompletionKeysAfterMappingSave = ->
-  validFirstKeys = {}
-  singleKeyCommands = []
+  sendRequestToAllTabs(getKeyToCommandRegistryRequest())
 
-  populateValidFirstKeys()
-  populateSingleKeyCommands()
-
-  sendRequestToAllTabs(getCompletionKeysRequest())
-
-# Generates a list of keys that can complete a valid command given the current key queue or the one passed in
-generateCompletionKeys = (keysToCheck) ->
-  splitHash = splitKeyQueue(keysToCheck || keyQueue)
-  command = splitHash.command
-  count = splitHash.count
-
-  completionKeys = singleKeyCommands.slice(0)
-
-  if (getActualKeyStrokeLength(command) == 1)
-    for key of Commands.keyToCommandRegistry
-      splitKey = splitKeyIntoFirstAndSecond(key)
-      if (splitKey.first == command)
-        completionKeys.push(splitKey.second)
-
-  completionKeys
-
-splitKeyQueue = (queue) ->
-  match = /([1-9][0-9]*)?(.*)/.exec(queue)
-  count = parseInt(match[1], 10)
-  command = match[2]
-
-  { count: count, command: command }
-
-handleKeyDown = (request, port) ->
-  key = request.keyChar
-  if (key == "<ESC>")
-    console.log("clearing keyQueue")
-    keyQueue = ""
+executeBackgroundCommand = (request) ->
+  {command, frameId, count, passCountToFunction, noRepeat} = request
+  if passCountToFunction
+    BackgroundCommands[command](count, frameId)
+  else if noRepeat
+    BackgroundCommands[command](frameId)
   else
-    console.log("checking keyQueue: [", keyQueue + key, "]")
-    keyQueue = checkKeyQueue(keyQueue + key, port.sender.tab.id, request.frameId)
-    console.log("new KeyQueue: " + keyQueue)
-  # Tell the content script whether there are keys in the queue.
-  # FIXME: There is a race condition here.  The behaviour in the content script depends upon whether this message gets
-  # back there before or after the next keystroke.
-  # That being said, I suspect there are other similar race conditions here, for example in checkKeyQueue().
-  # Steve (23 Aug, 14).
-  chrome.tabs.sendMessage(port.sender.tab.id,
-    name: "currentKeyQueue",
-    keyQueue: keyQueue)
-
-checkKeyQueue = (keysToCheck, tabId, frameId) ->
-  refreshedCompletionKeys = false
-  splitHash = splitKeyQueue(keysToCheck)
-  command = splitHash.command
-  count = splitHash.count
-
-  return keysToCheck if command.length == 0
-  count = 1 if isNaN(count)
-
-  if (Commands.keyToCommandRegistry[command])
-    registryEntry = Commands.keyToCommandRegistry[command]
-    runCommand = true
-
-    if registryEntry.noRepeat
-      count = 1
-    else if registryEntry.repeatLimit and count > registryEntry.repeatLimit
-      runCommand = confirm """
-        You have asked Vimium to perform #{count} repeats of the command:
-        #{Commands.availableCommands[registryEntry.command].description}
-
-        Are you sure you want to continue?
-      """
-
-    if runCommand
-      if not registryEntry.isBackgroundCommand
-        chrome.tabs.sendMessage(tabId,
-          name: "executePageCommand",
-          command: registryEntry.command,
-          frameId: frameId,
-          count: count,
-          passCountToFunction: registryEntry.passCountToFunction,
-          completionKeys: generateCompletionKeys(""))
-        refreshedCompletionKeys = true
-      else
-        if registryEntry.passCountToFunction
-          BackgroundCommands[registryEntry.command](count, frameId)
-        else if registryEntry.noRepeat
-          BackgroundCommands[registryEntry.command](frameId)
-        else
-          repeatFunction(BackgroundCommands[registryEntry.command], count, 0, frameId)
-
-    newKeyQueue = ""
-  else if (getActualKeyStrokeLength(command) > 1)
-    splitKey = splitKeyIntoFirstAndSecond(command)
-
-    # The second key might be a valid command by its self.
-    if (Commands.keyToCommandRegistry[splitKey.second])
-      newKeyQueue = checkKeyQueue(splitKey.second, tabId, frameId)
-    else
-      newKeyQueue = (if validFirstKeys[splitKey.second] then splitKey.second else "")
-  else
-    newKeyQueue = (if validFirstKeys[command] then count.toString() + command else "")
-
-  # If we haven't sent the completion keys piggybacked on executePageCommand,
-  # send them by themselves.
-  unless refreshedCompletionKeys
-    chrome.tabs.sendMessage(tabId, getCompletionKeysRequest(null, newKeyQueue), null)
-
-  newKeyQueue
+    repeatFunction(BackgroundCommands[command], count, 0, frameId)
 
 #
 # Message all tabs. Args should be the arguments hash used by the Chrome sendRequest API.
@@ -619,12 +497,12 @@ handleFrameFocused = (request, sender) ->
 
 # Port handler mapping
 portHandlers =
-  keyDown: handleKeyDown,
   settings: handleSettings,
   filterCompleter: filterCompleter
 
 sendRequestHandlers =
-  getCompletionKeys: getCompletionKeysRequest,
+  executeBackgroundCommand: executeBackgroundCommand,
+  getKeyToCommandRegistry: getKeyToCommandRegistryRequest,
   getCurrentTabUrl: getCurrentTabUrl,
   openUrlInNewTab: openUrlInNewTab,
   openUrlInIncognito: openUrlInIncognito,
@@ -654,8 +532,6 @@ Commands.clearKeyMappingsAndSetDefaults()
 if Settings.has("keyMappings")
   Commands.parseCustomKeyMappings(Settings.get("keyMappings"))
 
-populateValidFirstKeys()
-populateSingleKeyCommands()
 if shouldShowUpgradeMessage()
   sendRequestToAllTabs({ name: "showUpgradeNotification", version: currentVersion })
 

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -1,5 +1,4 @@
 KeyHandler =
-  port: undefined
   keyQueue: "" # Queue of keys typed
   validFirstKeys: {}
   singleKeyCommands: []
@@ -10,11 +9,7 @@ KeyHandler =
   # string.
   namedKeyRegex: /^(<(?:[amc]-.|(?:[amc]-)?[a-z0-9]{2,5})>)(.*)$/
 
-  setKeyPort: (@port) ->
-    @port.onmessage = (event) ->
-      KeyHandler.handleKeyDown event.data, @port
-
-  handleKeyDown: (request, port) ->
+  handleKeyDown: (request) ->
     key = request.keyChar
     if (key == "<ESC>")
       console.log("clearing keyQueue")

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -1,12 +1,6 @@
 KeyHandler =
   keyQueue: [] # Queue of keys typed
-  validFirstKeys: {}
   keyToCommandRegistry: {}
-
-  # Keys are either literal characters, or "named" - for example <a-b> (alt+b), <left> (left arrow) or <f12>.
-  # This regular expression captures two groups: the first is a named key, the second is the remainder of the
-  # string.
-  namedKeyRegex: /^(<(?:[amc]-.|(?:[amc]-)?[a-z0-9]{2,5})>)(.*)$/
 
   # Used to log our key handling progress to the background page.
   log: (data) ->
@@ -31,19 +25,7 @@ KeyHandler =
 
     keyHandled
 
-  splitKeyIntoFirstAndSecond: (key) ->
-    if (key.search(@namedKeyRegex) == 0)
-      { first: RegExp.$1, second: RegExp.$2 }
-    else
-      { first: key[0], second: key.slice(1) }
-
-  refreshKeyToCommandRegistry: (request) ->
-    @keyToCommandRegistry = request.keyToCommandRegistry
-    @populateValidFirstKeys()
-
-  populateValidFirstKeys: ->
-    for key of @keyToCommandRegistry
-      @validFirstKeys[@splitKeyIntoFirstAndSecond(key).first] = true
+  refreshKeyToCommandRegistry: (request) -> @keyToCommandRegistry = request.keyToCommandRegistry
 
   splitKeyQueue: (queue) ->
     l = queue.length

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -125,5 +125,8 @@ KeyHandler =
 
     @completionKeys
 
+  willHandleKey: (keyChar) ->
+    @completionKeys.indexOf(keyChar) != -1 or @validFirstKeys[keyChar] or /^[1-9]/.test(keyChar)
+
 root = exports ? window
 root.KeyHandler = KeyHandler

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -1,5 +1,6 @@
 KeyHandler =
   keyQueue: "" # Queue of keys typed
+  completionKeys: []
   validFirstKeys: {}
   singleKeyCommands: []
   keyToCommandRegistry: {}
@@ -27,14 +28,6 @@ KeyHandler =
       name: "currentKeyQueue",
       keyQueue: @keyQueue
 
-  #
-  # Returns the keys that can complete a valid command given the current key queue.
-  #
-  getCompletionKeysRequest: (keysToCheck = "") ->
-    name: "refreshCompletionKeys"
-    completionKeys: @generateCompletionKeys(keysToCheck)
-    validFirstKeys: @validFirstKeys
-
   splitKeyIntoFirstAndSecond: (key) ->
     if (key.search(@namedKeyRegex) == 0)
       { first: RegExp.$1, second: RegExp.$2 }
@@ -52,7 +45,7 @@ KeyHandler =
     @populateValidFirstKeys()
     @populateSingleKeyCommands()
 
-    requestHandlers.refreshCompletionKeys(@getCompletionKeysRequest())
+    @generateCompletionKeys("")
 
   populateValidFirstKeys: ->
     for key of @keyToCommandRegistry
@@ -121,7 +114,7 @@ KeyHandler =
       newKeyQueue = (if @validFirstKeys[command] then count.toString() + command else "")
 
     # Send the completion keys to vimium_frontend.coffee.
-    requestHandlers.refreshCompletionKeys(@getCompletionKeysRequest(newKeyQueue))
+    @generateCompletionKeys(newKeyQueue)
 
     newKeyQueue
 
@@ -131,15 +124,15 @@ KeyHandler =
     command = splitHash.command
     count = splitHash.count
 
-    completionKeys = @singleKeyCommands.slice(0)
+    @completionKeys = @singleKeyCommands.slice(0)
 
     if (@getActualKeyStrokeLength(command) == 1)
       for key of @keyToCommandRegistry
         splitKey = @splitKeyIntoFirstAndSecond(key)
         if (splitKey.first == command)
-          completionKeys.push(splitKey.second)
+          @completionKeys.push(splitKey.second)
 
-    completionKeys
+    @completionKeys
 
 root = exports ? window
 root.KeyHandler = KeyHandler

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -1,0 +1,157 @@
+KeyHandler =
+  port: undefined
+  keyQueue: "" # Queue of keys typed
+  validFirstKeys: {}
+  singleKeyCommands: []
+  keyToCommandRegistry: {}
+
+  # Keys are either literal characters, or "named" - for example <a-b> (alt+b), <left> (left arrow) or <f12>.
+  # This regular expression captures two groups: the first is a named key, the second is the remainder of the
+  # string.
+  namedKeyRegex: /^(<(?:[amc]-.|(?:[amc]-)?[a-z0-9]{2,5})>)(.*)$/
+
+  setKeyPort: (@port) ->
+    @port.onmessage = (event) ->
+      KeyHandler.handleKeyDown event.data, @port
+
+  handleKeyDown: (request, port) ->
+    key = request.keyChar
+    if (key == "<ESC>")
+      console.log("clearing keyQueue")
+      @keyQueue = ""
+    else
+      console.log("checking keyQueue: [", @keyQueue + key, "]")
+      @keyQueue = @checkKeyQueue(@keyQueue + key, request.frameId)
+      console.log("new KeyQueue: " + @keyQueue)
+    # Tell the content script whether there are keys in the queue.
+    # FIXME: There is a race condition here.  The behaviour in the content script depends upon whether this
+    # message gets back there before or after the next keystroke.
+    # That being said, I suspect there are other similar race conditions here, for example in
+    # checkKeyQueue().  Steve (23 Aug, 14).
+    requestHandlers.currentKeyQueue
+      name: "currentKeyQueue",
+      keyQueue: @keyQueue
+
+  #
+  # Returns the keys that can complete a valid command given the current key queue.
+  #
+  getCompletionKeysRequest: (keysToCheck = "") ->
+    name: "refreshCompletionKeys"
+    completionKeys: @generateCompletionKeys(keysToCheck)
+    validFirstKeys: @validFirstKeys
+
+  splitKeyIntoFirstAndSecond: (key) ->
+    if (key.search(@namedKeyRegex) == 0)
+      { first: RegExp.$1, second: RegExp.$2 }
+    else
+      { first: key[0], second: key.slice(1) }
+
+  getActualKeyStrokeLength: (key) ->
+    if (key.search(@namedKeyRegex) == 0)
+      1 + @getActualKeyStrokeLength(RegExp.$2)
+    else
+      key.length
+
+  refreshKeyToCommandRegistry: (request) ->
+    @keyToCommandRegistry = request.keyToCommandRegistry
+    @populateValidFirstKeys()
+    @populateSingleKeyCommands()
+
+    requestHandlers.refreshCompletionKeys(@getCompletionKeysRequest())
+
+  populateValidFirstKeys: ->
+    for key of @keyToCommandRegistry
+      if (@getActualKeyStrokeLength(key) == 2)
+        @validFirstKeys[@splitKeyIntoFirstAndSecond(key).first] = true
+
+  populateSingleKeyCommands: ->
+    for key of @keyToCommandRegistry
+      if (@getActualKeyStrokeLength(key) == 1)
+        @singleKeyCommands.push(key)
+
+  splitKeyQueue: (queue) ->
+    match = /([1-9][0-9]*)?(.*)/.exec(queue)
+    count = parseInt(match[1], 10)
+    command = match[2]
+
+    { count: count, command: command }
+
+  checkKeyQueue: (keysToCheck, frameId) ->
+    refreshedCompletionKeys = false
+    splitHash = @splitKeyQueue(keysToCheck)
+    command = splitHash.command
+    count = splitHash.count
+
+    return keysToCheck if command.length == 0
+    count = 1 if isNaN(count)
+
+    if (@keyToCommandRegistry[command])
+      registryEntry = @keyToCommandRegistry[command]
+      runCommand = true
+
+      if registryEntry.noRepeat
+        count = 1
+      else if registryEntry.repeatLimit and count > registryEntry.repeatLimit
+        runCommand = confirm """
+          You have asked Vimium to perform #{count} repeats of the command:
+          #{registryEntry.description}
+
+          Are you sure you want to continue?
+        """
+
+      if runCommand
+        if not registryEntry.isBackgroundCommand
+          requestHandlers.executePageCommand(
+            name: "executePageCommand",
+            command: registryEntry.command,
+            frameId: frameId,
+            count: count,
+            passCountToFunction: registryEntry.passCountToFunction,
+            completionKeys: @generateCompletionKeys(""))
+          refreshedCompletionKeys = true
+        else
+          chrome.runtime.sendMessage
+            handler: "executeBackgroundCommand",
+            command: registryEntry.command,
+            frameId: frameId,
+            count: count,
+            passCountToFunction: registryEntry.passCountToFunction,
+            noRepeat: registryEntry.noRepeat
+
+      newKeyQueue = ""
+    else if (@getActualKeyStrokeLength(command) > 1)
+      splitKey = @splitKeyIntoFirstAndSecond(command)
+
+      # The second key might be a valid command by its self.
+      if (@keyToCommandRegistry[splitKey.second])
+        newKeyQueue = @checkKeyQueue(splitKey.second, frameId)
+      else
+        newKeyQueue = (if @validFirstKeys[splitKey.second] then splitKey.second else "")
+    else
+      newKeyQueue = (if @validFirstKeys[command] then count.toString() + command else "")
+
+    # If we haven't sent the completion keys piggybacked on executePageCommand,
+    # send them by themselves.
+    unless refreshedCompletionKeys
+      requestHandlers.refreshCompletionKeys(@getCompletionKeysRequest(newKeyQueue))
+
+    newKeyQueue
+
+  # Generates a list of keys that can complete a valid command given the current key queue or the one passed in
+  generateCompletionKeys: (keysToCheck) ->
+    splitHash = @splitKeyQueue(keysToCheck || @keyQueue)
+    command = splitHash.command
+    count = splitHash.count
+
+    completionKeys = @singleKeyCommands.slice(0)
+
+    if (@getActualKeyStrokeLength(command) == 1)
+      for key of @keyToCommandRegistry
+        splitKey = @splitKeyIntoFirstAndSecond(key)
+        if (splitKey.first == command)
+          completionKeys.push(splitKey.second)
+
+    completionKeys
+
+root = exports ? window
+root.KeyHandler = KeyHandler

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -75,9 +75,9 @@ KeyHandler =
       if runCommand
         if not registryEntry.isBackgroundCommand
           if (registryEntry.passCountToFunction)
-            Utils.invokeCommandString(registryEntry.command, [count])
+            Utils.invokeCommandString(registryEntry.command, [count, registryEntry.args...])
           else
-            Utils.invokeCommandString(registryEntry.command) for i in [0...count]
+            Utils.invokeCommandString(registryEntry.command, registryEntry.args) for i in [0...count]
         else
           chrome.runtime.sendMessage
             handler: "executeBackgroundCommand",

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -19,14 +19,6 @@ KeyHandler =
       console.log("checking keyQueue: [", @keyQueue + key, "]")
       @keyQueue = @checkKeyQueue(@keyQueue + key, request.frameId)
       console.log("new KeyQueue: " + @keyQueue)
-    # Tell the content script whether there are keys in the queue.
-    # FIXME: There is a race condition here.  The behaviour in the content script depends upon whether this
-    # message gets back there before or after the next keystroke.
-    # That being said, I suspect there are other similar race conditions here, for example in
-    # checkKeyQueue().  Steve (23 Aug, 14).
-    requestHandlers.currentKeyQueue
-      name: "currentKeyQueue",
-      keyQueue: @keyQueue
 
   splitKeyIntoFirstAndSecond: (key) ->
     if (key.search(@namedKeyRegex) == 0)

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -36,12 +36,6 @@ KeyHandler =
     else
       { first: key[0], second: key.slice(1) }
 
-  getActualKeyStrokeLength: (key) ->
-    if (key.search(@namedKeyRegex) == 0)
-      1 + @getActualKeyStrokeLength(RegExp.$2)
-    else
-      key.length
-
   refreshKeyToCommandRegistry: (request) ->
     @keyToCommandRegistry = request.keyToCommandRegistry
     @populateValidFirstKeys()
@@ -102,9 +96,7 @@ KeyHandler =
             noRepeat: registryEntry.noRepeat
 
       newKeyQueue = ""
-    else if (@getActualKeyStrokeLength(command) > 1)
-      splitKey = @splitKeyIntoFirstAndSecond(command)
-
+    else if ((splitKey = @splitKeyIntoFirstAndSecond(command)).second != "")
       # The second key might be a valid command by its self.
       if (@keyToCommandRegistry[splitKey.second])
         keyHandled = @checkKeyQueue(splitKey.second, noAction)

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -21,7 +21,7 @@ KeyHandler =
       newKeyQueue = @keyQueue.concat([key])
       @log("checking keyQueue: [#{newKeyQueue.join("")}]") unless noAction
       keyHandled = @checkKeyQueue(newKeyQueue, noAction)
-      @log("new KeyQueue: " + @keyQueue) unless noAction
+      @log("new KeyQueue: " + @keyQueue.join("")) unless noAction
 
     keyHandled
 

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -67,7 +67,7 @@ KeyHandler =
       else if registryEntry.repeatLimit and count > registryEntry.repeatLimit
         runCommand = confirm """
           You have asked Vimium to perform #{count} repeats of the command:
-          #{registryEntry.description}
+          #{Utils.descriptionString registryEntry.description, registryEntry.args}
 
           Are you sure you want to continue?
         """

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -2,7 +2,6 @@ KeyHandler =
   keyQueue: "" # Queue of keys typed
   completionKeys: []
   validFirstKeys: {}
-  singleKeyCommands: []
   keyToCommandRegistry: {}
 
   # Keys are either literal characters, or "named" - for example <a-b> (alt+b), <left> (left arrow) or <f12>.
@@ -42,19 +41,12 @@ KeyHandler =
   refreshKeyToCommandRegistry: (request) ->
     @keyToCommandRegistry = request.keyToCommandRegistry
     @populateValidFirstKeys()
-    @populateSingleKeyCommands()
 
     @generateCompletionKeys("")
 
   populateValidFirstKeys: ->
     for key of @keyToCommandRegistry
-      if (@getActualKeyStrokeLength(key) == 2)
-        @validFirstKeys[@splitKeyIntoFirstAndSecond(key).first] = true
-
-  populateSingleKeyCommands: ->
-    for key of @keyToCommandRegistry
-      if (@getActualKeyStrokeLength(key) == 1)
-        @singleKeyCommands.push(key)
+      @validFirstKeys[@splitKeyIntoFirstAndSecond(key).first] = true
 
   splitKeyQueue: (queue) ->
     match = /([1-9][0-9]*)?(.*)/.exec(queue)
@@ -123,7 +115,7 @@ KeyHandler =
     command = splitHash.command
     count = splitHash.count
 
-    @completionKeys = @singleKeyCommands.slice(0)
+    @completionKeys = []
 
     if (@getActualKeyStrokeLength(command) == 1)
       for key of @keyToCommandRegistry

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -14,7 +14,7 @@ KeyHandler =
   # be activated by a keypress listener.
   handleKeyDown: (key, mode, noAction) ->
     keyHandled = false
-    if (key == "<ESC>")
+    if (key == "<ESC>" and not @keyToCommandRegistries[mode]?[key])
       @log("clearing keyQueue")
       @keyQueue = []
     else
@@ -94,7 +94,7 @@ KeyHandler =
       keyHandled = true
     else if commandQueue.length > 1
       commandQueue.shift()
-      keyHandled = @checkKeyQueue(commandQueue, noAction)
+      keyHandled = @checkKeyQueue(commandQueue, mode, noAction)
       newKeyQueue = @keyQueue
     else
       newKeyQueue = []

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -10,15 +10,22 @@ KeyHandler =
   # string.
   namedKeyRegex: /^(<(?:[amc]-.|(?:[amc]-)?[a-z0-9]{2,5})>)(.*)$/
 
+  # Used to log our key handling progress to the background page.
+  log: (data) ->
+    chrome.runtime.sendMessage
+      handler: "log"
+      data: data
+      frameId: frameId
+
   handleKeyDown: (request) ->
     key = request.keyChar
     if (key == "<ESC>")
-      console.log("clearing keyQueue")
+      @log("clearing keyQueue")
       @keyQueue = ""
     else
-      console.log("checking keyQueue: [", @keyQueue + key, "]")
+      @log("checking keyQueue: [#{@keyQueue + key}]")
       @keyQueue = @checkKeyQueue(@keyQueue + key, request.frameId)
-      console.log("new KeyQueue: " + @keyQueue)
+      @log("new KeyQueue: " + @keyQueue)
 
   splitKeyIntoFirstAndSecond: (key) ->
     if (key.search(@namedKeyRegex) == 0)

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -1,6 +1,5 @@
 KeyHandler =
   keyQueue: "" # Queue of keys typed
-  completionKeys: []
   validFirstKeys: {}
   keyToCommandRegistry: {}
 
@@ -46,8 +45,6 @@ KeyHandler =
   refreshKeyToCommandRegistry: (request) ->
     @keyToCommandRegistry = request.keyToCommandRegistry
     @populateValidFirstKeys()
-
-    @generateCompletionKeys("")
 
   populateValidFirstKeys: ->
     for key of @keyToCommandRegistry
@@ -127,30 +124,8 @@ KeyHandler =
         newKeyQueue = ""
         keyHandled = false
 
-    # Send the completion keys to vimium_frontend.coffee.
-    @generateCompletionKeys(newKeyQueue)
-
     @keyQueue = newKeyQueue unless noAction
     keyHandled
-
-  # Generates a list of keys that can complete a valid command given the current key queue or the one passed in
-  generateCompletionKeys: (keysToCheck) ->
-    splitHash = @splitKeyQueue(keysToCheck || @keyQueue)
-    command = splitHash.command
-    count = splitHash.count
-
-    @completionKeys = []
-
-    if (@getActualKeyStrokeLength(command) == 1)
-      for key of @keyToCommandRegistry
-        splitKey = @splitKeyIntoFirstAndSecond(key)
-        if (splitKey.first == command)
-          @completionKeys.push(splitKey.second)
-
-    @completionKeys
-
-  willHandleKey: (keyChar) ->
-    @completionKeys.indexOf(keyChar) != -1 or @validFirstKeys[keyChar] or /^[1-9]/.test(keyChar)
 
 root = exports ? window
 root.KeyHandler = KeyHandler

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -353,6 +353,8 @@ onKeypress = (event) ->
       else if (visualMode)
         if (KeyHandler.handleKeyDown(keyChar, "visual"))
           DomUtils.suppressEvent(event)
+        else
+          exitVisualMode()
       else if (!isInsertMode() && !findMode)
         if (isPassKey keyChar)
           return undefined
@@ -431,6 +433,8 @@ onKeydown = (event) ->
       if (KeyHandler.handleKeyDown(keyChar, "visual"))
         DomUtils.suppressEvent event
         handledKeydownEvents.push event
+      else
+        exitVisualMode()
 
 
   else if (!isInsertMode())

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -17,7 +17,6 @@ isShowingHelpDialog = false
 # are passed through to the underlying page.
 isEnabledForUrl = true
 passKeys = null
-keyQueue = null
 # The user's operating system.
 
 # The types in <input type="..."> that we consider for focusInput command. Right now this is recalculated in
@@ -114,7 +113,6 @@ initializePreDomReady = ->
     setScrollPosition: (request) -> setScrollPosition request.scrollX, request.scrollY
     getActiveState: -> { enabled: isEnabledForUrl, passKeys: passKeys }
     setState: setState
-    currentKeyQueue: (request) -> keyQueue = request.keyQueue
 
   chrome.runtime.onMessage.addListener (request, sender, sendResponse) ->
     # In the options page, we will receive requests from both content and background scripts. ignore those
@@ -322,7 +320,7 @@ extend window,
 # Keystrokes are *never* considered passKeys if the keyQueue is not empty.  So, for example, if 't' is a
 # passKey, then 'gt' and '99t' will neverthless be handled by vimium.
 isPassKey = ( keyChar ) ->
-  return !keyQueue and passKeys and 0 <= passKeys.indexOf(keyChar)
+  return !KeyHandler.keyQueue and passKeys and 0 <= passKeys.indexOf(keyChar)
 
 handledKeydownEvents = []
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -6,6 +6,7 @@
 window.handlerStack = new HandlerStack
 
 insertModeLock = null
+visualMode = false
 findMode = false
 findModeQuery = { rawQuery: "", matchCount: 0 }
 findModeQueryHasResults = false
@@ -539,6 +540,17 @@ isInsertMode = ->
   # the active element is contentEditable.
   document.activeElement and document.activeElement.isContentEditable and
     enterInsertModeWithoutShowingIndicator document.activeElement
+
+#
+# Enters visual mode and show an "Visual mode" message.
+#
+window.enterVisualMode = ->
+  visualMode = true
+  HUD.show("Visual mode")
+
+window.exitVisualMode = (target) ->
+  visualMode = false
+  HUD.hide()
 
 # should be called whenever rawQuery is modified.
 updateFindModeQuery = ->

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -350,6 +350,9 @@ onKeypress = (event) ->
       if (findMode)
         handleKeyCharForFindMode(keyChar)
         DomUtils.suppressEvent(event)
+      else if (visualMode)
+        if (KeyHandler.handleKeyDown(keyChar, "visual"))
+          DomUtils.suppressEvent(event)
       else if (!isInsertMode() && !findMode)
         if (isPassKey keyChar)
           return undefined
@@ -422,7 +425,15 @@ onKeydown = (event) ->
     DomUtils.suppressEvent event
     handledKeydownEvents.push event
 
-  else if (!isInsertMode() && !findMode)
+  else if (visualMode)
+    keyChar = "<ESC>" if (KeyboardUtils.isEscape(event))
+    if (keyChar)
+      if (KeyHandler.handleKeyDown(keyChar, "visual"))
+        DomUtils.suppressEvent event
+        handledKeydownEvents.push event
+
+
+  else if (!isInsertMode())
     keyChar = "<ESC>" if (KeyboardUtils.isEscape(event))
     if (keyChar)
       if (KeyHandler.handleKeyDown(keyChar, "normal"))

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -352,10 +352,8 @@ onKeypress = (event) ->
       else if (!isInsertMode() && !findMode)
         if (isPassKey keyChar)
           return undefined
-        if (KeyHandler.willHandleKey(keyChar))
+        if (KeyHandler.handleKeyDown({ keyChar:keyChar, frameId:frameId }))
           DomUtils.suppressEvent(event)
-
-        KeyHandler.handleKeyDown({ keyChar:keyChar, frameId:frameId })
 
 onKeydown = (event) ->
   return unless handlerStack.bubbleEvent('keydown', event)
@@ -424,15 +422,11 @@ onKeydown = (event) ->
     handledKeydownEvents.push event
 
   else if (!isInsertMode() && !findMode)
+    keyChar = "<ESC>" if (KeyboardUtils.isEscape(event))
     if (keyChar)
-      if (KeyHandler.willHandleKey(keyChar))
+      if (KeyHandler.handleKeyDown({ keyChar:keyChar, frameId:frameId }))
         DomUtils.suppressEvent event
         handledKeydownEvents.push event
-
-      KeyHandler.handleKeyDown({ keyChar:keyChar, frameId:frameId })
-
-    else if (KeyboardUtils.isEscape(event))
-      KeyHandler.handleKeyDown({ keyChar:"<ESC>", frameId:frameId })
 
     else if isPassKey KeyboardUtils.getKeyChar(event)
       return undefined

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -352,7 +352,7 @@ onKeypress = (event) ->
       else if (!isInsertMode() && !findMode)
         if (isPassKey keyChar)
           return undefined
-        if (KeyHandler.handleKeyDown(keyChar))
+        if (KeyHandler.handleKeyDown(keyChar, "normal"))
           DomUtils.suppressEvent(event)
 
 onKeydown = (event) ->
@@ -424,7 +424,7 @@ onKeydown = (event) ->
   else if (!isInsertMode() && !findMode)
     keyChar = "<ESC>" if (KeyboardUtils.isEscape(event))
     if (keyChar)
-      if (KeyHandler.handleKeyDown(keyChar))
+      if (KeyHandler.handleKeyDown(keyChar, "normal"))
         DomUtils.suppressEvent event
         handledKeydownEvents.push event
 
@@ -438,7 +438,8 @@ onKeydown = (event) ->
   # Subject to internationalization issues since we're using keyIdentifier instead of charCode (in keypress).
   #
   # TOOD(ilya): Revisit this. Not sure it's the absolute best approach.
-  if (keyChar == "" && !isInsertMode() && KeyHandler.handleKeyDown(KeyboardUtils.getKeyChar(event), true))
+  if (keyChar == "" && !isInsertMode() &&
+      KeyHandler.handleKeyDown(KeyboardUtils.getKeyChar(event), "normal", true))
     DomUtils.suppressPropagation(event)
     handledKeydownEvents.push event
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -12,7 +12,6 @@ findModeQuery = { rawQuery: "", matchCount: 0 }
 findModeQueryHasResults = false
 findModeAnchorNode = null
 isShowingHelpDialog = false
-keyPort = null
 # Users can disable Vimium on URL patterns via the settings page.  The following two variables
 # (isEnabledForUrl and passKeys) control Vimium's enabled/disabled behaviour.
 # "passKeys" are keys which would normally be handled by Vimium, but are disabled on this tab, and therefore
@@ -106,11 +105,6 @@ initializePreDomReady = ->
   checkIfEnabledForUrl()
 
   refreshCompletionKeys()
-
-  # Send the key to the key handler in the background page.
-  messageChannel = new MessageChannel()
-  KeyHandler.setKeyPort messageChannel.port1
-  keyPort = messageChannel.port2
 
   window.requestHandlers =
     hideUpgradeNotification: -> HUD.hideUpgradeNotification()
@@ -378,7 +372,7 @@ onKeypress = (event) ->
         if (currentCompletionKeys.indexOf(keyChar) != -1 or isValidFirstKey(keyChar))
           DomUtils.suppressEvent(event)
 
-        keyPort.postMessage({ keyChar:keyChar, frameId:frameId })
+        KeyHandler.handleKeyDown({ keyChar:keyChar, frameId:frameId })
 
 onKeydown = (event) ->
   return unless handlerStack.bubbleEvent('keydown', event)
@@ -452,10 +446,10 @@ onKeydown = (event) ->
         DomUtils.suppressEvent event
         handledKeydownEvents.push event
 
-      keyPort.postMessage({ keyChar:keyChar, frameId:frameId })
+      KeyHandler.handleKeyDown({ keyChar:keyChar, frameId:frameId })
 
     else if (KeyboardUtils.isEscape(event))
-      keyPort.postMessage({ keyChar:"<ESC>", frameId:frameId })
+      KeyHandler.handleKeyDown({ keyChar:"<ESC>", frameId:frameId })
 
     else if isPassKey KeyboardUtils.getKeyChar(event)
       return undefined

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -117,11 +117,11 @@ initializePreDomReady = ->
   chrome.runtime.onMessage.addListener (request, sender, sendResponse) ->
     # In the options page, we will receive requests from both content and background scripts. ignore those
     # from the former.
-    return if sender.tab and not sender.tab.url.startsWith 'chrome-extension://'
+    return if sender.tab and sender.tab.url.startsWith 'chrome-extension://'
     return unless isEnabledForUrl or request.name == 'getActiveState' or request.name == 'setState'
     # These requests are delivered to the options page, but there are no handlers there.
     return if request.handler == "registerFrame" or request.handler == "frameFocused"
-    sendResponse requestHandlers[request.name](request, sender)
+    sendResponse requestHandlers[request.name]?(request, sender)
     # Ensure the sendResponse callback is freed.
     false
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -116,7 +116,6 @@ initializePreDomReady = ->
     refreshKeyToCommandRegistry: KeyHandler.refreshKeyToCommandRegistry.bind(KeyHandler)
     getScrollPosition: -> scrollX: window.scrollX, scrollY: window.scrollY
     setScrollPosition: (request) -> setScrollPosition request.scrollX, request.scrollY
-    executePageCommand: executePageCommand
     getActiveState: -> { enabled: isEnabledForUrl, passKeys: passKeys }
     setState: setState
     currentKeyQueue: (request) -> keyQueue = request.keyQueue
@@ -203,16 +202,6 @@ enterInsertModeIfElementIsFocused = ->
     enterInsertModeWithoutShowingIndicator(document.activeElement)
 
 onDOMActivate = (event) -> handlerStack.bubbleEvent 'DOMActivate', event
-
-executePageCommand = (request) ->
-  return unless frameId == request.frameId
-
-  if (request.passCountToFunction)
-    Utils.invokeCommandString(request.command, [request.count])
-  else
-    Utils.invokeCommandString(request.command) for i in [0...request.count]
-
-  refreshCompletionKeys(request)
 
 setScrollPosition = (scrollX, scrollY) ->
   if (scrollX > 0 || scrollY > 0)

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -352,7 +352,7 @@ onKeypress = (event) ->
       else if (!isInsertMode() && !findMode)
         if (isPassKey keyChar)
           return undefined
-        if (KeyHandler.handleKeyDown({ keyChar:keyChar, frameId:frameId }))
+        if (KeyHandler.handleKeyDown(keyChar))
           DomUtils.suppressEvent(event)
 
 onKeydown = (event) ->
@@ -424,7 +424,7 @@ onKeydown = (event) ->
   else if (!isInsertMode() && !findMode)
     keyChar = "<ESC>" if (KeyboardUtils.isEscape(event))
     if (keyChar)
-      if (KeyHandler.handleKeyDown({ keyChar:keyChar, frameId:frameId }))
+      if (KeyHandler.handleKeyDown(keyChar))
         DomUtils.suppressEvent event
         handledKeydownEvents.push event
 
@@ -438,7 +438,7 @@ onKeydown = (event) ->
   # Subject to internationalization issues since we're using keyIdentifier instead of charCode (in keypress).
   #
   # TOOD(ilya): Revisit this. Not sure it's the absolute best approach.
-  if (keyChar == "" && !isInsertMode() && KeyHandler.willHandleKey(KeyboardUtils.getKeyChar(event)))
+  if (keyChar == "" && !isInsertMode() && KeyHandler.handleKeyDown(KeyboardUtils.getKeyChar(event), true))
     DomUtils.suppressPropagation(event)
     handledKeydownEvents.push event
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -352,7 +352,7 @@ onKeypress = (event) ->
       else if (!isInsertMode() && !findMode)
         if (isPassKey keyChar)
           return undefined
-        if (KeyHandler.completionKeys.indexOf(keyChar) != -1 or isValidFirstKey(keyChar))
+        if (KeyHandler.willHandleKey(keyChar))
           DomUtils.suppressEvent(event)
 
         KeyHandler.handleKeyDown({ keyChar:keyChar, frameId:frameId })
@@ -425,7 +425,7 @@ onKeydown = (event) ->
 
   else if (!isInsertMode() && !findMode)
     if (keyChar)
-      if (KeyHandler.completionKeys.indexOf(keyChar) != -1 or isValidFirstKey(keyChar))
+      if (KeyHandler.willHandleKey(keyChar))
         DomUtils.suppressEvent event
         handledKeydownEvents.push event
 
@@ -444,9 +444,7 @@ onKeydown = (event) ->
   # Subject to internationalization issues since we're using keyIdentifier instead of charCode (in keypress).
   #
   # TOOD(ilya): Revisit this. Not sure it's the absolute best approach.
-  if (keyChar == "" && !isInsertMode() &&
-     (KeyHandler.completionKeys.indexOf(KeyboardUtils.getKeyChar(event)) != -1 ||
-      isValidFirstKey(KeyboardUtils.getKeyChar(event))))
+  if (keyChar == "" && !isInsertMode() && KeyHandler.willHandleKey(KeyboardUtils.getKeyChar(event)))
     DomUtils.suppressPropagation(event)
     handledKeydownEvents.push event
 
@@ -480,9 +478,6 @@ checkIfEnabledForUrl = ->
 updateKeyToCommandRegistry = ->
   chrome.runtime.sendMessage { handler: "getKeyToCommandRegistry" }, (request) ->
     KeyHandler.refreshKeyToCommandRegistry request
-
-isValidFirstKey = (keyChar) ->
-  KeyHandler.validFirstKeys[keyChar] || /^[1-9]/.test(keyChar)
 
 onFocusCapturePhase = (event) ->
   if (isFocusable(event.target) && !findMode)

--- a/content_scripts/visual_mode.coffee
+++ b/content_scripts/visual_mode.coffee
@@ -54,20 +54,5 @@ VisualMode =
   yank: ->
     chrome.runtime.sendMessage {handler: "copyToClipboard", data: window.getSelection().toString()}
 
-directions = ["Forward", "Backward", "Left", "Right"]
-granularities = [
-  "Character", "Word", "Sentence", "Line", "Paragraph", "Lineboundary", "Sentenceboundary",
-  "Paragraphboundary", "Documentboundary"
-]
-types = ["Front", "Back", "Focus", "Anchor"]
-
-for direction in directions
-  for granularity in granularities
-    for type in types
-      fnName = "extend#{type}#{direction}By#{granularity}"
-      directionLower = direction.toLowerCase()
-      granularityLower = granularity.toLowerCase()
-      VisualMode[fnName] = VisualMode["extend#{type}"].bind(VisualMode, directionLower, granularityLower)
-
 root = exports ? window
 root.VisualMode = VisualMode

--- a/content_scripts/visual_mode.coffee
+++ b/content_scripts/visual_mode.coffee
@@ -7,20 +7,20 @@ VisualMode =
 
     anchorPoint.compareBoundaryPoints(Range.START_TO_START, focusPoint) >= 0
 
-  extendFront: (direction, granularity) ->
+  extendFront: (direction = "forward", granularity = "character") ->
     selectionForwards = @isSelectionForwards()
     @reverseSelection(selectionForwards) unless selectionForwards
     window.getSelection().modify "extend", direction, granularity
 
-  extendBack: (direction, granularity) ->
+  extendBack: (direction = "forward", granularity = "character") ->
     selectionForwards = @isSelectionForwards()
     @reverseSelection(selectionForwards) if selectionForwards
     window.getSelection().modify "extend", direction, granularity
 
-  extendFocus: (direction, granularity) ->
+  extendFocus: (direction = "forward", granularity = "character") ->
     window.getSelection().modify "extend", direction, granularity
 
-  extendAnchor: (direction, granularity) ->
+  extendAnchor: (direction = "forward", granularity = "character") ->
     @reverseSelection direction, granularity
     @extendFocus direction, granularity
     @reverseSelection direction, granularity

--- a/content_scripts/visual_mode.coffee
+++ b/content_scripts/visual_mode.coffee
@@ -11,19 +11,26 @@ VisualMode =
     selectionForwards = @isSelectionForwards()
     @reverseSelection(selectionForwards) unless selectionForwards
     window.getSelection().modify "extend", direction, granularity
+    @ensureNotEmpty direction
 
   extendBack: (direction = "forward", granularity = "character") ->
     selectionForwards = @isSelectionForwards()
     @reverseSelection(selectionForwards) if selectionForwards
     window.getSelection().modify "extend", direction, granularity
+    @ensureNotEmpty direction
 
   extendFocus: (direction = "forward", granularity = "character") ->
     window.getSelection().modify "extend", direction, granularity
+    @ensureNotEmpty direction
 
   extendAnchor: (direction = "forward", granularity = "character") ->
     @reverseSelection()
     @extendFocus direction, granularity
     @reverseSelection()
+
+  ensureNotEmpty: (direction = "forward") ->
+    selection = window.getSelection()
+    selection.modify("extend", direction, "character") if selection.isCollapsed
 
   reverseSelection: (forwards = @isSelectionForwards())->
     {anchorNode, anchorOffset, focusNode, focusOffset} = selection = window.getSelection()

--- a/content_scripts/visual_mode.coffee
+++ b/content_scripts/visual_mode.coffee
@@ -1,0 +1,52 @@
+VisualMode =
+  isSelectionForwards: ->
+    {anchorNode, anchorOffset, focusNode, focusOffset} = window.getSelection()
+
+    (anchorPoint = new Range()).setStart anchorNode, anchorOffset
+    (focusPoint = new Range()).setStart focusNode, focusOffset
+
+    anchorPoint.compareBoundaryPoints(Range.START_TO_START, focusPoint) >= 0
+
+  extendFront: (direction, granularity) ->
+    selectionForwards = @isSelectionForwards()
+    @reverseSelection(selectionForwards) unless selectionForwards
+    window.getSelection().modify "extend", direction, granularity
+
+  extendBack: (direction, granularity) ->
+    selectionForwards = @isSelectionForwards()
+    @reverseSelection(selectionForwards) if selectionForwards
+    window.getSelection().modify "extend", direction, granularity
+
+  extendFocus: (direction, granularity) ->
+    window.getSelection().modify "extend", direction, granularity
+
+  extendAnchor: (direction, granularity) ->
+    @reverseSelection direction, granularity
+    @extendFocus direction, granularity
+    @reverseSelection direction, granularity
+
+  reverseSelection: (forwards = @isSelectionForwards())->
+    selection = window.getSelection()
+    if forwards
+      selection.collapseToEnd()
+    else
+      selection.collapseToStart()
+    selection.extend anchorNode, anchorOffset
+
+directions = ["Forward", "Backward", "Left", "Right"]
+granularities = [
+  "Character", "Word", "Sentence", "Line", "Paragraph", "Lineboundary", "Sentenceboundary",
+  "Paragraphboundary", "Documentboundary"
+]
+types = ["Front", "Back", "Focus", "Anchor"]
+
+for direction in directions
+  for granularity in granularities
+    for type in types
+      fnName = "extend#{type}#{direction}By#{granularity}"
+      directionLower = direction.toLowerCase()
+      granularityLower = granularity.toLowerCase()
+      VisualMode[fnName] = VisualMode["extend#{type}"].bind(VisualMode, directionLower, granularityLower)
+
+root = exports ? window
+root.VisualMode = VisualMode

--- a/content_scripts/visual_mode.coffee
+++ b/content_scripts/visual_mode.coffee
@@ -5,7 +5,7 @@ VisualMode =
     (anchorPoint = new Range()).setStart anchorNode, anchorOffset
     (focusPoint = new Range()).setStart focusNode, focusOffset
 
-    anchorPoint.compareBoundaryPoints(Range.START_TO_START, focusPoint) >= 0
+    anchorPoint.compareBoundaryPoints(Range.START_TO_START, focusPoint) <= 0
 
   extendFront: (direction = "forward", granularity = "character") ->
     selectionForwards = @isSelectionForwards()
@@ -21,12 +21,12 @@ VisualMode =
     window.getSelection().modify "extend", direction, granularity
 
   extendAnchor: (direction = "forward", granularity = "character") ->
-    @reverseSelection direction, granularity
+    @reverseSelection()
     @extendFocus direction, granularity
-    @reverseSelection direction, granularity
+    @reverseSelection()
 
   reverseSelection: (forwards = @isSelectionForwards())->
-    selection = window.getSelection()
+    {anchorNode, anchorOffset, focusNode, focusOffset} = selection = window.getSelection()
     if forwards
       selection.collapseToEnd()
     else

--- a/content_scripts/visual_mode.coffee
+++ b/content_scripts/visual_mode.coffee
@@ -1,44 +1,55 @@
 VisualMode =
-  isSelectionForwards: ->
-    {anchorNode, anchorOffset, focusNode, focusOffset} = window.getSelection()
+  isSelectionForward: ->
+    if ["INPUT", "TEXTAREA"].indexOf(document.activeElement.tagName) > -1
+      document.activeElement.selectionDirection == "forward"
+    else
+      {anchorNode, anchorOffset, focusNode, focusOffset} = window.getSelection()
 
-    (anchorPoint = new Range()).setStart anchorNode, anchorOffset
-    (focusPoint = new Range()).setStart focusNode, focusOffset
+      (anchorPoint = new Range()).setStart anchorNode, anchorOffset
+      (focusPoint = new Range()).setStart focusNode, focusOffset
 
-    anchorPoint.compareBoundaryPoints(Range.START_TO_START, focusPoint) <= 0
+      anchorPoint.compareBoundaryPoints(Range.START_TO_START, focusPoint) <= 0
 
   extendFront: (direction = "forward", granularity = "character") ->
-    selectionForwards = @isSelectionForwards()
-    @reverseSelection(selectionForwards) unless selectionForwards
+    selectionForward = @isSelectionForward()
+    @reverseSelection(selectionForward) unless selectionForward
     window.getSelection().modify "extend", direction, granularity
     @ensureNotEmpty direction
 
   extendBack: (direction = "forward", granularity = "character") ->
-    selectionForwards = @isSelectionForwards()
-    @reverseSelection(selectionForwards) if selectionForwards
+    selectionForward = @isSelectionForward()
+    @reverseSelection(selectionForward) if selectionForward
     window.getSelection().modify "extend", direction, granularity
     @ensureNotEmpty direction
 
   extendFocus: (direction = "forward", granularity = "character") ->
     window.getSelection().modify "extend", direction, granularity
-    @ensureNotEmpty direction
 
   extendAnchor: (direction = "forward", granularity = "character") ->
     @reverseSelection()
     @extendFocus direction, granularity
     @reverseSelection()
+    @ensureNotEmpty direction
 
+  # If we move the 'anchor' of the current selection so that it overlaps the 'focus', it takes 2 operations
+  # to progress by one step.
   ensureNotEmpty: (direction = "forward") ->
-    selection = window.getSelection()
-    selection.modify("extend", direction, "character") if selection.isCollapsed
+    # There's already a cursor in input and textarea elements, so we don't have to ensure that there is a
+    # selection.
+    if ["INPUT", "TEXTAREA"].indexOf(document.activeElement.tagName) == -1
+      selection = window.getSelection()
+      selection.modify("extend", direction, "character") if selection.isCollapsed
 
-  reverseSelection: (forwards = @isSelectionForwards())->
-    {anchorNode, anchorOffset, focusNode, focusOffset} = selection = window.getSelection()
-    if forwards
-      selection.collapseToEnd()
+  reverseSelection: (forward = @isSelectionForward())->
+    if ["INPUT", "TEXTAREA"].indexOf(document.activeElement.tagName) > -1
+      document.activeElement.selectionDirection = if forward then "backward" else "forward"
     else
-      selection.collapseToStart()
-    selection.extend anchorNode, anchorOffset
+      {anchorNode, anchorOffset, focusNode, focusOffset} = selection = window.getSelection()
+      if forward
+        selection.collapseToEnd()
+      else
+        selection.collapseToStart()
+      selection.extend anchorNode, anchorOffset
 
 directions = ["Forward", "Backward", "Left", "Right"]
 granularities = [

--- a/content_scripts/visual_mode.coffee
+++ b/content_scripts/visual_mode.coffee
@@ -51,6 +51,9 @@ VisualMode =
         selection.collapseToStart()
       selection.extend anchorNode, anchorOffset
 
+  yank: ->
+    chrome.runtime.sendMessage {handler: "copyToClipboard", data: window.getSelection().toString()}
+
 directions = ["Forward", "Backward", "Left", "Right"]
 granularities = [
   "Character", "Word", "Sentence", "Line", "Paragraph", "Lineboundary", "Sentenceboundary",

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -136,6 +136,15 @@ Utils =
   # locale-sensitive uppercase detection
   hasUpperCase: (s) -> s.toLowerCase() != s
 
+  # Deletes all but the first n \\{...} blocks when there are n elements of args, and replaces every \\x with
+  # the value of the x-th argument.
+  descriptionString: (str, args) ->
+    n = args.length
+    str = str.replace /\\\{([^}]+)\}/g, (_, p1) -> if n-- > 0 then p1 else ""
+    for arg, i in args by -1 # Loop backwards to avoid partially replacing eg. \11 with the first argument.
+      str = str.replace(new RegExp("\\\\"+(i+1), "g"), arg)
+    str
+
 # This creates a new function out of an existing function, where the new function takes fewer arguments. This
 # allows us to pass around functions instead of functions + a partial list of arguments.
 Function::curry = ->

--- a/manifest.json
+++ b/manifest.json
@@ -41,6 +41,7 @@
              "content_scripts/vomnibar.js",
              "content_scripts/scroller.js",
              "content_scripts/marks.js",
+             "content_scripts/visual_mode.js",
              "content_scripts/key_handling.js",
              "content_scripts/vimium_frontend.js"
             ],

--- a/manifest.json
+++ b/manifest.json
@@ -41,6 +41,7 @@
              "content_scripts/vomnibar.js",
              "content_scripts/scroller.js",
              "content_scripts/marks.js",
+             "content_scripts/key_handling.js",
              "content_scripts/vimium_frontend.js"
             ],
       "css": ["content_scripts/vimium.css"],

--- a/pages/help_dialog.html
+++ b/pages/help_dialog.html
@@ -28,6 +28,8 @@
       {{tabManipulation}}
       <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Miscellaneous</td></tr>
       {{misc}}
+      <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Visual Mode</td></tr>
+      {{visualMode}}
       </tbody>
     </table>
   </div>

--- a/tests/dom_tests/dom_tests.html
+++ b/tests/dom_tests/dom_tests.html
@@ -37,6 +37,7 @@
     <script type="text/javascript" src="../../content_scripts/link_hints.js"></script>
     <script type="text/javascript" src="../../content_scripts/vomnibar.js"></script>
     <script type="text/javascript" src="../../content_scripts/scroller.js"></script>
+    <script type="text/javascript" src="../../content_scripts/key_handling.js"></script>
     <script type="text/javascript" src="../../content_scripts/vimium_frontend.js"></script>
 
     <script type="text/javascript" src="../shoulda.js/shoulda.js"></script>

--- a/tests/unit_tests/commands_test.coffee
+++ b/tests/unit_tests/commands_test.coffee
@@ -10,34 +10,41 @@ context "Key mappings",
     assert.equal (Commands.normalizeKey '<F12>'), '<f12>'
     assert.equal (Commands.normalizeKey '<C-F12>'), '<c-f12>'
 
+availableCommands = null
+
 context "Validate commands and options",
+  setup ->
+    availableCommands = {}
+    for mode, modedAvailableCommands of Commands.availableCommandsForMode
+      extend availableCommands, modedAvailableCommands
+
   should "have either noRepeat or repeatLimit, but not both", ->
     # TODO(smblott) For this and each following test, is there a way to structure the tests such that the name
     # of the offending command appears in the output, if the test fails?
-    for command, options of Commands.availableCommands
-      assert.isTrue not (options.noRepeat and options.repeatLimit)
+    for mode, availableCommands of Commands.availableCommandsForMode
+      for command, options of availableCommands
+        assert.isTrue not (options.noRepeat and options.repeatLimit)
 
   should "describe each command", ->
-    for command, options of Commands.availableCommands
-      assert.equal 'string', typeof options.description
+    for mode, availableCommands of Commands.availableCommandsForMode
+      for command, options of availableCommands
+        assert.equal 'string', typeof options.description
 
   should "define each command in each command group", ->
     for group, commands of Commands.commandGroups
       for command in commands
         assert.equal 'string', typeof command
-        assert.isTrue Commands.availableCommands[command]
+        assert.isTrue availableCommands[command]
 
   should "have valid commands for each advanced command", ->
     for command in Commands.advancedCommands
       assert.equal 'string', typeof command
-      assert.isTrue Commands.availableCommands[command]
+      assert.isTrue availableCommands[command]
 
   should "have valid commands for each default key mapping", ->
-    count = Object.keys(Commands.keyToCommandRegistry).length
-    assert.isTrue (0 < count)
     for key, command of Commands.keyToCommandRegistry
       assert.equal 'object', typeof command
-      assert.isTrue Commands.availableCommands[command.command]
+      assert.isTrue availableCommands[command.command]
 
 context "Validate advanced commands",
   setup ->


### PR DESCRIPTION
This PR is a continuation of PR #1275. It implements moded key bindings, and then sets up commands to implement visual mode. This fixes #61.

The visual mode commands take 2 arguments, `direction` and `granularity`, which are the same as the 2nd and 3rd arguments to [`Selection.modify`](https://developer.mozilla.org/en-US/docs/Web/API/Selection.modify):

> **direction**
The direction in which to adjust the current selection. You can specify "forward" or "backward" to adjust in the appropriate direction based on the language at the selection point. If you want to adjust in a specific direction, you can specify "left" or "right".
> **granularity**
The distance to adjust the current selection or cursor position. You can move by "character", "word", "sentence", "line", "paragraph", "lineboundary", "sentenceboundary", "paragraphboundary", or "documentboundary".