### PR TITLE
Fix scrolling in 1.47, all cases.

### DIFF
--- a/content_scripts/scroller.coffee
+++ b/content_scripts/scroller.coffee
@@ -34,13 +34,12 @@ getDimension = (el, direction, amount) ->
   else
     amount
 
-# Perform a scroll. Return true if we successfully scrolled by the requested amount, and false otherwise.
+# Perform a scroll. Return true if we successfully scrolled by any amount, and false otherwise.
 performScroll = (element, direction, amount) ->
   axisName = scrollProperties[direction].axisName
   before = element[axisName]
   element[axisName] += amount
-  scrollChange = element[axisName] - before
-  Math.abs(scrollChange - amount) <= 4 # At 25% zoom the scroll can be off by as much as 4.
+  element[axisName] != before
 
 # Test whether `element` should be scrolled. E.g. hidden elements should not be scrolled.
 shouldScroll = (element, direction) ->


### PR DESCRIPTION
Fixes all of the smooth scrolling issues with 1.46.
Also fixes #1330.

Remaining problems (only when zoomed):
- The final position of some scrolls may be off by a fractional amount.

Edit:  Also addresses the issues raised (by me) in #1327.)
