### PR TITLE
[Post-1.46] Enable link hints for all elements with click listeners, and drop some legacy link hint conditions

### DIFF
--- a/content_scripts/inject_script.coffee
+++ b/content_scripts/inject_script.coffee
@@ -1,0 +1,16 @@
+# Inject scripts into the page context before page scripts are executed
+
+fetchFileContents = (extensionFileName) ->
+  req = new XMLHttpRequest()
+  req.open("GET", chrome.runtime.getURL(extensionFileName), false) # false => synchronous
+  req.send()
+  req.responseText
+
+eventName = "reset"
+injectScripts = ["pages/addEventListener_hook.js"]
+
+# Injection method taken from method 3 of this stackoverflow answer http://stackoverflow.com/a/9517879
+for script in injectScripts
+  document.documentElement.setAttribute("on#{eventName}", fetchFileContents script)
+  document.documentElement.dispatchEvent(new CustomEvent(eventName))
+  document.documentElement.removeAttribute("on#{eventName}")

--- a/content_scripts/inject_script.coffee
+++ b/content_scripts/inject_script.coffee
@@ -2,15 +2,28 @@
 
 fetchFileContents = (extensionFileName) ->
   req = new XMLHttpRequest()
-  req.open("GET", chrome.runtime.getURL(extensionFileName), false) # false => synchronous
+  req.open "GET", chrome.runtime.getURL(extensionFileName), false # false => synchronous
   req.send()
   req.responseText
 
 eventName = "reset"
+listenerName = "on#{eventName}"
 injectScripts = ["pages/addEventListener_hook.js"]
+
+# Store the original value of the event listener if one exists, or null otherwise.
+oldValue =
+  if document.documentElement.hasAttribute listenerName
+    document.documentElement.getAttribute listenerName
+  else
+    null
 
 # Injection method taken from method 3 of this stackoverflow answer http://stackoverflow.com/a/9517879
 for script in injectScripts
-  document.documentElement.setAttribute("on#{eventName}", fetchFileContents script)
-  document.documentElement.dispatchEvent(new CustomEvent(eventName))
-  document.documentElement.removeAttribute("on#{eventName}")
+  document.documentElement.setAttribute listenerName, fetchFileContents script
+  document.documentElement.dispatchEvent new CustomEvent eventName
+
+# Clear our event listener and restore the original, if there was one.
+if oldValue?
+  document.documentElement.setAttribute listenerName, oldValue
+else
+  document.documentElement.removeAttribute listenerName

--- a/content_scripts/inject_script.coffee
+++ b/content_scripts/inject_script.coffee
@@ -17,13 +17,25 @@ oldValue =
   else
     null
 
-# Injection method taken from method 3 of this stackoverflow answer http://stackoverflow.com/a/9517879
+firstDocumentElementChild = document.documentElement.firstElementChild
+
 for script in injectScripts
+  # Injection method taken from method 3 of this stackoverflow answer http://stackoverflow.com/a/9517879
   document.documentElement.setAttribute listenerName, fetchFileContents script
   document.documentElement.dispatchEvent new CustomEvent eventName
+
+  # Also inject as a script, so that we can still catch any addEventListener call fired at/after
+  # DOMContentLoaded.
+  scriptEl = document.createElement "script"
+  scriptEl.src = chrome.runtime.getURL injectScripts[0]
+  document.documentElement.insertBefore scriptEl, firstDocumentElementChild
 
 # Clear our event listener and restore the original, if there was one.
 if oldValue?
   document.documentElement.setAttribute listenerName, oldValue
 else
   document.documentElement.removeAttribute listenerName
+
+scriptEl = document.createElement "script"
+scriptEl.src = chrome.runtime.getURL injectScripts[0]
+document.documentElement.insertBefore scriptEl, document.documentElement.firstElementChild

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -156,7 +156,8 @@ LinkHints =
     if (element.hasAttribute("onclick") or
         element.getAttribute("role")?.toLowerCase() in ["button", "link"] or
         element.getAttribute("class")?.toLowerCase().indexOf("button") >= 0 or
-        element.getAttribute("contentEditable")?.toLowerCase() in ["", "contentEditable", "true"])
+        element.getAttribute("contentEditable")?.toLowerCase() in ["", "contentEditable", "true"] or
+        element.hasAttribute("vimium-has-onclick-listener"))
       isClickable = true
 
     # Check for jsaction event listeners on the element.

--- a/manifest.json
+++ b/manifest.json
@@ -54,6 +54,12 @@
       "css": ["content_scripts/file_urls.css"],
       "run_at": "document_start",
       "all_frames": true
