### PR TITLE
Allow open popups from bookmarklets. Fix #968.

### DIFF
--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -229,15 +229,11 @@ extend BackgroundCompleter,
   completionActions:
     navigateToUrl: (url, openInNewTab) ->
       # If the URL is a bookmarklet prefixed with javascript:, we shouldn't open that in a new tab.
-      if url.startsWith "javascript:"
-        script = document.createElement 'script'
-        script.textContent = decodeURIComponent(url["javascript:".length..])
-        (document.head || document.documentElement).appendChild script
-      else
-        chrome.runtime.sendMessage(
-          handler: if openInNewTab then "openUrlInNewTab" else "openUrlInCurrentTab"
-          url: url,
-          selected: openInNewTab)
+      openInNewTab = false if url.startsWith("javascript:")
+      chrome.runtime.sendMessage(
+        handler: if openInNewTab then "openUrlInNewTab" else "openUrlInCurrentTab"
+        url: url,
+        selected: openInNewTab)
 
     switchToTab: (tabId) -> chrome.runtime.sendMessage({ handler: "selectSpecificTab", id: tabId })
 

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -26,7 +26,7 @@ Utils =
     -> id += 1
 
   hasChromePrefix: do ->
-    chromePrefixes = [ "about:", "view-source:", "extension:", "chrome-extension:", "data:" ]
+    chromePrefixes = [ "about:", "view-source:", "extension:", "chrome-extension:", "data:", "javascript:" ]
     (url) ->
       if 0 < url.indexOf ":"
         for prefix in chromePrefixes


### PR DESCRIPTION
Use the `openUrlInCurrentTab` message to open bookmarklets so they are opened
via `chrome.tabs.update` instead of an injected script element. This allows
bookmarklets to open popups.

This is a rebase of PR #981 onto the current master. It fixes #968.
