### PR TITLE
Skip over tiny frames when calling focusThisFrame

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -633,6 +633,7 @@ sendRequestHandlers =
   registerFrame: registerFrame,
   unregisterFrame: unregisterFrame,
   frameFocused: handleFrameFocused,
+  nextFrame: (request) -> BackgroundCommands.nextFrame 1, request.frameId
   upgradeNotificationClosed: upgradeNotificationClosed,
   updateScrollPosition: handleUpdateScrollPosition,
   copyToClipboard: copyToClipboard,

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -225,6 +225,10 @@ setScrollPosition = (scrollX, scrollY) ->
 # Called from the backend in order to change frame focus.
 #
 window.focusThisFrame = (shouldHighlight) ->
+  if window.innerWidth < 3 or window.innerHeight < 3
+    # This frame is too small to focus. Cancel and tell the background frame to focus the next one instead.
+    chrome.runtime.sendMessage({ handler: "nextFrame", frameId: frameId })
+    return
   window.focus()
   if (document.body && shouldHighlight)
     borderWas = document.body.style.border


### PR DESCRIPTION
This fixes (hopefully?) #1317 by implementing the idea in [this comment](https://github.com/philc/vimium/issues/1317#issuecomment-67046634).
