### PR TITLE
Modal browsing, and towards visual mode (a proof of concept)

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -339,6 +339,13 @@ updateOpenTabs = (tab) ->
 setBrowserActionIcon = (tabId,path) ->
   chrome.browserAction.setIcon({ tabId: tabId, path: path })
 
+# This color should match the blue of the Vimium browser popup (although it looks a little darker, to me?).
+chrome.browserAction.setBadgeBackgroundColor {color: [102, 176, 226, 255]}
+
+setBadge = (response) ->
+  badge = response?.badge || ""
+  chrome.browserAction.setBadgeText {text: badge}
+
 # Updates the browserAction icon to indicate whether Vimium is enabled or disabled on the current page.
 # Also propagates new enabled/disabled/passkeys state to active window, if necessary.
 # This lets you disable Vimium on a page without needing to reload.
@@ -349,6 +356,7 @@ root.updateActiveState = updateActiveState = (tabId) ->
   partialIcon = "icons/browser_action_partial.png"
   chrome.tabs.get tabId, (tab) ->
     chrome.tabs.sendMessage tabId, { name: "getActiveState" }, (response) ->
+      setBadge response
       if response
         isCurrentlyEnabled = response.enabled
         currentPasskeys = response.passKeys
@@ -602,6 +610,7 @@ unregisterFrame = (request, sender) ->
       frameIdsForTab[tabId] = frameIdsForTab[tabId].filter (id) -> id != request.frameId
 
 handleFrameFocused = (request, sender) ->
+  setBadge request
   tabId = sender.tab.id
   if frameIdsForTab[tabId]?
     frameIdsForTab[tabId] =
@@ -633,6 +642,7 @@ sendRequestHandlers =
   refreshCompleter: refreshCompleter
   createMark: Marks.create.bind(Marks)
   gotoMark: Marks.goto.bind(Marks)
+  setBadge: setBadge
 
 # Convenience function for development use.
 window.runTests = -> open(chrome.runtime.getURL('tests/dom_tests/dom_tests.html'))

--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -1,12 +1,74 @@
-root = exports ? window
 
-class root.Mode
-  constructor: (onKeydown, onKeypress, onKeyup, @popModeCallback) ->
+class Mode
+  # Static members.
+  @modes: []
+  @current: -> Mode.modes[0]
+  @suppressPropagation = false
+  @propagate = true
+
+  # Default values.
+  name: ""             # The name of this mode.
+  badge: ""            # A badge to display on the popup when this mode is active.
+  keydown: "suppress"  # A function, or "suppress" or "pass"; the latter are replaced with suitable functions.
+  keypress: "suppress" # A function, or "suppress" or "pass"; the latter are replaced with suitable functions.
+  keyup: "suppress"    # A function, or "suppress" or "pass"; the latter are replaced with suitable functions.
+  onDeactivate: ->     # Called when leaving this mode.
+  onReactivate: ->     # Called when this mode is reactivated.
+
+  constructor: (options) ->
+    extend @, options
+
     @handlerId = handlerStack.push
-      keydown: onKeydown
-      keypress: onKeypress
-      keyup: onKeyup
+      keydown: @checkForBuiltInHandler "keydown", @keydown
+      keypress: @checkForBuiltInHandler "keypress", @keypress
+      keyup: @checkForBuiltInHandler "keyup", @keyup
+      reactivateMode: =>
+        @onReactivate()
+        Mode.setBadge()
+        return Mode.suppressPropagation
 
-  popMode: ->
+    Mode.modes.unshift @
+    Mode.setBadge()
+
+  # Allow the strings "suppress" and "pass" to be used as proxies for the built-in handlers.
+  checkForBuiltInHandler: (type, handler) ->
+    switch handler
+      when "suppress" then @generateSuppressPropagation type
+      when "pass" then @generatePassThrough type
+      else handler
+
+  # Generate a default handler which always passes through; except Esc, which pops the current mode.
+  generatePassThrough: (type) ->
+    me = @
+    (event) ->
+      if type == "keydown" and KeyboardUtils.isEscape event
+        me.popMode event
+        return Mode.suppressPropagation
+      handlerStack.passThrough
+
+  # Generate a default handler which always suppresses propagation; except Esc, which pops the current mode.
+  generateSuppressPropagation: (type) ->
+    handler = @generatePassThrough type
+    (event) -> handler(event) and Mode.suppressPropagation # Always falsy.
+
+  # Leave the current mode; event may or may not be provide.  It is the responsibility of the creator of this
+  # object to know whether or not an event will be provided.  Bubble a "reactivateMode" event to notify the
+  # now-active mode that it is once again top dog.
+  popMode: (event) ->
+    Mode.modes = Mode.modes.filter (mode) => mode != @
     handlerStack.remove @handlerId
