### PR TITLE
Move key handling to the frontend

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -508,6 +508,7 @@ portHandlers =
 
 sendRequestHandlers =
   executeBackgroundCommand: executeBackgroundCommand
+  log: (request, sender) -> console.log "(tab #{sender.tab.id}, frame #{request.frameId}): #{request.data}"
   getKeyToCommandRegistry: getKeyToCommandRegistryRequest
   getCurrentTabUrl: getCurrentTabUrl
   openUrlInNewTab: openUrlInNewTab

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -1,5 +1,4 @@
 KeyHandler =
-  port: undefined
   keyQueue: "" # Queue of keys typed
   validFirstKeys: {}
   singleKeyCommands: []
@@ -10,11 +9,7 @@ KeyHandler =
   # string.
   namedKeyRegex: /^(<(?:[amc]-.|(?:[amc]-)?[a-z0-9]{2,5})>)(.*)$/
 
-  setKeyPort: (@port) ->
-    @port.onmessage = (event) ->
-      KeyHandler.handleKeyDown event.data, @port
-
-  handleKeyDown: (request, port) ->
+  handleKeyDown: (request) ->
     key = request.keyChar
     if (key == "<ESC>")
       console.log("clearing keyQueue")

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -1,12 +1,6 @@
 KeyHandler =
   keyQueue: [] # Queue of keys typed
-  validFirstKeys: {}
   keyToCommandRegistry: {}
-
-  # Keys are either literal characters, or "named" - for example <a-b> (alt+b), <left> (left arrow) or <f12>.
-  # This regular expression captures two groups: the first is a named key, the second is the remainder of the
-  # string.
-  namedKeyRegex: /^(<(?:[amc]-.|(?:[amc]-)?[a-z0-9]{2,5})>)(.*)$/
 
   # Used to log our key handling progress to the background page.
   log: (data) ->
@@ -31,19 +25,7 @@ KeyHandler =
 
     keyHandled
 
-  splitKeyIntoFirstAndSecond: (key) ->
-    if (key.search(@namedKeyRegex) == 0)
-      { first: RegExp.$1, second: RegExp.$2 }
-    else
-      { first: key[0], second: key.slice(1) }
-
-  refreshKeyToCommandRegistry: (request) ->
-    @keyToCommandRegistry = request.keyToCommandRegistry
-    @populateValidFirstKeys()
-
-  populateValidFirstKeys: ->
-    for key of @keyToCommandRegistry
-      @validFirstKeys[@splitKeyIntoFirstAndSecond(key).first] = true
+  refreshKeyToCommandRegistry: (request) -> @keyToCommandRegistry = request.keyToCommandRegistry
 
   splitKeyQueue: (queue) ->
     l = queue.length

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -125,5 +125,8 @@ KeyHandler =
 
     @completionKeys
 
+  willHandleKey: (keyChar) ->
+    @completionKeys.indexOf(keyChar) != -1 or @validFirstKeys[keyChar] or /^[1-9]/.test(keyChar)
+
 root = exports ? window
 root.KeyHandler = KeyHandler

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -1,5 +1,6 @@
 KeyHandler =
   keyQueue: "" # Queue of keys typed
+  completionKeys: []
   validFirstKeys: {}
   singleKeyCommands: []
   keyToCommandRegistry: {}
@@ -27,14 +28,6 @@ KeyHandler =
       name: "currentKeyQueue",
       keyQueue: @keyQueue
 
-  #
-  # Returns the keys that can complete a valid command given the current key queue.
-  #
-  getCompletionKeysRequest: (keysToCheck = "") ->
-    name: "refreshCompletionKeys"
-    completionKeys: @generateCompletionKeys(keysToCheck)
-    validFirstKeys: @validFirstKeys
-
   splitKeyIntoFirstAndSecond: (key) ->
     if (key.search(@namedKeyRegex) == 0)
       { first: RegExp.$1, second: RegExp.$2 }
@@ -52,7 +45,7 @@ KeyHandler =
     @populateValidFirstKeys()
     @populateSingleKeyCommands()
 
-    requestHandlers.refreshCompletionKeys(@getCompletionKeysRequest())
+    @generateCompletionKeys("")
 
   populateValidFirstKeys: ->
     for key of @keyToCommandRegistry
@@ -121,7 +114,7 @@ KeyHandler =
       newKeyQueue = (if @validFirstKeys[command] then count.toString() + command else "")
 
     # Send the completion keys to vimium_frontend.coffee.
-    requestHandlers.refreshCompletionKeys(@getCompletionKeysRequest(newKeyQueue))
+    @generateCompletionKeys(newKeyQueue)
 
     newKeyQueue
 
