### PR TITLE
Fix smooth scrolling when zoomed.

### DIFF
--- a/content_scripts/scroller.coffee
+++ b/content_scripts/scroller.coffee
@@ -39,7 +39,8 @@ performScroll = (element, direction, amount) ->
   axisName = scrollProperties[direction].axisName
   before = element[axisName]
   element[axisName] += amount
-  element[axisName] == amount + before
+  scrollChange = element[axisName] - before
+  Math.abs(scrollChange - amount) <= 4 # At 25% zoom the scroll can be off by as much as 4.
 
 # Test whether `element` should be scrolled. E.g. hidden elements should not be scrolled.
 shouldScroll = (element, direction) ->


### PR DESCRIPTION
Use a tolerance when checking scrolling to fix zoomed scrolls.

This fixes #1322, fixes #1321 and hopefully makes #1320 redundant.

@philc can you merge this and push to the web store to fix all the smooth scrolling issues?