+    },
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content_scripts/inject_script.js"],
+      "run_at": "document_start",
+      "all_frames": true
     }
   ],
   "browser_action": {
@@ -61,6 +67,7 @@
     "default_popup": "pages/popup.html"
   },
   "web_accessible_resources": [
-    "pages/vomnibar.html"
+    "pages/vomnibar.html",
+    "pages/addEventListener_hook.js"
   ]
 }

--- a/pages/addEventListener_hook.coffee
+++ b/pages/addEventListener_hook.coffee
@@ -1,0 +1,10 @@
+_addEventListener = Element::addEventListener
+
+Element::addEventListener = (type, listener, useCapture) ->
+  if type == "click"
+    unless @getAttribute("onclick")
+      # Perform this asynchronously; not doing so breaks some of the facebook UI for some unclear reason
+      setTimeout(=>
+        @setAttribute("onclick", "")
+      , 0)
+  _addEventListener.apply(this, arguments)

--- a/pages/addEventListener_hook.coffee
+++ b/pages/addEventListener_hook.coffee
@@ -2,9 +2,6 @@ _addEventListener = Element::addEventListener
 
 Element::addEventListener = (type, listener, useCapture) ->
   if type == "click"
-    unless @getAttribute("vimium-has-onclick-listener")
-      # Perform this asynchronously; not doing so breaks some of the facebook UI for some unclear reason
-      setTimeout(=>
-        @setAttribute("vimium-has-onclick-listener", "")
-      , 0)
+    unless @hasAttribute("vimium-has-onclick-listener")
+      @setAttribute("vimium-has-onclick-listener", "")
   _addEventListener.apply(this, arguments)

--- a/pages/addEventListener_hook.coffee
+++ b/pages/addEventListener_hook.coffee
@@ -2,9 +2,9 @@ _addEventListener = Element::addEventListener
 
 Element::addEventListener = (type, listener, useCapture) ->
   if type == "click"
-    unless @getAttribute("onclick")
+    unless @getAttribute("vimium-has-onclick-listener")
       # Perform this asynchronously; not doing so breaks some of the facebook UI for some unclear reason
       setTimeout(=>
-        @setAttribute("onclick", "")
+        @setAttribute("vimium-has-onclick-listener", "")
       , 0)
   _addEventListener.apply(this, arguments)

--- a/pages/addEventListener_hook.coffee
+++ b/pages/addEventListener_hook.coffee
@@ -1,3 +1,6 @@
+return if document.documentElement.hasAttribute("vimium-listening-for-onclick-listeners") or
+          document.documentElement.hasAttribute("vimium-listening-for-onclick-listeners-slow")
+
 _addEventListener = Element::addEventListener
 
 Element::addEventListener = (type, listener, useCapture) ->
@@ -6,4 +9,9 @@ Element::addEventListener = (type, listener, useCapture) ->
       @setAttribute "vimium-has-onclick-listener", ""
   _addEventListener.apply this, arguments
 
-document.documentElement.setAttribute "vimium-listening-for-onclick-listeners", ""
+if window.event?
+  # Executing before any page scripts.
+  document.documentElement.setAttribute "vimium-listening-for-onclick-listeners", ""
+else
+  # Executing before DOMContentLoaded, after page scripts.
+  document.documentElement.setAttribute "vimium-listening-for-onclick-listeners-slow", ""

--- a/pages/addEventListener_hook.coffee
+++ b/pages/addEventListener_hook.coffee
@@ -2,6 +2,8 @@ _addEventListener = Element::addEventListener
 
 Element::addEventListener = (type, listener, useCapture) ->
   if type == "click"
-    unless @hasAttribute("vimium-has-onclick-listener")
-      @setAttribute("vimium-has-onclick-listener", "")
-  _addEventListener.apply(this, arguments)
+    unless @hasAttribute "vimium-has-onclick-listener"
+      @setAttribute "vimium-has-onclick-listener", ""
+  _addEventListener.apply this, arguments
+
+document.documentElement.setAttribute "vimium-listening-for-onclick-listeners", ""


### PR DESCRIPTION
This PR is #1167 rebased onto `post-1.46`.

This also contains a check for whether our `addEventListener` hook has been applied successfully:
* if so, we drop a couple of legacy link hint conditions (`tabIndex`, `button` in `className`)
* if not, we fall back to the legacy conditions.

This removes a lot of the duplicate/useless link hints we were seeing on a lot of pages (eg. the options page).