@@ -131,15 +124,15 @@ KeyHandler =
     command = splitHash.command
     count = splitHash.count
 
-    completionKeys = @singleKeyCommands.slice(0)
+    @completionKeys = @singleKeyCommands.slice(0)
 
     if (@getActualKeyStrokeLength(command) == 1)
       for key of @keyToCommandRegistry
         splitKey = @splitKeyIntoFirstAndSecond(key)
         if (splitKey.first == command)
-          completionKeys.push(splitKey.second)
+          @completionKeys.push(splitKey.second)
 
-    completionKeys
+    @completionKeys
 
 root = exports ? window
 root.KeyHandler = KeyHandler

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -1,0 +1,157 @@
+KeyHandler =
+  port: undefined
+  keyQueue: "" # Queue of keys typed
+  validFirstKeys: {}
+  singleKeyCommands: []
+  keyToCommandRegistry: {}
+
+  # Keys are either literal characters, or "named" - for example <a-b> (alt+b), <left> (left arrow) or <f12>.
+  # This regular expression captures two groups: the first is a named key, the second is the remainder of the
+  # string.
+  namedKeyRegex: /^(<(?:[amc]-.|(?:[amc]-)?[a-z0-9]{2,5})>)(.*)$/
+
+  setKeyPort: (@port) ->
+    @port.onmessage = (event) ->
+      KeyHandler.handleKeyDown event.data, @port
+
+  handleKeyDown: (request, port) ->
+    key = request.keyChar
+    if (key == "<ESC>")
+      console.log("clearing keyQueue")
+      @keyQueue = ""
+    else
+      console.log("checking keyQueue: [", @keyQueue + key, "]")
+      @keyQueue = @checkKeyQueue(@keyQueue + key, request.frameId)
+      console.log("new KeyQueue: " + @keyQueue)
+    # Tell the content script whether there are keys in the queue.
+    # FIXME: There is a race condition here.  The behaviour in the content script depends upon whether this
+    # message gets back there before or after the next keystroke.
+    # That being said, I suspect there are other similar race conditions here, for example in
+    # checkKeyQueue().  Steve (23 Aug, 14).
+    requestHandlers.currentKeyQueue
+      name: "currentKeyQueue",
+      keyQueue: @keyQueue
+
+  #
+  # Returns the keys that can complete a valid command given the current key queue.
+  #
+  getCompletionKeysRequest: (keysToCheck = "") ->
+    name: "refreshCompletionKeys"
+    completionKeys: @generateCompletionKeys(keysToCheck)
+    validFirstKeys: @validFirstKeys
+
+  splitKeyIntoFirstAndSecond: (key) ->
+    if (key.search(@namedKeyRegex) == 0)
+      { first: RegExp.$1, second: RegExp.$2 }
+    else
+      { first: key[0], second: key.slice(1) }
+
+  getActualKeyStrokeLength: (key) ->
+    if (key.search(@namedKeyRegex) == 0)
+      1 + @getActualKeyStrokeLength(RegExp.$2)
+    else
+      key.length
+
+  refreshKeyToCommandRegistry: (request) ->
+    @keyToCommandRegistry = request.keyToCommandRegistry
+    @populateValidFirstKeys()
+    @populateSingleKeyCommands()
+
+    requestHandlers.refreshCompletionKeys(@getCompletionKeysRequest())
+
+  populateValidFirstKeys: ->
+    for key of @keyToCommandRegistry
+      if (@getActualKeyStrokeLength(key) == 2)
+        @validFirstKeys[@splitKeyIntoFirstAndSecond(key).first] = true
+
+  populateSingleKeyCommands: ->
+    for key of @keyToCommandRegistry
+      if (@getActualKeyStrokeLength(key) == 1)
+        @singleKeyCommands.push(key)
+
+  splitKeyQueue: (queue) ->
+    match = /([1-9][0-9]*)?(.*)/.exec(queue)
+    count = parseInt(match[1], 10)
+    command = match[2]
+
+    { count: count, command: command }
+
+  checkKeyQueue: (keysToCheck, frameId) ->
+    refreshedCompletionKeys = false
+    splitHash = @splitKeyQueue(keysToCheck)
+    command = splitHash.command
+    count = splitHash.count
+
+    return keysToCheck if command.length == 0
+    count = 1 if isNaN(count)
+
+    if (@keyToCommandRegistry[command])
+      registryEntry = @keyToCommandRegistry[command]
+      runCommand = true
+
+      if registryEntry.noRepeat
+        count = 1
+      else if registryEntry.repeatLimit and count > registryEntry.repeatLimit
+        runCommand = confirm """
+          You have asked Vimium to perform #{count} repeats of the command:
+          #{registryEntry.description}
+
+          Are you sure you want to continue?
+        """
+
+      if runCommand
+        if not registryEntry.isBackgroundCommand
+          requestHandlers.executePageCommand(
+            name: "executePageCommand",
+            command: registryEntry.command,
+            frameId: frameId,
+            count: count,
+            passCountToFunction: registryEntry.passCountToFunction,
+            completionKeys: @generateCompletionKeys(""))
+          refreshedCompletionKeys = true
+        else
+          chrome.runtime.sendMessage
+            handler: "executeBackgroundCommand",
+            command: registryEntry.command,
+            frameId: frameId,
+            count: count,
+            passCountToFunction: registryEntry.passCountToFunction,
+            noRepeat: registryEntry.noRepeat
+
+      newKeyQueue = ""
+    else if (@getActualKeyStrokeLength(command) > 1)
+      splitKey = @splitKeyIntoFirstAndSecond(command)
+
+      # The second key might be a valid command by its self.
+      if (@keyToCommandRegistry[splitKey.second])
+        newKeyQueue = @checkKeyQueue(splitKey.second, frameId)
+      else
+        newKeyQueue = (if @validFirstKeys[splitKey.second] then splitKey.second else "")
+    else
+      newKeyQueue = (if @validFirstKeys[command] then count.toString() + command else "")
+
+    # If we haven't sent the completion keys piggybacked on executePageCommand,
+    # send them by themselves.
+    unless refreshedCompletionKeys
+      requestHandlers.refreshCompletionKeys(@getCompletionKeysRequest(newKeyQueue))
+
+    newKeyQueue
+
+  # Generates a list of keys that can complete a valid command given the current key queue or the one passed in
+  generateCompletionKeys: (keysToCheck) ->
+    splitHash = @splitKeyQueue(keysToCheck || @keyQueue)
+    command = splitHash.command
+    count = splitHash.count
+
+    completionKeys = @singleKeyCommands.slice(0)
+
+    if (@getActualKeyStrokeLength(command) == 1)
+      for key of @keyToCommandRegistry
+        splitKey = @splitKeyIntoFirstAndSecond(key)
+        if (splitKey.first == command)
+          completionKeys.push(splitKey.second)
+
+    completionKeys
+
+root = exports ? window
+root.KeyHandler = KeyHandler

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -19,14 +19,6 @@ KeyHandler =
       console.log("checking keyQueue: [", @keyQueue + key, "]")
       @keyQueue = @checkKeyQueue(@keyQueue + key, request.frameId)
       console.log("new KeyQueue: " + @keyQueue)
