### PR TITLE
On simulateSelect, do not change selection if selection exists.

### DIFF
--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -177,9 +177,10 @@ DomUtils =
 
   simulateSelect: (element) ->
     element.focus()
-    # When focusing a textbox, put the selection caret at the end of the textbox's contents.
-    # For some HTML5 input types (eg. date) we can't position the caret, so we wrap this with a try.
-    try element.setSelectionRange(element.value.length, element.value.length)
+    unless @isSelected element
+      # When focusing a textbox, put the selection caret at the end of the textbox's contents.
+      # For some HTML5 input types (eg. date) we can't position the caret, so we wrap this with a try.
+      try element.setSelectionRange(element.value.length, element.value.length)
 
   simulateClick: (element, modifiers) ->
     modifiers ||= {}

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -176,13 +176,14 @@ DomUtils =
       element.selectionStart? and element.selectionEnd? and element.selectionStart != element.selectionEnd
 
   simulateSelect: (element) ->
+    isSelected = @isSelected element
     # If element == document.activeElement, then we won't get a new focus event.  So, we pretend (to any
     # active modes which care, e.g. PostFindMode) that element has been clicked.
     if element == document.activeElement and DomUtils.isEditable document.activeElement
       handlerStack.bubbleEvent "click", target: element
 
     element.focus()
-    unless @isSelected element
+    unless isSelected
       # When focusing a textbox, put the selection caret at the end of the textbox's contents.
       # For some HTML5 input types (eg. date) we can't position the caret, so we wrap this with a try.
       try element.setSelectionRange(element.value.length, element.value.length)


### PR DESCRIPTION
Fixes #1430.

This is the same as #1431, except it uses a different version of `isSelected` ([here](https://github.com/philc/vimium/blob/master/lib/dom_utils.coffee#L171)).