-    @popModeCallback()
+    @onDeactivate event
+    handlerStack.bubbleEvent "reactivateMode", event
+
+  # Set the badge on the browser popup to indicate the current mode; static method.
+  @setBadge: ->
+    badge = Mode.getBadge()
+    chrome.runtime.sendMessage({ handler: "setBadge", badge: badge })
+
+  # Static convenience methods.
+  @is: (mode) -> Mode.current()?.name == mode
+  @getBadge: -> Mode.current()?.badge || ""
+  @isInsert: -> Mode.is "insert"
+
+root = exports ? window
+root.Mode = Mode

--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -1,0 +1,12 @@
+root = exports ? window
+
+class root.Mode
+  constructor: (onKeydown, onKeypress, onKeyup, @popModeCallback) ->
+    @handlerId = handlerStack.push
+      keydown: onKeydown
+      keypress: onKeypress
+      keyup: onKeyup
+
+  popMode: ->
+    handlerStack.remove @handlerId
+    @popModeCallback()

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -122,6 +122,7 @@ initializePreDomReady = ->
   Scroller.init settings
 
   handlePassKeyEvent = (event) ->
+    return true if findMode # This is necessary for legacy find mode; will not be necessary in future.
     for keyChar in [ KeyboardUtils.getKeyChar(event), String.fromCharCode(event.charCode) ]
       return handlerStack.passThrough if keyChar and isPassKey keyChar
     true

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -618,8 +618,8 @@ window.enterInsertMode = (target) ->
 # Note. This returns the truthiness of target, which is required by isInsertMode.
 #
 enterInsertModeWithoutShowingIndicator = (target) ->
-  insertModeLock = target
   unless Mode.isInsert()
+    insertModeLock = target
     # Install insert-mode handler.  Hereafter, all key events will be passed directly to the underlying page.
     # The current isInsertMode logic in the normal-mode handlers is now redundant..
     new Mode

--- a/lib/handler_stack.coffee
+++ b/lib/handler_stack.coffee
@@ -1,11 +1,11 @@
 root = exports ? window
 
-class root.HandlerStack
+class HandlerStack
 
   constructor: ->
     @stack = []
     @counter = 0
-    @passThrough = {}
+    @passThrough = new Object() # Used only as a constant, distinct from any other value.
 
   genId: -> @counter = ++@counter & 0xffff
 
@@ -19,7 +19,6 @@ class root.HandlerStack
   # propagation by returning a falsy value.
   bubbleEvent: (type, event) ->
     for i in [(@stack.length - 1)..0] by -1
-      console.log i, type
       handler = @stack[i]
       # We need to check for existence of handler because the last function call may have caused the release
       # of more than one handler.
@@ -29,8 +28,8 @@ class root.HandlerStack
         if not passThrough
           DomUtils.suppressEvent(event)
           return false
-        # If @passThrough is returned, then discontinue further bubbling and pass the event through to the
-        # underlying page.  The event is not suppresssed.
+        # If the constant @passThrough is returned, then discontinue further bubbling and pass the event
+        # through to the underlying page.  The event is not suppresssed.
         if passThrough == @passThrough
           return false
     true
@@ -42,4 +41,5 @@ class root.HandlerStack
         @stack.splice(i, 1)
         break
 
+root. HandlerStack = HandlerStack
 root.handlerStack = new HandlerStack

--- a/lib/handler_stack.coffee
+++ b/lib/handler_stack.coffee
@@ -41,5 +41,5 @@ class HandlerStack
         @stack.splice(i, 1)
         break
 
-root. HandlerStack = HandlerStack
+root.HandlerStack = HandlerStack
 root.handlerStack = new HandlerStack

--- a/lib/handler_stack.coffee
+++ b/lib/handler_stack.coffee
@@ -5,6 +5,7 @@ class root.HandlerStack
   constructor: ->
     @stack = []
     @counter = 0
+    @passThrough = {}
 
   genId: -> @counter = ++@counter & 0xffff
 
@@ -18,6 +19,7 @@ class root.HandlerStack
   # propagation by returning a falsy value.
   bubbleEvent: (type, event) ->
     for i in [(@stack.length - 1)..0] by -1
