### PR TITLE
URI Encode search engine queries.

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -327,7 +327,7 @@ class SearchEngineCompleter
     searchEngineMatch = this.getSearchEngineMatches(queryTerms[0])
     suggestions = []
     if searchEngineMatch
-      searchEngineMatch = searchEngineMatch.replace(/%s/g, queryTerms[1..].join("+"))
+      searchEngineMatch = searchEngineMatch.replace(/%s/g, Utils.createSearchQuery queryTerms[1..])
       suggestion = new Suggestion(queryTerms, "search", searchEngineMatch, queryTerms[0] + ": " + queryTerms[1..].join(" "), @computeRelevancy)
       suggestions.push(suggestion)
     onComplete(suggestions)

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -88,11 +88,17 @@ Utils =
     # Fallback: no URL
     return false
 
+  # Map a search query to its URL encoded form. The query may be either a string or an array of strings.
+  # E.g. "BBC Sport" -> "BBC+Sport".
+  createSearchQuery: (query) ->
+    query = query.split(/\s+/) if typeof(query) == "string"
+    query.map(encodeURIComponent).join "+"
+
   # Creates a search URL from the given :query.
   createSearchUrl: (query) ->
     # it would be better to pull the default search engine from chrome itself,
     # but it is not clear if/how that is possible
-    Settings.get("searchUrl") + encodeURIComponent(query)
+    Settings.get("searchUrl") + @createSearchQuery query
 
   # Converts :string into a Google search if it's not already a URL. We don't bother with escaping characters
   # as Chrome will do that for us.


### PR DESCRIPTION
Fixes #1334.

This is pretty ugly, because the URI-encoded string appears in the vomnibar, `%20` for space and all.

But I'll leave this here for a bit, until further inspiration strikes. 
