### PR TITLE
Give focusInput (gi) a memory

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -338,7 +338,11 @@ getFocusedElementIndexByRecency = do ->
   installListener window, "focus", (event) ->
     focusedElement = event.target if DomUtils.isEditable event.target
 
-  (elements) ->
+  # Only for tests.
+  window.resetFocusInputFocusedElement = ->
+    focusedElement = null
+
+  (elements = null) ->
     Math.max 0, elements.indexOf focusedElement
 
 extend window,

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -342,7 +342,7 @@ getFocusedElementIndexByRecency = do ->
   window.resetFocusInputFocusedElement = ->
     focusedElement = null
 
-  (elements = null) ->
+  (elements) ->
     Math.max 0, elements.indexOf focusedElement
 
 extend window,

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -184,10 +184,12 @@ context "Input focus",
       <input type='password' id='third' value='some value'/>"
     document.getElementById("test-div").innerHTML = testContent
     backupStackState()
+    resetFocusInputFocusedElement()
 
   tearDown ->
     document.getElementById("test-div").innerHTML = ""
     restoreStackState()
+    resetFocusInputFocusedElement()
 
   should "focus the right element", ->
     focusInput 1
@@ -204,10 +206,25 @@ context "Input focus",
     focusInput 1
     handlerStack.bubbleEvent 'focus', { target: document.activeElement }
     assert.isTrue InsertMode.permanentInstance.isActive()
+    # deactivate the tabbing mode and its overlays
+    handlerStack.bubbleEvent 'keydown', mockKeyboardEvent("A")
 
     focusInput 100
     handlerStack.bubbleEvent 'focus', { target: document. activeElement }
     assert.isTrue InsertMode.permanentInstance.isActive()
+    # deactivate the tabbing mode and its overlays
+    handlerStack.bubbleEvent 'keydown', mockKeyboardEvent("A")
+
+  should "select the previously-focused input when count is 1", ->
+    focusInput 100
+    assert.equal "third", document.activeElement.id
+    # deactivate the tabbing mode and its overlays
+    handlerStack.bubbleEvent 'keydown', mockKeyboardEvent("A")
+
+    focusInput 1
+    assert.equal "third", document.activeElement.id
+    # deactivate the tabbing mode and its overlays
+    handlerStack.bubbleEvent 'keydown', mockKeyboardEvent("A")
 
 # TODO: these find prev/next link tests could be refactored into unit tests which invoke a function which has
 # a tighter contract than goNext(), since they test minor aspects of goNext()'s link matching behavior, and we

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -184,12 +184,10 @@ context "Input focus",
       <input type='password' id='third' value='some value'/>"
     document.getElementById("test-div").innerHTML = testContent
     backupStackState()
-    resetFocusInputFocusedElement()
 
   tearDown ->
     document.getElementById("test-div").innerHTML = ""
     restoreStackState()
-    resetFocusInputFocusedElement()
 
   should "focus the right element", ->
     focusInput 1
@@ -204,25 +202,16 @@ context "Input focus",
     focusInput 1
     handlerStack.bubbleEvent 'focus', target: document.activeElement
     assert.isTrue InsertMode.permanentInstance.isActive()
-    # deactivate the tabbing mode and its overlays
-    handlerStack.bubbleEvent 'keydown', mockKeyboardEvent("A")
 
     focusInput 100
     handlerStack.bubbleEvent 'focus', target: document. activeElement
     assert.isTrue InsertMode.permanentInstance.isActive()
-    # deactivate the tabbing mode and its overlays
-    handlerStack.bubbleEvent 'keydown', mockKeyboardEvent("A")
 
   should "select the previously-focused input when count is 1", ->
     focusInput 100
-    assert.equal "third", document.activeElement.id
-    # deactivate the tabbing mode and its overlays
-    handlerStack.bubbleEvent 'keydown', mockKeyboardEvent("A")
-
+    handlerStack.bubbleEvent 'focus', target: document. activeElement
     focusInput 1
     assert.equal "third", document.activeElement.id
-    # deactivate the tabbing mode and its overlays
-    handlerStack.bubbleEvent 'keydown', mockKeyboardEvent("A")
 
 # TODO: these find prev/next link tests could be refactored into unit tests which invoke a function which has
 # a tighter contract than goNext(), since they test minor aspects of goNext()'s link matching behavior, and we


### PR DESCRIPTION
When there are multiple inputs available (such as on the new-issue page, here), `focusInput` allows the user to choose which input to focus (via `Tab`).  It's really annoying when the input you want is the third or fourth one.  And it's *particularly* annoying when you move in and out of insert mode several times, but always have to tab back to the same spot.

This PR gives `focusInput` a memory:
- It remembers the most recently-active input.
- When offering a choice, the most recently-active input is selected (not always the first).
- As a side effect, when `focusInput` is run again, the previous choice is immediately selected.

All of this applies only if the count is `1`.  Unfortunately,  this breaks the existing meaning of `1gi`.  In fact, the user has no way of saying *focus the fist input*.

Nevertheless, I propose that this is a big win for a fairly common use case, and losing the ability to force focus the first input is not so bad.

Agree?  Disagree?

Edit:  There's a suitable (junk) test page [here](http://static.smblott.org/inputs.html).

More edit: for correctness.