### PR TITLE
Correctly implement normal mode after find when an input is focused

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -453,19 +453,7 @@ onKeydown = (event) ->
       if (modifiers.length > 0 || keyChar.length > 1)
         keyChar = "<" + keyChar + ">"
 
-  if (isInsertMode() && KeyboardUtils.isEscape(event))
-    if isEditable(event.srcElement) or isEmbed(event.srcElement)
-      # Remove focus so the user can't just get himself back into insert mode by typing in the same input
-      # box.
-      # NOTE(smblott, 2014/12/22) Including embeds for .blur() etc. here is experimental.  It appears to be
-      # the right thing to do for most common use cases.  However, it could also cripple flash-based sites and
-      # games.  See discussion in #1211 and #1194.
-      event.srcElement.blur()
-    exitInsertMode()
-    DomUtils.suppressEvent event
-    KeydownEvents.push event
-
-  else if (findMode)
+  if (findMode)
     if (KeyboardUtils.isEscape(event))
       handleEscapeForFindMode()
       DomUtils.suppressEvent event
@@ -484,6 +472,18 @@ onKeydown = (event) ->
     else if (!modifiers)
       DomUtils.suppressPropagation(event)
       KeydownEvents.push event
+
+  else if (isInsertMode() && KeyboardUtils.isEscape(event))
+    if isEditable(event.srcElement) or isEmbed(event.srcElement)
+      # Remove focus so the user can't just get himself back into insert mode by typing in the same input
+      # box.
+      # NOTE(smblott, 2014/12/22) Including embeds for .blur() etc. here is experimental.  It appears to be
+      # the right thing to do for most common use cases.  However, it could also cripple flash-based sites and
+      # games.  See discussion in #1211 and #1194.
+      event.srcElement.blur()
+    exitInsertMode()
+    DomUtils.suppressEvent event
+    KeydownEvents.push event
 
   else if (isShowingHelpDialog && KeyboardUtils.isEscape(event))
     hideHelpDialog()

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -614,14 +614,19 @@ window.enterInsertMode = (target) ->
 enterInsertModeWithoutShowingIndicator = (target) ->
   insertModeLock = target
   # normalModeForInput is a sub-mode of insert mode; it shouldn't be persisted across insert mode instances.
+  # We re-establish insert mode when the user clicks to fix #1414.
+  target?.addEventListener? "click", reestablishInputModeOnClick, false
   normalModeForInput = false
 
 exitInsertMode = (target) ->
   if (target == undefined || insertModeLock == target)
     # normalModeForInput is a sub-mode of insert mode; deactivate it if insert mode isn't active.
+    target?.removeEventListener? "click", reestablishInputModeOnClick, false
     normalModeForInput = false
     insertModeLock = null
     HUD.hide()
+
+reestablishInputModeOnClick = -> enterInsertModeWithoutShowingIndicator this
 
 isInsertMode = ->
   return true if insertModeLock != null

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -220,7 +220,7 @@ unregisterFrame = ->
 # Enters insert mode if the currently focused element in the DOM is focusable.
 #
 enterInsertModeIfElementIsFocused = ->
-  if (document.activeElement && isEditable(document.activeElement) && !findMode)
+  if (document.activeElement && isEditable(document.activeElement))
     enterInsertModeWithoutShowingIndicator(document.activeElement)
 
 onDOMActivate = (event) -> handlerStack.bubbleEvent 'DOMActivate', event
@@ -548,7 +548,7 @@ isValidFirstKey = (keyChar) ->
   validFirstKeys[keyChar] || /^[1-9]/.test(keyChar)
 
 onFocusCapturePhase = (event) ->
-  if (isFocusable(event.target) && !findMode)
+  if (isFocusable(event.target))
     enterInsertModeWithoutShowingIndicator(event.target)
 
 onBlurCapturePhase = (event) ->

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -7,7 +7,7 @@
 window.handlerStack = new HandlerStack
 
 insertModeLock = null
-normalModeForInput = false
+normalModeForInput = false # This is a sub-mode of insert mode for normal mode when an input is focused.
 findMode = false
 findModeQuery = { rawQuery: "", matchCount: 0 }
 findModeQueryHasResults = false
@@ -500,6 +500,9 @@ onKeydown = (event) ->
       normalModeForInput = false
 
     if (normalModeForInput && KeyboardUtils.isEscape(event))
+      # If we've focused an input, but are still providing the user with normal mode, we should drop into
+      # insert mode when they hit <esc>.
+      # NOTE(mrmr1993): This is purely to retain an old behaviour, and is not my design decision.
       normalModeForInput = false
       DomUtils.suppressEvent event
       KeydownEvents.push event
@@ -724,6 +727,8 @@ handleEnterForFindMode = ->
   # If an input is focused, we still want to drop the user back into normal mode. normalModeForInput is a
   # sub-mode of insert mode (and will exit if the insert mode focus changes, we exit insert mode, or were
   # never in insert mode to start with).
+  # NOTE(mrmr1993): We don't check isInsertMode here in case contentEditable is set dynamically (see comment
+  # in isInsertMode).
   normalModeForInput = true
   document.body.classList.add("vimiumFindMode")
   settings.set("findModeRawQuery", findModeQuery.rawQuery)


### PR DESCRIPTION
This PR implements a sub-mode of input mode, called `normalModeForInput`, which allows us to run normal mode commands after having focused an `input`/`textarea`/`contentEditable` element. It also removes the old, broken hack of blocking insert mode when find mode is active, and readjusts the order of modes in the key handler so find mode gets keys before insert mode (seems counter-intuitive, but it's definitely what we want in practice).

This
* fixes #1414.
* fixes #1412.
* fixes #1410.
* fixes #1415.

@smblott-github, this was your list of issues with `master` in its current state [over in #1413](https://github.com/philc/vimium/pull/1413#issuecomment-69307693), could you take a look over this?