### PR TITLE
Fix race condition on the options page.

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -1142,7 +1142,7 @@ CursorHider =
 initializePreDomReady()
 window.addEventListener("DOMContentLoaded", registerFrame)
 window.addEventListener("unload", unregisterFrame)
-DomUtils.runWhenDOMLoaded initializeOnDomReady
+DomUtils.documentReady initializeOnDomReady
 
 window.onbeforeunload = ->
   chrome.runtime.sendMessage(

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -1142,7 +1142,7 @@ CursorHider =
 initializePreDomReady()
 window.addEventListener("DOMContentLoaded", registerFrame)
 window.addEventListener("unload", unregisterFrame)
-window.addEventListener("DOMContentLoaded", initializeOnDomReady)
+DomUtils.runWhenDOMLoaded initializeOnDomReady
 
 window.onbeforeunload = ->
   chrome.runtime.sendMessage(

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -1140,9 +1140,9 @@ CursorHider =
     window.addEventListener "scroll", @onScroll
 
 initializePreDomReady()
-window.addEventListener("DOMContentLoaded", registerFrame)
-window.addEventListener("unload", unregisterFrame)
 DomUtils.documentReady initializeOnDomReady
+DomUtils.documentReady registerFrame
+window.addEventListener "unload", unregisterFrame
 
 window.onbeforeunload = ->
   chrome.runtime.sendMessage(

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -2,10 +2,11 @@ DomUtils =
   #
   # Runs :callback if the DOM has loaded, otherwise runs it on load
   #
-  documentReady: do ->
-    loaded = false
-    window.addEventListener("DOMContentLoaded", -> loaded = true)
-    (callback) -> if loaded then callback() else window.addEventListener("DOMContentLoaded", callback)
+  documentReady: (func) ->
+    if document.readyState == "loading"
+      window.addEventListener "DOMContentLoaded", func
+    else
+      func()
 
   #
   # Adds a list of elements to a page.
@@ -177,13 +178,6 @@ DomUtils =
   suppressEvent: (event) ->
     event.preventDefault()
     @suppressPropagation(event)
-
-  # Calls func either now (if the DOM has already loaded), or when the DOM is loaded.
-  runWhenDOMLoaded: (func) ->
-    if document.readyState == "loading"
-      window.addEventListener "DOMContentLoaded", func
-    else
-      func()
 
 root = exports ? window
 root.DomUtils = DomUtils

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -178,5 +178,12 @@ DomUtils =
     event.preventDefault()
     @suppressPropagation(event)
 
+  # Calls func either now (if the DOM has already loaded), or when the DOM is loaded.
+  runWhenDOMLoaded: (func) ->
+    if document.readyState == "loading"
+      window.addEventListener "DOMContentLoaded", func
+    else
+      func()
+
 root = exports ? window
 root.DomUtils = DomUtils


### PR DESCRIPTION
Call onDOMContentLoaded handlers immediately, if the DOM is already loaded.

Fixes #1426.