-    # Tell the content script whether there are keys in the queue.
-    # FIXME: There is a race condition here.  The behaviour in the content script depends upon whether this
-    # message gets back there before or after the next keystroke.
-    # That being said, I suspect there are other similar race conditions here, for example in
-    # checkKeyQueue().  Steve (23 Aug, 14).
-    requestHandlers.currentKeyQueue
-      name: "currentKeyQueue",
-      keyQueue: @keyQueue
 
   splitKeyIntoFirstAndSecond: (key) ->
     if (key.search(@namedKeyRegex) == 0)

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -36,12 +36,6 @@ KeyHandler =
     else
       { first: key[0], second: key.slice(1) }
 
-  getActualKeyStrokeLength: (key) ->
-    if (key.search(@namedKeyRegex) == 0)
-      1 + @getActualKeyStrokeLength(RegExp.$2)
-    else
-      key.length
-
   refreshKeyToCommandRegistry: (request) ->
     @keyToCommandRegistry = request.keyToCommandRegistry
     @populateValidFirstKeys()
@@ -102,9 +96,7 @@ KeyHandler =
             noRepeat: registryEntry.noRepeat
 
       newKeyQueue = ""
-    else if (@getActualKeyStrokeLength(command) > 1)
-      splitKey = @splitKeyIntoFirstAndSecond(command)
-
+    else if ((splitKey = @splitKeyIntoFirstAndSecond(command)).second != "")
       # The second key might be a valid command by its self.
       if (@keyToCommandRegistry[splitKey.second])
         keyHandled = @checkKeyQueue(splitKey.second, noAction)

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -21,7 +21,7 @@ KeyHandler =
       newKeyQueue = @keyQueue.concat([key])
       @log("checking keyQueue: [#{newKeyQueue.join("")}]") unless noAction
       keyHandled = @checkKeyQueue(newKeyQueue, noAction)
-      @log("new KeyQueue: " + @keyQueue) unless noAction
+      @log("new KeyQueue: " + @keyQueue.join("")) unless noAction
 
     keyHandled
 

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -2,7 +2,6 @@ KeyHandler =
   keyQueue: "" # Queue of keys typed
   completionKeys: []
   validFirstKeys: {}
