### PR TITLE
Merge post 1.46

### DIFF
--- a/content_scripts/scroller.coffee
+++ b/content_scripts/scroller.coffee
@@ -63,7 +63,7 @@ shouldScroll = (element, direction) ->
 # Instead, we scroll the element by 1 or -1 and see if it moved (then put it back).  :factor is the factor by
 # which :scrollBy and :scrollTo will later scale the scroll amount. :factor can be negative, so we need it
 # here in order to decide whether we should test a forward scroll or a backward scroll.
-# Bug verified in Chrome 38.0.2125.104.
+# Bug last verified in Chrome 38.0.2125.104.
 doesScroll = (element, direction, amount, factor) ->
   # amount is treated as a relative amount, which is correct for relative scrolls. For absolute scrolls (only
   # gg, G, and friends), amount can be either a string ("max" or "viewSize") or zero. In the former case,
@@ -83,7 +83,7 @@ findScrollableElement = (element, direction, amount, factor) ->
 # On some pages, document.body is not scrollable.  Here, we search the document for the largest visible
 # element which does scroll vertically. This is used to initialize activatedElement. See #1358.
 firstScrollableElement = (element=document.body) ->
-  if doesScroll element, "y", 1, 1
+  if doesScroll(element, "y", 1, 1) or doesScroll(element, "y", -1, 1)
     element
   else
     children = ({element: child, rect: DomUtils.getVisibleClientRect(child)} for child in element.children)

--- a/content_scripts/scroller.coffee
+++ b/content_scripts/scroller.coffee
@@ -215,7 +215,7 @@ Scroller =
         window.scrollBy(0, amount)
       return
 
-    activatedElement ||= firstScrollableElement()
+    activatedElement ||= document.body and firstScrollableElement()
     return unless activatedElement
 
     # Avoid the expensive scroll calculation if it will not be used.  This reduces costs during smooth,
@@ -226,7 +226,7 @@ Scroller =
       CoreScroller.scroll element, direction, elementAmount
 
   scrollTo: (direction, pos) ->
-    activatedElement ||= firstScrollableElement()
+    activatedElement ||= document.body and firstScrollableElement()
     return unless activatedElement
 
     element = findScrollableElement activatedElement, direction, pos, 1

--- a/content_scripts/scroller.coffee
+++ b/content_scripts/scroller.coffee
@@ -215,7 +215,7 @@ Scroller =
         window.scrollBy(0, amount)
       return
 
-    activatedElement ||= firstScrollableElement() || document.body
+    activatedElement ||= firstScrollableElement()
     return unless activatedElement
 
     # Avoid the expensive scroll calculation if it will not be used.  This reduces costs during smooth,
@@ -226,8 +226,8 @@ Scroller =
       CoreScroller.scroll element, direction, elementAmount
 
   scrollTo: (direction, pos) ->
-    return unless document.body or activatedElement
-    activatedElement ||= firstScrollableElement() || document.body
+    activatedElement ||= firstScrollableElement()
+    return unless activatedElement
 
     element = findScrollableElement activatedElement, direction, pos, 1
     amount = getDimension(element,direction,pos) - element[scrollProperties[direction].axisName]

--- a/content_scripts/scroller.coffee
+++ b/content_scripts/scroller.coffee
@@ -80,14 +80,17 @@ findScrollableElement = (element, direction, amount, factor) ->
       element = element.parentElement || document.body
   element
 
-# On some pages, document.body is not scrollable.  Here, we search the document for the first visible element
-# which does scroll vertically. This is used to initialize activatedElement. See #1358.
+# On some pages, document.body is not scrollable.  Here, we search the document for the largest visible
+# element which does scroll vertically. This is used to initialize activatedElement. See #1358.
 firstScrollableElement = (element=document.body) ->
   if doesScroll element, "y", 1, 1
     element
   else
-    for child in element.children
-      return ele if DomUtils.getVisibleClientRect(child) and ele = firstScrollableElement child
+    children = ({element: child, rect: DomUtils.getVisibleClientRect(child)} for child in element.children)
+    children = children.filter (child) -> child.rect # Filter out non-visible elements.
+    children.map (child) -> child.area = child.rect.width * child.rect.height
+    for child in children.sort((a,b) -> b.area - a.area) # Largest to smallest by visible area.
+      return ele if ele = firstScrollableElement child.element
     null
 
 checkVisibility = (element) ->

--- a/content_scripts/scroller.coffee
+++ b/content_scripts/scroller.coffee
@@ -80,6 +80,16 @@ findScrollableElement = (element, direction, amount, factor) ->
       element = element.parentElement || document.body
   element
 
+# On some pages, document.body is not scrollable.  Here, we search the document for the first visible element
+# which does scroll vertically. This is used to initialize activatedElement. See #1358.
+firstScrollableElement = (element=document.body) ->
+  if doesScroll element, "y", 1, 1
+    element
+  else
+    for child in element.children
+      return ele if DomUtils.getVisibleClientRect(child) and ele = firstScrollableElement child
+    null
+
 checkVisibility = (element) ->
   # If the activated element has been scrolled completely offscreen, then subsequent changes in its scroll
   # position will not provide any more visual feedback to the user. Therefore, we deactivate it so that
