### PR TITLE
be null-safe when checking `document.body.tagName`

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -186,7 +186,7 @@ initializeOnDomReady = ->
 
 registerFrame = ->
   # Don't register frameset containers; focusing them is no use.
-  if document.body.tagName.toLowerCase() != "frameset"
+  unless document.body?.tagName.toLowerCase() == "frameset"
     chrome.runtime.sendMessage
       handler: "registerFrame"
       frameId: frameId


### PR DESCRIPTION
fixes #1365