+      console.log i, type
       handler = @stack[i]
       # We need to check for existence of handler because the last function call may have caused the release
       # of more than one handler.
@@ -27,6 +29,10 @@ class root.HandlerStack
         if not passThrough
           DomUtils.suppressEvent(event)
           return false
+        # If @passThrough is returned, then discontinue further bubbling and pass the event through to the
+        # underlying page.  The event is not suppresssed.
+        if passThrough == @passThrough
+          return false
     true
 
   remove: (id = @currentId) ->
@@ -35,3 +41,5 @@ class root.HandlerStack
       if handler.id == id
         @stack.splice(i, 1)
         break
+
+root.handlerStack = new HandlerStack

--- a/manifest.json
+++ b/manifest.json
@@ -43,6 +43,7 @@
              "content_scripts/vomnibar.js",
              "content_scripts/scroller.js",
              "content_scripts/marks.js",
+             "content_scripts/mode.js",
              "content_scripts/vimium_frontend.js"
             ],
       "css": ["content_scripts/vimium.css"],

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -178,6 +178,7 @@ context "Input focus",
     focusInput 1
     assert.equal "first", document.activeElement.id
     # deactivate the tabbing mode and its overlays
+    currentCompletionKeys = ""
     handlerStack.bubbleEvent 'keydown', mockKeyboardEvent("A")
 
     focusInput 100

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -178,7 +178,6 @@ context "Input focus",
     focusInput 1
     assert.equal "first", document.activeElement.id
     # deactivate the tabbing mode and its overlays
-    currentCompletionKeys = ""
     handlerStack.bubbleEvent 'keydown', mockKeyboardEvent("A")
 
     focusInput 100

--- a/tests/dom_tests/dom_tests.html
+++ b/tests/dom_tests/dom_tests.html
@@ -39,6 +39,7 @@
     <script type="text/javascript" src="../../content_scripts/link_hints.js"></script>
     <script type="text/javascript" src="../../content_scripts/vomnibar.js"></script>
     <script type="text/javascript" src="../../content_scripts/scroller.js"></script>
+    <script type="text/javascript" src="../../content_scripts/mode.js"></script>
     <script type="text/javascript" src="../../content_scripts/vimium_frontend.js"></script>
 
     <script type="text/javascript" src="../shoulda.js/shoulda.js"></script>

--- a/tests/unit_tests/test_chrome_stubs.coffee
+++ b/tests/unit_tests/test_chrome_stubs.coffee
@@ -41,6 +41,8 @@ exports.chrome =
       addListener: () -> true
     getAll: () -> true
 
+  browserAction:
+    setBadgeBackgroundColor: ->
   storage:
     # chrome.storage.local
     local:


### PR DESCRIPTION
A major goal for the next release is visual mode.  This is a proof-of-concept illustrating how we can introduce a clean, modal browsing experience within our existing framework.  And hence, how we can move forward to visual mode (and others).

Design goals:

- Re-use existing code where possible.  Because, if it works, let's use it.

- To the greatest extent possible, limit changes to existing code.  Because changes introduce unintended side effects and bugs; changes always come with risk.

- Allow modal browsing.  While the immediate goal is visual mode, ultimately we may introduce other new modes too.  For example, a vim-like editing mode.  We need an architecture which allows us to move smoothly and orthogonally between modes.  Examples:
  - `normal` -> `visual`
  - `normal` -> `insert`
  - `normal` -> `hint`
  - `normal` -> `edit` -> `insert`
  - `normal` -> `edit` -> `visual`
  - `normal` -> `edit` -> `visual` -> `edit` -> `insert` (and so on)

This proof-of-concept does not introduce any new functionality.  It does:

- Introduce a class `Mode` for handling modes and mode transitions.  Basically, this implements a stack of modes using the existing `HandlerStack` infrastructure for key handling.

- Move normal Vimium key handling to a mode (`normal`).  So `normal` mode is handled just like any other mode.

- Move insert mode and passkeys handling to new modes (`insert` and `passkeys`). `normal` mode and `passkeys` mode are always on the mode stack.  They are never deactivated.  Link-hint mode is not yet incorporated.

- Provide visual feedback as to the current mode via a badge on the browser popup.

Feedback would be appreciated.

Edit.  I forgot to add...
- With `insert` and `passkeys` mode incorporated within the mode framework, much of the current `normal`-mode key handling can be simplified.  To keep the PR clean, I've left that out for the moment.