### PR TITLE
Ensure we only init CursorHider once

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -1124,6 +1124,7 @@ CursorHider =
     CursorHider.isScrolling = false
 
   init: ->
+    return unless @cursorHideStyle?
     @cursorHideStyle = document.createElement("style")
     @cursorHideStyle.innerHTML = """
       body * {pointer-events: none !important; cursor: none !important;}


### PR DESCRIPTION
Checks whether we've already initialised `CursorHider`, and stops us from doing it again if so.
