### PR TITLE
Restore scroll position after failed find with /.

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -11,6 +11,8 @@ findModeQuery = { rawQuery: "", matchCount: 0 }
 findModeQueryHasResults = false
 findModeAnchorNode = null
 findModeInitialRange = null
+findModeInitialScrollTop = null
+findModeInitialScrollLeft = null
 isShowingHelpDialog = false
 keyPort = null
 # Users can disable Vimium on URL patterns via the settings page.  The following two variables
@@ -1002,11 +1004,15 @@ getCurrentRange = ->
 
 findModeSaveSelection = ->
   findModeInitialRange = getCurrentRange()
+  findModeInitialScrollTop = document.body?.scrollTop
+  findModeInitialScrollLeft = document.body?.scrollLeft
 
 findModeRestoreSelection = (range = findModeInitialRange) ->
   selection = getSelection()
   selection.removeAllRanges()
   selection.addRange range
+  document.body.scrollTop = findModeInitialScrollTop if findModeInitialScrollTop
+  document.body.scrollLeft = findModeInitialScrollLeft if findModeInitialScrollLeft
 
 window.enterFindMode = ->
   # Save the selection, so performFindInPlace can restore it.


### PR DESCRIPTION
When using /, if the first few characters match, the scroll position may change.  If further characters then fail to match, we're left at an arbitrary position within the document.  When considering how find mode might work with visual mode, this becomes a problem.  The user can no longer see the text they could originally see.  See @z0rch's comments in #1441.

This restores the scroll position when search using `/` fails.  It's not obvious that this *always* the right thing to do.  However, it does fix @z0rch's concerns in #1441.