### PR TITLE
Fix parsing of command mappings.

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -58,7 +58,7 @@ Commands =
 
     for line in lines
       continue if (line[0] == "\"" || line[0] == "#")
-      splitLine = line.split(/\s+/)
+      splitLine = line.replace(/\s+$/, "").split(/\s+/)
 
       lineCommand = splitLine[0]
 


### PR DESCRIPTION
This fixes the parsing of command mappings with trailing whitespace, this case:

```
map q scrollDown_
```

(where `_` is whitespace).

It turns out there's actually another problem.  The following doesn't work either:

```
_map q scrollDown
```

I didn't fix this case.  It doesn't seem to be causing problems in the wild, and there may be people relying on it as an alternative way of commenting out rules.

Fixes #1443.