### PR TITLE
Support all mappable keys in passkeys and treat exit insert mode as a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ Please see [CONTRIBUTING.md](https://github.com/philc/vimium/blob/master/CONTRIB
 
 Release Notes
 -------------
+1.49 (2014-12-16)
+
+- An option to toggle smooth scrolling.
+- Make Vimium work on older versions of Chrome.
+
 1.46, 1.47, 1.48 (2014-12-15)
 
 - Site-specific excluded keys: you can disable some Vimium key bindings on sites like gmail.com, so you can use the key bindings provided by the site itself.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -359,7 +359,7 @@ setPassKeys = (newPassKeys) ->
   passKeyGroups = passKeys.split " "
   splitPassKeys = []
   for passKeyGroup in passKeyGroups
-    namedKeyMatch = passKeyGroup.match namedKeyRegex
+    namedKeyMatch = passKeyGroup.search namedKeyRegex
     if namedKeyMatch # The current space delimited group is a single named key.
       splitPassKeys.push passKeyGroup # Push this to as a single key
     else

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -359,8 +359,7 @@ setPassKeys = (newPassKeys) ->
   passKeyGroups = passKeys.split " "
   splitPassKeys = []
   for passKeyGroup in passKeyGroups
-    namedKeyMatch = passKeyGroup.search namedKeyRegex
-    if namedKeyMatch # The current space delimited group is a single named key.
+    if namedKeyRegex.test passKeyGroup # The current space delimited group is a single named key.
       splitPassKeys.push passKeyGroup # Push this to as a single key
     else
       splitPassKeys = splitPassKeys.concat passKeyGroup.split "" # Pass all the characters as seperate keys.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -462,6 +462,7 @@ onKeydown = (event) ->
   isInsertExitPassKey = (rawKeyChar in insertExitPassKeys)
 
   if (isInsertMode() and (isInsertExitPassKey or rawKeyChar in insertExitKeys))
+    return undefined if (isPassKey rawKeyChar)
     # We don't want to programmatically blur out of Flash embeds from Javascript.
     if (!isEmbed(event.srcElement))
       # Remove focus so the user can't just get himself back into insert mode by typing in the same input

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -19,10 +19,16 @@ keyPort = null
 # are passed through to the underlying page.
 isEnabledForUrl = true
 passKeys = null
+splitPassKeys = []
 keyQueue = null
 # The user's operating system.
 currentCompletionKeys = null
 validFirstKeys = null
+
+# Keys are either literal characters, or "named" - for example <a-b> (alt+b), <left> (left arrow) or <f12>
+# This regular expression captures two groups: the first is a named key, the second is the remainder of
+# the string.
+namedKeyRegex = /^(<(?:[amc]-.|(?:[amc]-)?[a-z0-9]{2,5})>)$/
 
 # The types in <input type="..."> that we consider for focusInput command. Right now this is recalculated in
 # each content script. Alternatively we could calculate it once in the background page and use a request to
@@ -149,7 +155,7 @@ installListener = (element, event, callback) ->
 installedListeners = false
 initializeWhenEnabled = (newPassKeys) ->
   isEnabledForUrl = true
-  passKeys = newPassKeys
+  setPassKeys newPassKeys
   if (!installedListeners)
     # Key event handlers fire on window before they do on document. Prefer window for key events so the page
     # can't set handlers to grab the keys before us.
@@ -165,7 +171,7 @@ initializeWhenEnabled = (newPassKeys) ->
 setState = (request) ->
   initializeWhenEnabled(request.passKeys) if request.enabled
   isEnabledForUrl = request.enabled
-  passKeys = request.passKeys
+  setPassKeys request.passKeys
 
 #
 # The backend needs to know which frame has focus.
@@ -345,8 +351,19 @@ extend window,
 # Decide whether this keyChar should be passed to the underlying page.
 # Keystrokes are *never* considered passKeys if the keyQueue is not empty.  So, for example, if 't' is a
 # passKey, then 'gt' and '99t' will neverthless be handled by vimium.
-isPassKey = ( keyChar ) ->
-  return !keyQueue and passKeys and 0 <= passKeys.indexOf(keyChar)
+isPassKey = (keyChar) ->
+  not keyQueue and splitPassKeys and 0 <= splitPassKeys.indexOf(keyChar)
+
+setPassKeys = (newPassKeys) ->
+  passKeys = newPassKeys
+  passKeyGroups = passKeys.split " "
+  splitPassKeys = []
+  for passKeyGroup in passKeyGroups
+    namedKeyMatch = passKeyGroup.match namedKeyRegex
+    if namedKeyMatch # The current space delimited group is a single named key.
+      splitPassKeys.push passKeyGroup # Push this to as a single key
+    else
+      splitPassKeys = splitPassKeys.concat passKeyGroup.split "" # Pass all the characters as seperate keys.
 
 # Track which keydown events we have handled, so that we can subsequently suppress the corresponding keyup
 # event.
@@ -473,6 +490,8 @@ onKeydown = (event) ->
 
   else if (!isInsertMode() && !findMode)
     if (keyChar)
+      if isPassKey keyChar
+        return undefined
       if (currentCompletionKeys.indexOf(keyChar) != -1 or isValidFirstKey(keyChar))
         DomUtils.suppressEvent event
         KeydownEvents.push event

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -95,11 +95,11 @@ DomUtils =
   #
   # The html5 input types that should use simulateSelect are:
   #   ["date", "datetime", "datetime-local", "email", "month", "number", "password", "range", "search",
-  #    "submit", "tel", "text", "time", "url", "week"]
+  #    "tel", "text", "time", "url", "week"]
   # An unknown type will be treated the same as "text", in the same way that the browser does.
   #
   isSelectable: (element) ->
-    unselectableTypes = ["button", "checkbox", "color", "file", "hidden", "image", "radio", "reset"]
+    unselectableTypes = ["button", "checkbox", "color", "file", "hidden", "image", "radio", "reset", "submit"]
     (element.nodeName.toLowerCase() == "input" && unselectableTypes.indexOf(element.type) == -1) ||
         element.nodeName.toLowerCase() == "textarea"
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Vimium",
-  "version": "1.48",
+  "version": "1.49",
   "description": "The Hacker's Browser. Vimium provides keyboard shortcuts for navigation and control in the spirit of Vim.",
   "icons": {  "16": "icons/icon16.png",
               "48": "icons/icon48.png",

--- a/pages/options.html
+++ b/pages/options.html
@@ -253,6 +253,10 @@
                 <br/><br/>
                 If "Keys" is left empty, then vimium is wholly disabled.
                 Otherwise, just the listed keys are disabled (they are passed through).
+                <br/><br/>
+                To enter complex keys such as
+                <pre>&lt;c-[&gt;, &lt;a-f&gt;, &lt;c-a-A&gt;</pre>
+                simply seperate them from other passkeys with a space.
               </div>
             </div>
             <div>


### PR DESCRIPTION
This PR combines #1140 and #1368, and adds a tweak to support passkeys for `exitInsertMode`. It does the majority of what is outlined in [this comment](https://github.com/philc/vimium/pull/1211#issuecomment-67776693) with a view to making #1211 mergable and enabled by default.

Specifically, this PR:
* adds passkey support for all mappable keys, with multi-character key representations recognised when delimited with spaces (via #1368).
* adds `exitInsertMode` and `exitInsertModeAndPassKey` commands (via #1140), which fixes #301 and starts work on resolving #1176.
* enable passkeys for the `exitInsertMode`/`exitInsertModeAndPassKey` commands.