-  singleKeyCommands: []
   keyToCommandRegistry: {}
 
   # Keys are either literal characters, or "named" - for example <a-b> (alt+b), <left> (left arrow) or <f12>.
@@ -42,19 +41,12 @@ KeyHandler =
   refreshKeyToCommandRegistry: (request) ->
     @keyToCommandRegistry = request.keyToCommandRegistry
     @populateValidFirstKeys()
-    @populateSingleKeyCommands()
 
     @generateCompletionKeys("")
 
   populateValidFirstKeys: ->
     for key of @keyToCommandRegistry
-      if (@getActualKeyStrokeLength(key) == 2)
-        @validFirstKeys[@splitKeyIntoFirstAndSecond(key).first] = true
-
-  populateSingleKeyCommands: ->
-    for key of @keyToCommandRegistry
-      if (@getActualKeyStrokeLength(key) == 1)
-        @singleKeyCommands.push(key)
+      @validFirstKeys[@splitKeyIntoFirstAndSecond(key).first] = true
 
   splitKeyQueue: (queue) ->
     match = /([1-9][0-9]*)?(.*)/.exec(queue)
@@ -123,7 +115,7 @@ KeyHandler =
     command = splitHash.command
     count = splitHash.count
 
-    @completionKeys = @singleKeyCommands.slice(0)
+    @completionKeys = []
 
     if (@getActualKeyStrokeLength(command) == 1)
       for key of @keyToCommandRegistry

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -10,15 +10,22 @@ KeyHandler =
   # string.
   namedKeyRegex: /^(<(?:[amc]-.|(?:[amc]-)?[a-z0-9]{2,5})>)(.*)$/
 
+  # Used to log our key handling progress to the background page.
+  log: (data) ->
+    chrome.runtime.sendMessage
+      handler: "log"
+      data: data
+      frameId: frameId
+
   handleKeyDown: (request) ->
     key = request.keyChar
     if (key == "<ESC>")
-      console.log("clearing keyQueue")
+      @log("clearing keyQueue")
       @keyQueue = ""
     else
-      console.log("checking keyQueue: [", @keyQueue + key, "]")
+      @log("checking keyQueue: [#{@keyQueue + key}]")
       @keyQueue = @checkKeyQueue(@keyQueue + key, request.frameId)
-      console.log("new KeyQueue: " + @keyQueue)
+      @log("new KeyQueue: " + @keyQueue)
 
   splitKeyIntoFirstAndSecond: (key) ->
     if (key.search(@namedKeyRegex) == 0)

--- a/content_scripts/key_handling.coffee
+++ b/content_scripts/key_handling.coffee
@@ -1,6 +1,5 @@
 KeyHandler =
   keyQueue: "" # Queue of keys typed
-  completionKeys: []
   validFirstKeys: {}
   keyToCommandRegistry: {}
 
@@ -46,8 +45,6 @@ KeyHandler =
   refreshKeyToCommandRegistry: (request) ->
     @keyToCommandRegistry = request.keyToCommandRegistry
     @populateValidFirstKeys()
-
-    @generateCompletionKeys("")
 
   populateValidFirstKeys: ->
     for key of @keyToCommandRegistry
@@ -127,30 +124,8 @@ KeyHandler =
         newKeyQueue = ""
         keyHandled = false
 
-    # Send the completion keys to vimium_frontend.coffee.
-    @generateCompletionKeys(newKeyQueue)
-
     @keyQueue = newKeyQueue unless noAction
     keyHandled
-
-  # Generates a list of keys that can complete a valid command given the current key queue or the one passed in
-  generateCompletionKeys: (keysToCheck) ->
-    splitHash = @splitKeyQueue(keysToCheck || @keyQueue)
-    command = splitHash.command
-    count = splitHash.count
-
-    @completionKeys = []
-
-    if (@getActualKeyStrokeLength(command) == 1)
-      for key of @keyToCommandRegistry
-        splitKey = @splitKeyIntoFirstAndSecond(key)
-        if (splitKey.first == command)
-          @completionKeys.push(splitKey.second)
-
-    @completionKeys
-
-  willHandleKey: (keyChar) ->
-    @completionKeys.indexOf(keyChar) != -1 or @validFirstKeys[keyChar] or /^[1-9]/.test(keyChar)
 
 root = exports ? window
 root.KeyHandler = KeyHandler

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -116,23 +116,19 @@ initializePreDomReady = ->
 
   refreshCompletionKeys()
 
