### PR TITLE
Only consider fullscreen elements' children for link hints

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -141,12 +141,7 @@ LinkHints =
   # of digits needed to enumerate all of the links on screen.
   #
   getVisibleClickableElements: ->
-    # If we are fullscreen, only consider elements contained in the fullscreen element.
-    resultType = XPathResult.ORDERED_NODE_SNAPSHOT_TYPE
-    resultSet = if document.webkitIsFullScreen
-      DomUtils.evaluateXPath(@clickableElementsXPath, resultType, document.webkitFullscreenElement)
-    else
-      DomUtils.evaluateXPath(@clickableElementsXPath, resultType)
+    resultSet = DomUtils.evaluateXPath(@clickableElementsXPath, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE)
 
     visibleElements = []
 

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -36,7 +36,13 @@ DomUtils =
       xpath.push(".//" + element, ".//xhtml:" + element)
     xpath.join(" | ")
 
-  evaluateXPath: (xpath, resultType, contextNode = document.documentElement) ->
+  # Evaluates an XPath on the whole document, or on the contents of the fullscreen element if an element is
+  # fullscreen.
+  evaluateXPath: (xpath, resultType) ->
+    contextNode = if document.webkitIsFullScreen
+      document.webkitFullscreenElement
+    else
+      document.documentElement
     namespaceResolver = (namespace) ->
       if (namespace == "xhtml") then "http://www.w3.org/1999/xhtml" else null
     document.evaluate(xpath, contextNode, namespaceResolver, resultType, null)


### PR DESCRIPTION
This PR stops us from showing link hints for elements concealed by fullscreening when an element is made fullscreen.

Fullscreen youtube videos are the best example of this; it's useful to be able to click the play/pause and fullscreen buttons, but we also show a lot of link hints for links on the underlying page, which we can't see.