@@ -202,7 +212,7 @@ Scroller =
         window.scrollBy(0, amount)
       return
 
-    activatedElement ||= document.body
+    activatedElement ||= firstScrollableElement() || document.body
     return unless activatedElement
 
     # Avoid the expensive scroll calculation if it will not be used.  This reduces costs during smooth,
@@ -214,7 +224,7 @@ Scroller =
 
   scrollTo: (direction, pos) ->
     return unless document.body or activatedElement
-    activatedElement ||= document.body
+    activatedElement ||= firstScrollableElement() || document.body
 
     element = findScrollableElement activatedElement, direction, pos, 1
     amount = getDimension(element,direction,pos) - element[scrollProperties[direction].axisName]

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -57,6 +57,16 @@ settings =
     @port = chrome.runtime.connect({ name: "settings" })
     @port.onMessage.addListener(@receiveMessage)
 
+    # If the port is closed, the background page has gone away (since we never close it ourselves). Stub the
+    # settings object so we don't keep trying to connect to the extension even though it's gone away.
+    @port.onDisconnect.addListener =>
+      @port = null
+      _get = @get # @get doesn't depend on @port, so we can continue to support it to try and reduce errors.
+      for own property, value of this
+        @[property] = (->) if "function" == typeof value
+      @get = _get
+
+
   get: (key) -> @values[key]
 
   set: (key, value) ->
@@ -109,6 +119,13 @@ initializePreDomReady = ->
 
   # Send the key to the key handler in the background page.
   keyPort = chrome.runtime.connect({ name: "keyDown" })
+  # If the port is closed, the background page has gone away (since we never close it ourselves). Disable all
+  # our event listeners, and stub out chrome.runtime.sendMessage/connect (to prevent errors).
+  # TODO(mrmr1993): Do some actual cleanup to free resources, hide UI, etc.
+  keyPort.onDisconnect.addListener ->
+    isEnabledForUrl = false
+    chrome.runtime.sendMessage = ->
+    chrome.runtime.connect = ->
 
   requestHandlers =
     hideUpgradeNotification: -> HUD.hideUpgradeNotification()

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -455,6 +455,9 @@ onKeydown = (event) ->
     if isEditable(event.srcElement) or isEmbed(event.srcElement)
       # Remove focus so the user can't just get himself back into insert mode by typing in the same input
       # box.
+      # NOTE(smblott, 2014/12/22) Including embeds for .blur() etc. here is experimental.  It appears to be
+      # the right thing to do for most common use cases.  However, it could also cripple flash-based sites and
+      # games.  See discussion in #1211 and #1194.
       event.srcElement.blur()
     exitInsertMode()
     DomUtils.suppressEvent event

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -452,15 +452,13 @@ onKeydown = (event) ->
         keyChar = "<" + keyChar + ">"
 
   if (isInsertMode() && KeyboardUtils.isEscape(event))
-    # Note that we can't programmatically blur out of Flash embeds from Javascript.
-    if (!isEmbed(event.srcElement))
+    if isEditable(event.srcElement) or isEmbed(event.srcElement)
       # Remove focus so the user can't just get himself back into insert mode by typing in the same input
       # box.
-      if (isEditable(event.srcElement))
-        event.srcElement.blur()
-      exitInsertMode()
-      DomUtils.suppressEvent event
-      KeydownEvents.push event
+      event.srcElement.blur()
+    exitInsertMode()
+    DomUtils.suppressEvent event
+    handledKeydownEvents.push event
 
   else if (findMode)
     if (KeyboardUtils.isEscape(event))

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -61,10 +61,9 @@ settings =
     # settings object so we don't keep trying to connect to the extension even though it's gone away.
     @port.onDisconnect.addListener =>
       @port = null
-      _get = @get # @get doesn't depend on @port, so we can continue to support it to try and reduce errors.
       for own property, value of this
-        @[property] = (->) if "function" == typeof value
-      @get = _get
+        # @get doesn't depend on @port, so we can continue to support it to try and reduce errors.
+        @[property] = (->) if "function" == typeof value and property != "get"
 
 
   get: (key) -> @values[key]

--- a/tests/dom_tests/chrome.coffee
+++ b/tests/dom_tests/chrome.coffee
@@ -10,6 +10,9 @@ root.chrome = {
       onMessage: {
         addListener: ->
       }
+      onDisconnect: {
+        addListener: ->
+      }
       postMessage: ->
     }
     onMessage: {


### PR DESCRIPTION
1.49 has been out for a couple of weeks now and doesn't seem to contain any more show stoppers.

So... This PR merges some of the changes which are in `post-1.46`, but not yet in `master`.

Included:
- #1286, #1360, #1377 

Omitted:
- #1064 and #1349 (hide cursor on scroll).  This is not a high-value feature, and has so far proven unreliable in practice (works on some sites, not others; triggers chrome bug on some sites for some chrome versions).
- #1214 (vomnibar in iframe).  See discussion in #1382.  The version currently in `post-1.46` is a little laggy, and we have not yet resolved whether and how to fix it (one proposal is in #1382).

Going forward:
- I propose that we work primarily off `master`.
- However, I'll keep `post-1.46` around for a bit, in case we make progress on any of the remaining features.