### PR TITLE
Fix travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js: 0.10
 before_install:
   - "npm install -g coffee-script"
   - "npm install path"
+  - "npm install util"
   - "cake build"
 script: "cake test"
 notifications:


### PR DESCRIPTION
This explicitly installs the `utils` package in Travis, fixing recent test failures. Fixes #1419.