### PR TITLE
Vomnibar in iframe flickers (post-1.46 only)

### DIFF
--- a/pages/vomnibar.css
+++ b/pages/vomnibar.css
@@ -3,7 +3,7 @@
 
 #vomnibar ol, #vomnibar ul {
   list-style: none;
-  display: block;
+  display: none;
 }
 
 #vomnibar {


### PR DESCRIPTION
@mrmr1993,

I'm seeing a flicker below the vomnibar sometimes when it's first loaded (particularly on busy pages).  Are you seeing that?

This seems to fix it.  What do you think?

(This does not affect `master` or 1.49.)
