### PR TITLE
Consider all overlapping exclusion rules, not only the first one

### DIFF
--- a/background_scripts/exclusions.coffee
+++ b/background_scripts/exclusions.coffee
@@ -21,11 +21,10 @@ root.Exclusions = Exclusions =
 
   rules: Settings.get("exclusionRules")
 
-  # Return the first exclusion rule matching the URL, or null.
-  getRule: (url) ->
-    for rule in @rules
-      return rule if url.match(RegexpCache.get(rule.pattern))
-    return null
+  # Return exclusion rules matching the URL.
+  getRules: (url) ->
+    return @rules.filter (rule) ->
+      url.match(RegexpCache.get(rule.pattern))
 
   setRules: (rules) ->
     # Callers map a rule to null to have it deleted, and rules without a pattern are useless.

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -73,11 +73,16 @@ getCurrentTabUrl = (request, sender) -> sender.tab.url
 # whether any keys should be passed through to the underlying page.
 #
 root.isEnabledForUrl = isEnabledForUrl = (request) ->
-  rule = Exclusions.getRule(request.url)
+  rules = Exclusions.getRules(request.url)
+  passKeys = []
+  for rule in rules
+    if rule.passKeys
+      passKeys.push rule.passKeys
+    else
+      return isEnabledForUrl: false
   {
-    rule: rule
-    isEnabledForUrl: not rule or rule.passKeys
-    passKeys: rule?.passKeys or ""
+    isEnabledForUrl: true
+    passKeys: passKeys.join ""
   }
 
 # Called by the popup UI.


### PR DESCRIPTION
If the site (or another extension) introduces several keyboard shortcuts that the user wants to enable on different pages, it is natural to create a set of exclusions for different pages on that site.

For example:

```
*://site.com/* b
*://site.com/*.html r
```

It seems counter-intuitive to stop after the first match. This way on `*.html` pages `r` is not excluded at all. (Or `b` if the order is switched.)

This PR changes this behavior to looking through all exclusion patterns.