-  # Send the key to the key handler in the background page.
-  keyPort = chrome.runtime.connect({ name: "keyDown" })
-  # If the port is closed, the background page has gone away (since we never close it ourselves). Disable all
-  # our event listeners, and stub out chrome.runtime.sendMessage/connect (to prevent errors).
-  # TODO(mrmr1993): Do some actual cleanup to free resources, hide UI, etc.
-  keyPort.onDisconnect.addListener ->
-    isEnabledForUrl = false
-    chrome.runtime.sendMessage = ->
-    chrome.runtime.connect = ->
+  # Send the key to the key handler.
+  messageChannel = new MessageChannel()
+  KeyHandler.setKeyPort messageChannel.port1
+  keyPort = messageChannel.port2
 
-  requestHandlers =
+  window.requestHandlers =
     hideUpgradeNotification: -> HUD.hideUpgradeNotification()
     showUpgradeNotification: (request) -> HUD.showUpgradeNotification(request.version)
     showHUDforDuration: (request) -> HUD.showForDuration request.text, request.duration
     toggleHelpDialog: (request) -> toggleHelpDialog(request.dialogHtml, request.frameId)
     focusFrame: (request) -> if (frameId == request.frameId) then focusThisFrame(request.highlight)
     refreshCompletionKeys: refreshCompletionKeys
+    refreshKeyToCommandRegistry: KeyHandler.refreshKeyToCommandRegistry.bind(KeyHandler)
     getScrollPosition: -> scrollX: window.scrollX, scrollY: window.scrollY
     setScrollPosition: (request) -> setScrollPosition request.scrollX, request.scrollY
     executePageCommand: executePageCommand
@@ -523,7 +519,8 @@ refreshCompletionKeys = (response) ->
     if (response.validFirstKeys)
       validFirstKeys = response.validFirstKeys
   else
-    chrome.runtime.sendMessage({ handler: "getCompletionKeys" }, refreshCompletionKeys)
+    chrome.runtime.sendMessage { handler: "getKeyToCommandRegistry" }, (request) ->
+      KeyHandler.refreshKeyToCommandRegistry request
 
 isValidFirstKey = (keyChar) ->
   validFirstKeys[keyChar] || /^[1-9]/.test(keyChar)

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -125,7 +125,6 @@ initializePreDomReady = ->
     refreshKeyToCommandRegistry: KeyHandler.refreshKeyToCommandRegistry.bind(KeyHandler)
     getScrollPosition: -> scrollX: window.scrollX, scrollY: window.scrollY
     setScrollPosition: (request) -> setScrollPosition request.scrollX, request.scrollY
-    executePageCommand: executePageCommand
     getActiveState: -> { enabled: isEnabledForUrl, passKeys: passKeys }
     setState: setState
     currentKeyQueue: (request) -> keyQueue = request.keyQueue
@@ -215,16 +214,6 @@ enterInsertModeIfElementIsFocused = ->
     enterInsertModeWithoutShowingIndicator(document.activeElement)
 
 onDOMActivate = (event) -> handlerStack.bubbleEvent 'DOMActivate', event
-
-executePageCommand = (request) ->
-  return unless frameId == request.frameId
-
-  if (request.passCountToFunction)
-    Utils.invokeCommandString(request.command, [request.count])
-  else
-    Utils.invokeCommandString(request.command) for i in [0...request.count]
-
-  refreshCompletionKeys(request)
 
 setScrollPosition = (scrollX, scrollY) ->
   if (scrollX > 0 || scrollY > 0)

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -364,7 +364,7 @@ onKeypress = (event) ->
       else if (!isInsertMode() && !findMode)
         if (isPassKey keyChar)
           return undefined
-        if (KeyHandler.completionKeys.indexOf(keyChar) != -1 or isValidFirstKey(keyChar))
+        if (KeyHandler.willHandleKey(keyChar))
           DomUtils.suppressEvent(event)
 
         KeyHandler.handleKeyDown({ keyChar:keyChar, frameId:frameId })
@@ -437,7 +437,7 @@ onKeydown = (event) ->
 
   else if (!isInsertMode() && !findMode)
     if (keyChar)
-      if (KeyHandler.completionKeys.indexOf(keyChar) != -1 or isValidFirstKey(keyChar))
+      if (KeyHandler.willHandleKey(keyChar))
         DomUtils.suppressEvent event
         handledKeydownEvents.push event
 
@@ -456,9 +456,7 @@ onKeydown = (event) ->
   # Subject to internationalization issues since we're using keyIdentifier instead of charCode (in keypress).
   #
   # TOOD(ilya): Revisit this. Not sure it's the absolute best approach.
