### PR TITLE
Ui component changes

### DIFF
--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -2,8 +2,6 @@ class UIComponent
   iframeElement: null
   iframePort: null
   showing: null
-  showStyle: "display: block;"
-  hideStyle: "display: none;"
 
   constructor: (iframeUrl, className, @handleMessage) ->
     @iframeElement = document.createElement "iframe"
@@ -34,20 +32,21 @@ class UIComponent
     if @showing
       # NOTE(smblott) Experimental.  Not sure this is a great idea. If the iframe was already showing, then
       # the user gets no visual feedback when it is re-focused.  So flash its border.
-      borderWas = @iframeElement.style.border
-      @iframeElement.style.border = '5px solid yellow'
-      setTimeout((=> @iframeElement.style.border = borderWas), 200)
+      @iframeElement.classList.add "vimiumUIComponentReactivated"
+      setTimeout((=> @iframeElement.classList.remove "vimiumUIComponentReactivated"), 200)
     else
       @show()
     @iframeElement.focus()
 
   show: (message) ->
     @postMessage message if message?
-    @iframeElement.setAttribute "style", @showStyle
+    @iframeElement.classList.remove "vimiumUIComponentHidden"
+    @iframeElement.classList.add "vimiumUIComponentShowing"
     @showing = true
 
   hide: (focusWindow = true)->
-    @iframeElement.setAttribute "style", @hideStyle
+    @iframeElement.classList.remove "vimiumUIComponentShowing"
+    @iframeElement.classList.add "vimiumUIComponentHidden"
     window.focus() if focusWindow
     @showing = false
 

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -302,3 +302,16 @@ div#vimiumFlash {
   position: absolute;
   z-index: 2147483648;
 }
+
+/* UIComponent CSS */
+iframe.vimiumUIComponentHidden {
+  display: none;
+}
+
+iframe.vimiumUIComponentVisible {
+  display: block;
+}
+
+iframe.vimiumUIComponentReactivated {
+  border: 5px solid yellow;
+}


### PR DESCRIPTION
This PR
- reinstates `UIComponent.show` as a non-focusing alternative to `UIComponent.activate` (useful for the HUD).
- uses classes and rules in the stylesheet to show/hide components.
  - this allows code to add custom styles for hidden, visible and 'reactivated' elements without getting involved with `UIComponent`'s inner workings.

@smblott-github I just went to try and move the HUD to an iframe as a `UIComponent`, but it seems you killed `UIComponent.show` in 0524bdc3f76279e8930bfe4b1b42d93e0e9bf6e4. This fixes that :)
