### PR TITLE
Find history should not survive browser restart (or should it?)

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -680,5 +680,4 @@ chrome.windows.getAll { populate: true }, (windows) ->
         (response) -> updateScrollPosition(tab, response.scrollX, response.scrollY) if response?
       chrome.tabs.sendMessage(tab.id, { name: "getScrollPosition" }, createScrollPositionHandler())
 
-# Start pulling changes from synchronized storage.
-Sync.init()
+Settings.init()

--- a/background_scripts/settings.coffee
+++ b/background_scripts/settings.coffee
@@ -4,6 +4,13 @@
 
 root = exports ? window
 root.Settings = Settings =
+  init: ->
+    # Start pulling changes from synchronized storage.
+    Sync.init()
+    # Reset findModeRawQueryList to contain only the most recent query (so "n" still works, but all earlier
+    # history is cleared).
+    @set "findModeRawQueryList", @get("findModeRawQueryList")?[0..0] or []
+
   get: (key) ->
     if (key of localStorage) then JSON.parse(localStorage[key]) else @defaults[key]
 
@@ -63,8 +70,6 @@ root.Settings = Settings =
     this.parseSearchEngines(@get("searchEngines") || "") if Object.keys(@searchEnginesMap).length == 0
     @searchEnginesMap
 
-  # options.coffee and options.html only handle booleans and strings; therefore all defaults must be booleans
-  # or strings
   defaults:
     scrollStepSize: 60
     smoothScroll: true

--- a/background_scripts/settings.coffee
+++ b/background_scripts/settings.coffee
@@ -7,6 +7,15 @@ root.Settings = Settings =
   init: ->
     # Start pulling changes from synchronized storage.
     Sync.init()
+
+    # Reset or migrate findModeRawQueryList for find-mode history.
+    unless @has "findModeRawQueryList"
+      # Migration (from 1.49, 2015/2/1).
+      # Legacy setting: findModeRawQuery (a string).
+      # New setting: findModeRawQueryList (a list of strings).
+      @set "findModeRawQueryList", (if @has "findModeRawQuery" then [ @get "findModeRawQuery" ] else [])
+      @clear "findModeRawQuery"
+
     # Reset findModeRawQueryList to contain only the most recent query (so "n" still works, but all earlier
     # history is cleared).
     @set "findModeRawQueryList", @get("findModeRawQueryList")?[0..0] or []

--- a/background_scripts/sync.coffee
+++ b/background_scripts/sync.coffee
@@ -21,7 +21,7 @@ root = exports ? window
 root.Sync = Sync =
 
   storage: chrome.storage.sync
-  doNotSync: ["settingsVersion", "previousVersion"]
+  doNotSync: [ "settingsVersion", "previousVersion", "findModeRawQueryList" ]
 
   # This is called in main.coffee.
   init: ->

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -537,23 +537,13 @@ isValidFirstKey = (keyChar) ->
 # queries, most recent first.
 FindModeHistory =
   getQuery: (index = 0) ->
-    @migration()
     recentQueries = settings.get "findModeRawQueryList"
     if index < recentQueries.length then recentQueries[index] else ""
 
   recordQuery: (query) ->
-    @migration()
     if 0 < query.length
       recentQueries = settings.get "findModeRawQueryList"
       settings.set "findModeRawQueryList", ([ query ].concat recentQueries.filter (q) -> q != query)[0..50]
-
-  # Migration (from 1.49, 2015/2/1).
-  # Legacy setting: findModeRawQuery (a string).
-  # New setting: findModeRawQueryList (a list of strings).
-  migration: ->
-    unless settings.get "findModeRawQueryList"
-      rawQuery = settings.get "findModeRawQuery"
-      settings.set "findModeRawQueryList", (if rawQuery then [ rawQuery ] else [])
 
 # should be called whenever rawQuery is modified.
 updateFindModeQuery = ->

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -41,9 +41,9 @@ settings =
   port: null
   values: {}
   loadedValues: 0
-  valuesToLoad: ["scrollStepSize", "linkHintCharacters", "linkHintNumbers", "filterLinkHints", "hideHud",
-    "previousPatterns", "nextPatterns", "findModeRawQuery", "findModeRawQueryList", "regexFindMode", "userDefinedLinkHintCss",
-    "helpDialog_showAdvancedCommands", "smoothScroll"]
+  valuesToLoad: [ "scrollStepSize", "linkHintCharacters", "linkHintNumbers", "filterLinkHints", "hideHud",
+    "previousPatterns", "nextPatterns", "findModeRawQuery", "findModeRawQueryList", "regexFindMode",
+    "userDefinedLinkHintCss", "helpDialog_showAdvancedCommands", "smoothScroll" ]
   isLoaded: false
   eventListeners: {}
 

--- a/tests/unit_tests/exclusion_test.coffee
+++ b/tests/unit_tests/exclusion_test.coffee
@@ -16,7 +16,7 @@ extend(global, require "../../lib/utils.js")
 Utils.getCurrentVersion = -> '1.44'
 extend(global,require "../../background_scripts/sync.js")
 extend(global,require "../../background_scripts/settings.js")
-Sync.init()
+Settings.init()
 extend(global, require "../../background_scripts/exclusions.js")
 extend(global, require "../../background_scripts/commands.js")
 extend(global, require "../../background_scripts/main.js")

--- a/tests/unit_tests/settings_test.coffee
+++ b/tests/unit_tests/settings_test.coffee
@@ -6,7 +6,7 @@ Utils.getCurrentVersion = -> '1.44'
 global.localStorage = {}
 extend(global,require "../../background_scripts/sync.js")
 extend(global,require "../../background_scripts/settings.js")
-Sync.init()
+Settings.init()
 
 context "settings",
 

--- a/tests/unit_tests/utils_test.coffee
+++ b/tests/unit_tests/utils_test.coffee
@@ -4,7 +4,7 @@ extend(global, require "../../lib/utils.js")
 Utils.getCurrentVersion = -> '1.43'
 extend(global, require "../../background_scripts/sync.js")
 extend(global, require "../../background_scripts/settings.js")
-Sync.init()
+Settings.init()
 
 context "isUrl",
   should "accept valid URLs", ->


### PR DESCRIPTION
This follows on from #1454, and resets the find-mode history on browser restart. We keep only the most recent search (so `n` still works, as it always has).

Should we reset the find-mode history in this way?  I'm not sure.  However, I doubt resetting the history has much negative impact on any important use case.