-  if (keyChar == "" && !isInsertMode() &&
-     (KeyHandler.completionKeys.indexOf(KeyboardUtils.getKeyChar(event)) != -1 ||
-      isValidFirstKey(KeyboardUtils.getKeyChar(event))))
+  if (keyChar == "" && !isInsertMode() && KeyHandler.willHandleKey(KeyboardUtils.getKeyChar(event)))
     DomUtils.suppressPropagation(event)
     handledKeydownEvents.push event
 
@@ -492,9 +490,6 @@ checkIfEnabledForUrl = ->
 updateKeyToCommandRegistry = ->
   chrome.runtime.sendMessage { handler: "getKeyToCommandRegistry" }, (request) ->
     KeyHandler.refreshKeyToCommandRegistry request
-
-isValidFirstKey = (keyChar) ->
-  KeyHandler.validFirstKeys[keyChar] || /^[1-9]/.test(keyChar)
 
 onFocusCapturePhase = (event) ->
   if (isFocusable(event.target) && !findMode)

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -364,10 +364,8 @@ onKeypress = (event) ->
       else if (!isInsertMode() && !findMode)
         if (isPassKey keyChar)
           return undefined
-        if (KeyHandler.willHandleKey(keyChar))
+        if (KeyHandler.handleKeyDown({ keyChar:keyChar, frameId:frameId }))
           DomUtils.suppressEvent(event)
-
-        KeyHandler.handleKeyDown({ keyChar:keyChar, frameId:frameId })
 
 onKeydown = (event) ->
   return unless handlerStack.bubbleEvent('keydown', event)
@@ -436,15 +434,11 @@ onKeydown = (event) ->
     handledKeydownEvents.push event
 
   else if (!isInsertMode() && !findMode)
+    keyChar = "<ESC>" if (KeyboardUtils.isEscape(event))
     if (keyChar)
-      if (KeyHandler.willHandleKey(keyChar))
+      if (KeyHandler.handleKeyDown({ keyChar:keyChar, frameId:frameId }))
         DomUtils.suppressEvent event
         handledKeydownEvents.push event
-
-      KeyHandler.handleKeyDown({ keyChar:keyChar, frameId:frameId })
-
-    else if (KeyboardUtils.isEscape(event))
-      KeyHandler.handleKeyDown({ keyChar:"<ESC>", frameId:frameId })
 
     else if isPassKey KeyboardUtils.getKeyChar(event)
       return undefined

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -364,7 +364,7 @@ onKeypress = (event) ->
       else if (!isInsertMode() && !findMode)
         if (isPassKey keyChar)
           return undefined
-        if (KeyHandler.handleKeyDown({ keyChar:keyChar, frameId:frameId }))
+        if (KeyHandler.handleKeyDown(keyChar))
           DomUtils.suppressEvent(event)
 
 onKeydown = (event) ->
@@ -436,7 +436,7 @@ onKeydown = (event) ->
   else if (!isInsertMode() && !findMode)
     keyChar = "<ESC>" if (KeyboardUtils.isEscape(event))
     if (keyChar)
-      if (KeyHandler.handleKeyDown({ keyChar:keyChar, frameId:frameId }))
+      if (KeyHandler.handleKeyDown(keyChar))
         DomUtils.suppressEvent event
         handledKeydownEvents.push event
 
@@ -450,7 +450,7 @@ onKeydown = (event) ->
   # Subject to internationalization issues since we're using keyIdentifier instead of charCode (in keypress).
   #
   # TOOD(ilya): Revisit this. Not sure it's the absolute best approach.
-  if (keyChar == "" && !isInsertMode() && KeyHandler.willHandleKey(KeyboardUtils.getKeyChar(event)))
+  if (keyChar == "" && !isInsertMode() && KeyHandler.handleKeyDown(KeyboardUtils.getKeyChar(event), true))
     DomUtils.suppressPropagation(event)
     handledKeydownEvents.push event
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -17,7 +17,6 @@ isShowingHelpDialog = false
 # are passed through to the underlying page.
 isEnabledForUrl = true
 passKeys = null
-keyQueue = null
 # The user's operating system.
 
 # The types in <input type="..."> that we consider for focusInput command. Right now this is recalculated in
@@ -123,7 +122,6 @@ initializePreDomReady = ->
     setScrollPosition: (request) -> setScrollPosition request.scrollX, request.scrollY
     getActiveState: -> { enabled: isEnabledForUrl, passKeys: passKeys }
     setState: setState
-    currentKeyQueue: (request) -> keyQueue = request.keyQueue
     vomnibarShow: -> Vomnibar.show()
     vomnibarClose: -> Vomnibar.close()
 
