### PR TITLE
Disable smooth scrolling.

### DIFF
--- a/content_scripts/scroller.coffee
+++ b/content_scripts/scroller.coffee
@@ -123,7 +123,7 @@ CoreScroller =
   scroll: (element, direction, amount) ->
     return unless amount
 
-    unless @settings.get "smoothScroll"
+    if true # unless @settings.get "smoothScroll"
       # Jump scrolling.
       performScroll element, direction, amount
       checkVisibility element


### PR DESCRIPTION
@philc.  Even with #1324 there are issues related to smooth scrolling when zoomed.  I suggest we should disable it entirely for now.

Issues:
- `gg` might not take us to the top of the screen.
- We may not be able to scroll out of sub-elements (not sure about this).
- The scroll speed is affected by the zoom level.

These can all be solved, but we need time to get the solution right.
