### PR TITLE
Fix custom search engine auto selection (with descriptions)

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -21,6 +21,8 @@ class Suggestion
   # - extraRelevancyData: data (like the History item itself) which may be used by the relevancy function.
   constructor: (@queryTerms, @type, @url, @title, @computeRelevancyFunction, @extraRelevancyData) ->
     @title ||= ""
+    # When @autoSelect is truthy, the suggestion is automatically pre-selected in the vomnibar.
+    @autoSelect = false
 
   computeRelevancy: -> @relevancy = @computeRelevancyFunction(this)
 
@@ -335,6 +337,7 @@ class SearchEngineCompleter
         type = "search"
         query = queryTerms[0] + ": " + queryTerms[1..].join(" ")
       suggestion = new Suggestion(queryTerms, type, url, query, @computeRelevancy)
+      suggestion.autoSelect = true
       suggestions.push(suggestion)
     onComplete(suggestions)
 

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -69,18 +69,14 @@ class VomnibarUI
     @selection = @initialSelectionValue
 
   updateSelection: ->
-    # We have taken the option to add some global state here (previousCompletionType) to tell if a search
-    # item has just appeared or disappeared, if that happens we either set the initialSelectionValue to 0 or 1
-    # I feel that this approach is cleaner than bubbling the state up from the suggestion level
-    # so we just inspect it afterwards
+    # We retain global state here (previousAutoSelect) to tell if a search item (for which autoSelect is set)
+    # has just appeared or disappeared. If that happens, we set @selection to 0 or -1.
     if @completions[0]
-      if @previousCompletionType != "search" && @completions[0].type == "search"
-        @selection = 0
-      else if @previousCompletionType == "search" && @completions[0].type != "search"
-        @selection = -1
+      @selection = 0 if @completions[0].autoSelect and not @previousAutoSelect
+      @selection = -1 if @previousAutoSelect and not @completions[0].autoSelect
+      @previousAutoSelect = @completions[0].autoSelect
     for i in [0...@completionList.children.length]
       @completionList.children[i].className = (if i == @selection then "vomnibarSelected" else "")
-    @previousCompletionType = @completions[0].type if @completions[0]
 
   #
   # Returns the user's action ("up", "down", "enter", "dismiss" or null) based on their keypress.


### PR DESCRIPTION
In #1389 (c52c0ea57f86c1c5a132819fe85e763db84ce712) we added descriptions to search engines. We (I) omitted to realise that the "type" of a selection (in particular, the constant `search`) is also used to determine whether the suggestion is automatically selected by the vomnibar.

This fixes that, such that custom search engines with descriptions are now automatically selected in the vomnibar.