### PR TITLE
Pressing Shift cancels OpenLinkMode on Linux

### DIFF
--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -33,10 +33,12 @@ KeyboardUtils =
   getKeyChar: (event) ->
     keyIdentifier = event.keyIdentifier
 
-    # On Linux, the keyIdentifier for Shift key is not "Shift", but a "U+" code.
-    # See this for details: https://bugs.webkit.org/show_bug.cgi?id=139430
-    if (@platform == "Linux" && event.keyCode == keyCodes.shiftKey)
-      keyIdentifier = "Shift"
+    # On Linux (and probably Mac), the keyIdentifier for control keys is a "U+" code, but should be textual.
+    # Webkit bug: https://bugs.webkit.org/show_bug.cgi?id=139429
+    # Chromium bug: https://code.google.com/p/chromium/issues/detail?id=362551
+    keyIdentifiersToFix = { 16: "Shift", 17: "Ctrl", 18: "Alt" }
+    if (@platform != "Windows" && event.keyCode of keyIdentifiersToFix)
+      keyIdentifier = keyIdentifiersToFix[event.keyCode]
 
     # Not a letter
     if (keyIdentifier.slice(0, 2) != "U+")


### PR DESCRIPTION
Hello,

My usual workflow is the following:
1. Press `f` to enter OpenLinkMode;
2. Locate the key of the link I want to open (let it be `E` for example);
3. Decide if I want to open it in the current or in a new tab;
4. If in the current tab, hit `E`;
5. If in the new tab, hit `Shift+E`.

On Windows it works fine for me. However, on Linux step 5 is broken: as soon as I press `Shift`, OpenLinkMode is cancelled.

This happens because on Windows the `keyIdentifier` of keydown event equals to `"Shift"`, while on Linux it equals to `"U+00A0"` (for LShift) or `"U+00A1"` (for RShift).

I created a [bug for Webkit](http), because I believe your code is correct: key identifiers should be textual according to [W3C spec](http://www.w3.org/TR/2006/WD-DOM-Level-3-Events-20060413/keyset.html#KeySet-Set-h2) (at least in a way I understand this document :smile:).

But I don't feel like waiting for this bug to be resolved, it is very annoying!
That's why I propose this pull request as a simple workaround.

In a long-term, I think you should consider making your code `event.keyIdentifier`-agnostic, because I can see this is not the first patch for it. Unfortunately, I don't have time to help with that right now.

So anyway, please have a look and let me know if it makes sense and/or if you want additional details.

Platform: Kubuntu 14.10, Google Chrome 39.0.2171.71, Webkit 537.36