@@ -334,7 +332,7 @@ extend window,
 # Keystrokes are *never* considered passKeys if the keyQueue is not empty.  So, for example, if 't' is a
 # passKey, then 'gt' and '99t' will neverthless be handled by vimium.
 isPassKey = ( keyChar ) ->
-  return !keyQueue and passKeys and 0 <= passKeys.indexOf(keyChar)
+  return !KeyHandler.keyQueue and passKeys and 0 <= passKeys.indexOf(keyChar)
 
 handledKeydownEvents = []
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -12,7 +12,6 @@ findModeQuery = { rawQuery: "", matchCount: 0 }
 findModeQueryHasResults = false
 findModeAnchorNode = null
 isShowingHelpDialog = false
-keyPort = null
 # Users can disable Vimium on URL patterns via the settings page.  The following two variables
 # (isEnabledForUrl and passKeys) control Vimium's enabled/disabled behaviour.
 # "passKeys" are keys which would normally be handled by Vimium, but are disabled on this tab, and therefore
@@ -115,11 +114,6 @@ initializePreDomReady = ->
   checkIfEnabledForUrl()
 
   refreshCompletionKeys()
-
-  # Send the key to the key handler.
-  messageChannel = new MessageChannel()
-  KeyHandler.setKeyPort messageChannel.port1
-  keyPort = messageChannel.port2
 
   window.requestHandlers =
     hideUpgradeNotification: -> HUD.hideUpgradeNotification()
@@ -390,7 +384,7 @@ onKeypress = (event) ->
         if (currentCompletionKeys.indexOf(keyChar) != -1 or isValidFirstKey(keyChar))
           DomUtils.suppressEvent(event)
 
-        keyPort.postMessage({ keyChar:keyChar, frameId:frameId })
+        KeyHandler.handleKeyDown({ keyChar:keyChar, frameId:frameId })
 
 onKeydown = (event) ->
   return unless handlerStack.bubbleEvent('keydown', event)
@@ -464,10 +458,10 @@ onKeydown = (event) ->
         DomUtils.suppressEvent event
         handledKeydownEvents.push event
 
-      keyPort.postMessage({ keyChar:keyChar, frameId:frameId })
+      KeyHandler.handleKeyDown({ keyChar:keyChar, frameId:frameId })
 
     else if (KeyboardUtils.isEscape(event))
-      keyPort.postMessage({ keyChar:"<ESC>", frameId:frameId })
+      KeyHandler.handleKeyDown({ keyChar:"<ESC>", frameId:frameId })
 
     else if isPassKey KeyboardUtils.getKeyChar(event)
       return undefined

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -1,4 +1,3 @@
-#
 # This content script takes input from its webpage and executes commands locally on behalf of the background
 # page. It must be run prior to domReady so that we perform some operations very early. We tell the
 # background page that we're in domReady and ready to accept normal commands by connectiong to a port named
@@ -20,8 +19,6 @@ isEnabledForUrl = true
 passKeys = null
 keyQueue = null
 # The user's operating system.
-currentCompletionKeys = null
-validFirstKeys = null
 
 # The types in <input type="..."> that we consider for focusInput command. Right now this is recalculated in
 # each content script. Alternatively we could calculate it once in the background page and use a request to
@@ -113,7 +110,7 @@ initializePreDomReady = ->
 
   checkIfEnabledForUrl()
 
-  refreshCompletionKeys()
+  updateKeyToCommandRegistry()
 
   window.requestHandlers =
     hideUpgradeNotification: -> HUD.hideUpgradeNotification()
@@ -121,7 +118,6 @@ initializePreDomReady = ->
     showHUDforDuration: (request) -> HUD.showForDuration request.text, request.duration
     toggleHelpDialog: (request) -> toggleHelpDialog(request.dialogHtml, request.frameId)
     focusFrame: (request) -> if (frameId == request.frameId) then focusThisFrame(request.highlight)
-    refreshCompletionKeys: refreshCompletionKeys
     refreshKeyToCommandRegistry: KeyHandler.refreshKeyToCommandRegistry.bind(KeyHandler)
     getScrollPosition: -> scrollX: window.scrollX, scrollY: window.scrollY
     setScrollPosition: (request) -> setScrollPosition request.scrollX, request.scrollY
@@ -370,7 +366,7 @@ onKeypress = (event) ->
       else if (!isInsertMode() && !findMode)
         if (isPassKey keyChar)
           return undefined
-        if (currentCompletionKeys.indexOf(keyChar) != -1 or isValidFirstKey(keyChar))
+        if (KeyHandler.completionKeys.indexOf(keyChar) != -1 or isValidFirstKey(keyChar))
           DomUtils.suppressEvent(event)
 
         KeyHandler.handleKeyDown({ keyChar:keyChar, frameId:frameId })
