### PR TITLE
Give find mode a history

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -762,10 +762,7 @@ handleDeleteForFindMode = ->
     exitFindMode()
     performFindInPlace()
   else
-    findModeQuery.rawQuery = findModeQuery.rawQuery.substring(0, findModeQuery.rawQuery.length - 1)
-    updateFindModeQuery()
-    performFindInPlace()
-    showFindModeHUDForQuery()
+    updateQueryForFindMode findModeQuery.rawQuery.substring(0, findModeQuery.rawQuery.length - 1)
 
 # <esc> sends us into insert mode if possible, but <cr> does not.
 # <esc> corresponds approximately to 'nevermind, I have found it already' while <cr> means 'I want to save

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -1014,11 +1014,13 @@ window.goNext = ->
   findAndFollowRel("next") || findAndFollowLink(nextStrings)
 
 showFindModeHUDForQuery = ->
-  if (findModeQueryHasResults || findModeQuery.parsedQuery.length == 0)
+  if findModeQuery.rawQuery and (findModeQueryHasResults || findModeQuery.parsedQuery.length == 0)
     plural = if findModeQuery.matchCount == 1 then "" else "es"
     HUD.show("/" + findModeQuery.rawQuery + " (" + findModeQuery.matchCount + " Match#{plural})")
-  else
+  else if findModeQuery.rawQuery
     HUD.show("/" + findModeQuery.rawQuery + " (No Matches)")
+  else
+    HUD.show("/")
 
 getCurrentRange = ->
   selection = getSelection()

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -673,8 +673,8 @@ FindModeHistory =
 
   recordQuery: (query) ->
     @migration()
-    recentQueries = settings.get "findModeRawQueryList"
-    if 0 < query?.length
+    if 0 < query.length
+      recentQueries = settings.get "findModeRawQueryList"
       settings.set "findModeRawQueryList", ([ query ].concat recentQueries.filter (q) -> q != query)[0..50]
 
   # Migration (from 1.49, 2015/2/1).

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -779,6 +779,7 @@ handleEnterForFindMode = ->
 class FindMode extends Mode
   constructor: ->
     @historyIndex = -1
+    @partialQuery = ""
     super
       name: "find"
       badge: "/"
@@ -796,11 +797,12 @@ class FindMode extends Mode
         else if event.keyCode == keyCodes.upArrow
           if rawQuery = FindModeHistory.getQuery @historyIndex + 1
             @historyIndex += 1
+            @partialQuery = findModeQuery.rawQuery if @historyIndex == 0
             updateQueryForFindMode rawQuery
           @suppressEvent
         else if event.keyCode == keyCodes.downArrow
           @historyIndex = Math.max -1, @historyIndex - 1
-          rawQuery = if 0 <= @historyIndex then FindModeHistory.getQuery @historyIndex else ""
+          rawQuery = if 0 <= @historyIndex then FindModeHistory.getQuery @historyIndex else @partialQuery
           updateQueryForFindMode rawQuery
           @suppressEvent
         else

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -1015,7 +1015,8 @@ window.goNext = ->
 
 showFindModeHUDForQuery = ->
   if (findModeQueryHasResults || findModeQuery.parsedQuery.length == 0)
-    HUD.show("/" + findModeQuery.rawQuery + " (" + findModeQuery.matchCount + " Matches)")
+    plural = if findModeQuery.matchCount == 1 then "" else "es"
+    HUD.show("/" + findModeQuery.rawQuery + " (" + findModeQuery.matchCount + " Match#{plural})")
   else
     HUD.show("/" + findModeQuery.rawQuery + " (No Matches)")
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -711,6 +711,9 @@ updateFindModeQuery = ->
   # default to 'smartcase' mode, unless noIgnoreCase is explicitly specified
   findModeQuery.ignoreCase = !hasNoIgnoreCaseFlag && !Utils.hasUpperCase(findModeQuery.parsedQuery)
 
+  # Don't count matches in the HUD.
+  HUD.hide(true)
+
   # if we are dealing with a regex, grep for all matches in the text, and then call window.find() on them
   # sequentially so the browser handles the scrolling / text selection.
   if findModeQuery.isRegex

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -1,7 +1,7 @@
 KeyboardUtils =
   keyCodes:
     { ESC: 27, backspace: 8, deleteKey: 46, enter: 13, space: 32, shiftKey: 16, ctrlKey: 17, f1: 112,
-    f12: 123, tab: 9 }
+    f12: 123, tab: 9, downArrow: 40, upArrow: 38 }
 
   keyNames:
     { 37: "left", 38: "up", 39: "right", 40: "down" }


### PR DESCRIPTION
This gives find mode a history.

(Am I missing something?  Why have we never had this before?)

Edit:
- Also fix the long-standing issue whereby we report `1 Matches`.
- Also fix the long-standing issue whereby we report a match count for empty queries.