### PR TITLE
Esc to exit insert mode in embeds

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -436,15 +436,13 @@ onKeydown = (event) ->
         keyChar = "<" + keyChar + ">"
 
   if (isInsertMode() && KeyboardUtils.isEscape(event))
-    # Note that we can't programmatically blur out of Flash embeds from Javascript.
-    if (!isEmbed(event.srcElement))
+    if isEditable(event.srcElement) or isEmbed(event.srcElement)
       # Remove focus so the user can't just get himself back into insert mode by typing in the same input
       # box.
-      if (isEditable(event.srcElement))
-        event.srcElement.blur()
-      exitInsertMode()
-      DomUtils.suppressEvent event
-      KeydownEvents.push event
+      event.srcElement.blur()
+    exitInsertMode()
+    DomUtils.suppressEvent event
+    handledKeydownEvents.push event
 
   else if (findMode)
     if (KeyboardUtils.isEscape(event))


### PR DESCRIPTION
This enables `esc` to exit insert mode for `<embed>`/`<object>` elements.

Test page [here](http://www.bensilvis.com/?p=146).

Ping @smblott-github