@@ -443,7 +439,7 @@ onKeydown = (event) ->
 
   else if (!isInsertMode() && !findMode)
     if (keyChar)
-      if (currentCompletionKeys.indexOf(keyChar) != -1 or isValidFirstKey(keyChar))
+      if (KeyHandler.completionKeys.indexOf(keyChar) != -1 or isValidFirstKey(keyChar))
         DomUtils.suppressEvent event
         handledKeydownEvents.push event
 
@@ -463,7 +459,7 @@ onKeydown = (event) ->
   #
   # TOOD(ilya): Revisit this. Not sure it's the absolute best approach.
   if (keyChar == "" && !isInsertMode() &&
-     (currentCompletionKeys.indexOf(KeyboardUtils.getKeyChar(event)) != -1 ||
+     (KeyHandler.completionKeys.indexOf(KeyboardUtils.getKeyChar(event)) != -1 ||
       isValidFirstKey(KeyboardUtils.getKeyChar(event))))
     DomUtils.suppressPropagation(event)
     handledKeydownEvents.push event
@@ -495,18 +491,12 @@ checkIfEnabledForUrl = ->
       # Quickly hide any HUD we might already be showing, e.g. if we entered insert mode on page load.
       HUD.hide()
 
-refreshCompletionKeys = (response) ->
-  if (response)
-    currentCompletionKeys = response.completionKeys
-
-    if (response.validFirstKeys)
-      validFirstKeys = response.validFirstKeys
-  else
-    chrome.runtime.sendMessage { handler: "getKeyToCommandRegistry" }, (request) ->
-      KeyHandler.refreshKeyToCommandRegistry request
+updateKeyToCommandRegistry = ->
+  chrome.runtime.sendMessage { handler: "getKeyToCommandRegistry" }, (request) ->
+    KeyHandler.refreshKeyToCommandRegistry request
 
 isValidFirstKey = (keyChar) ->
-  validFirstKeys[keyChar] || /^[1-9]/.test(keyChar)
+  KeyHandler.validFirstKeys[keyChar] || /^[1-9]/.test(keyChar)
 
 onFocusCapturePhase = (event) ->
   if (isFocusable(event.target) && !findMode)

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -128,11 +128,11 @@ initializePreDomReady = ->
   chrome.runtime.onMessage.addListener (request, sender, sendResponse) ->
     # In the options page, we will receive requests from both content and background scripts. ignore those
     # from the former.
-    return if sender.tab and not sender.tab.url.startsWith 'chrome-extension://'
+    return if sender.tab and sender.tab.url.startsWith 'chrome-extension://'
     return unless isEnabledForUrl or request.name == 'getActiveState' or request.name == 'setState'
     # These requests are delivered to the options page, but there are no handlers there.
     return if request.handler == "registerFrame" or request.handler == "frameFocused"
-    sendResponse requestHandlers[request.name](request, sender)
+    sendResponse requestHandlers[request.name]?(request, sender)
     # Ensure the sendResponse callback is freed.
     false
 

--- a/manifest.json
+++ b/manifest.json
@@ -41,6 +41,7 @@
              "content_scripts/vomnibar.js",
              "content_scripts/scroller.js",
              "content_scripts/marks.js",
+             "content_scripts/key_handling.js",
              "content_scripts/vimium_frontend.js"
             ],
       "css": ["content_scripts/vimium.css"],

--- a/tests/dom_tests/dom_tests.html
+++ b/tests/dom_tests/dom_tests.html
@@ -40,6 +40,7 @@
          testing the DOM aspects of "../../content_scripts/vomnibar.js".
     <script type="text/javascript" src="../../content_scripts/vomnibar.js"></script>  -->
     <script type="text/javascript" src="../../content_scripts/scroller.js"></script>
+    <script type="text/javascript" src="../../content_scripts/key_handling.js"></script>
     <script type="text/javascript" src="../../content_scripts/vimium_frontend.js"></script>
     <script type="text/javascript" src="../../pages/vomnibar.js"></script>
 


### PR DESCRIPTION
This is PR #1275, but as a pull request on `post-1.46`. This makes the diff much more manageable to look at. To quote #1275:

> This PR begins work on #1274.
* Key handling has been moved to a content script (`content_scripts/key_handling.coffee`).
* Key handling is now done synchronously as part of the event's key handler.
* Checks on whether we handle a key are all done using the same code. This ensures consistency (eg. now we don't pass `0` to the underlying page if we've handled it ourselves as part of a number prefix).
>
> ...
>
> Apart from bugfixes coming from unifying the frontend and backend key handling, this should function the same as before.