### PR TITLE
Updated link should point to release notes.

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -1006,7 +1006,7 @@ HUD =
 
   showUpgradeNotification: (version) ->
     HUD.upgradeNotificationElement().innerHTML = "Vimium has been upgraded to #{version}. See
-      <a class='vimiumReset'
+      <a class='vimiumReset' target='_blank'
       href='https://github.com/philc/vimium#release-notes'>
       what's new</a>.<a class='vimiumReset close-button' href='#'>&times;</a>"
     links = HUD.upgradeNotificationElement().getElementsByTagName("a")


### PR DESCRIPTION
When Vimium is upgraded, the HUD displays a notification together with a link.  The link points the Chrome Store (which is pretty useless).

Would it not be better to point to the [release notes](https://github.com/philc/vimium#release-notes), so users can see what's new?
