### PR TITLE
Fix slightly wonky perform-find-in-place

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -702,18 +702,10 @@ handleEnterForFindMode = ->
   settings.set("findModeRawQuery", findModeQuery.rawQuery)
 
 performFindInPlace = ->
-  cachedScrollX = window.scrollX
-  cachedScrollY = window.scrollY
-
   query = if findModeQuery.isRegex then getNextQueryFromRegexMatches(0) else findModeQuery.parsedQuery
 
-  # Search backwards first to "free up" the current word as eligible for the real forward search. This allows
-  # us to search in place without jumping around between matches as the query grows.
-  executeFind(query, { backwards: true, caseSensitive: !findModeQuery.ignoreCase })
-
-  # We need to restore the scroll position because we might've lost the right position by searching
-  # backwards.
-  window.scrollTo(cachedScrollX, cachedScrollY)
+  selection = window.getSelection()
+  selection.collapseToStart() if selection.type == "Range"
 
   findModeQueryHasResults = executeFind(query, { caseSensitive: !findModeQuery.ignoreCase })
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -703,6 +703,8 @@ handleEnterForFindMode = ->
   settings.set("findModeRawQuery", findModeQuery.rawQuery)
 
 performFindInPlace = ->
+  # Restore the selection.  That way, we're always searching forward from the same place, so we find the right
+  # match as the user adds matching characters, or removes previously-matched characters. See #1434.
   findModeRestoreSelection()
   query = if findModeQuery.isRegex then getNextQueryFromRegexMatches(0) else findModeQuery.parsedQuery
   findModeQueryHasResults = executeFind(query, { caseSensitive: !findModeQuery.ignoreCase })
@@ -927,7 +929,7 @@ getCurrentRange = ->
     range
   else
     selection.collapseToStart() if selection.type == "Range"
-    range = selection.getRangeAt 0
+    selection.getRangeAt 0
 
 findModeSaveSelection = ->
   findModeInitialRange = getCurrentRange()
@@ -938,6 +940,7 @@ findModeRestoreSelection = (range = findModeInitialRange) ->
   selection.addRange range
 
 window.enterFindMode = ->
+  # Save the selection, so performFindInPlace can restore it.
   findModeSaveSelection()
   findModeQuery = { rawQuery: "" }
   findMode = true


### PR DESCRIPTION
When we use `/` for find, the selection should stay put if it continues to match the query as characters are added.  The is handled currently by first searching backwards, before beginning the real search.  This trick doesn't always work.  Here's an example: 

- Go [here](http://static.smblott.org/inputs.html) (my wonky-find test page).
- Search: `/ooo`

The search jumps around unnecessarily. Bad UX.

This PR uses a different (simpler?) method for sticking to the existing match.  Basically, we store the initial selection, then restore it before each `performFindInPlace`.  So we're always starting from the same place.

(I was hoping to get a fix for #1375; but no joy.)