### PR TITLE
Remove default binding for LinkHints.activateModeToDownloadLink.

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -207,8 +207,6 @@ defaultKeyMappings =
   "F":     "LinkHints.activateModeToOpenInNewTab"
   "<a-f>": "LinkHints.activateModeWithQueue"
 
-  "af": "LinkHints.activateModeToDownloadLink"
-
   "/": "enterFindMode"
   "n": "performFind"
   "N": "performBackwardsFind"


### PR DESCRIPTION
`LinkHints.activateModeToDownloadLink` is newly-added, and hasn't been in a release before.  It's an advanced command, and it's not clear it warrants a default binding.

@philc, @mrmr1993.  I'd merge this before release.  What do you guys think?
