### PR TITLE
Esc to exit insert mode in embeds.

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -455,12 +455,14 @@ onKeydown = (event) ->
         keyChar = "<" + keyChar + ">"
 
   if (isInsertMode() && KeyboardUtils.isEscape(event))
-    # Note that we can't programmatically blur out of Flash embeds from Javascript.
-    if (!isEmbed(event.srcElement))
+    if isEditable(event.srcElement) or isEmbed(event.srcElement)
       # Remove focus so the user can't just get himself back into insert mode by typing in the same input
       # box.
       if (isEditable(event.srcElement))
         event.srcElement.blur()
+      # NOTE(smblott, 2014/12/22) Including embeds for exitInsertMode() etc. here is experimental.  It's the
+      # right thing to do for most common use cases.  However, it could also cripple flash-based sites and
+      # games.  See #1211 and #1194.
       exitInsertMode()
       DomUtils.suppressEvent event
       KeydownEvents.push event


### PR DESCRIPTION
Currently, when an `embed` has the focus, `Esc` doesn't get Vimium out of insert mode.  This fixes that.

This is the right thing to do in the most common use cases, and for most users.  Unfortunately, it could cripple some flash-based sites and games.

Proposal:
- Introduce this into `post-1.46` on an experimental basis.

We (I, actually) need feedback as to whether this is the right thing to do.

Here's a (rather unfortunate) [test page](http://www.dumpert.nl/embed/6631539/8d9ff21c/).

See also #1211 and #1194.
