### PR TITLE
Find mode history for incognito mode

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -382,7 +382,7 @@ root.updateActiveState = updateActiveState = (tabId) ->
           setBrowserActionIcon(tabId,disabledIcon)
         # Propagate the new state only if it has changed.
         if (isCurrentlyEnabled != enabled || currentPasskeys != passKeys)
-          chrome.tabs.sendMessage(tabId, { name: "setState", enabled: enabled, passKeys: passKeys })
+          chrome.tabs.sendMessage(tabId, { name: "setState", enabled: enabled, passKeys: passKeys, incognito: tab.incognito })
       else
         # We didn't get a response from the front end, so Vimium isn't running.
         setBrowserActionIcon(tabId,disabledIcon)

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -189,6 +189,10 @@ handleSettings = (args, port) ->
     port.postMessage({ key: args.key, value: value })
   else # operation == "set"
     Settings.set(args.key, args.value)
+    # For some settings, we propagate changes to all tabs immediately.
+    # In the case of findModeRawQueryList, this allows each tab to accurately track the find-mode history.
+    if args.key in [ "findModeRawQueryList" ]
+      sendRequestToAllTabs extend args, name: "updateSettings"
 
 refreshCompleter = (request) -> completers[request.name].refresh()
 

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -193,6 +193,15 @@ handleSettings = (args, port) ->
     # In the case of findModeRawQueryList, this allows each tab to accurately track the find-mode history.
     if args.key in [ "findModeRawQueryList" ]
       sendRequestToAllTabs extend args, name: "updateSettings"
+    # We also track the incognito find-mode history setting in the tabInfoMap for all incognito tabs.
+    if args.incognito and args.key == "findModeRawQueryList"
+      for own _, map of tabInfoMap
+        map.findModeRawQueryList = args.value if map.incognito
+
+# Search through the active tab map for an up-to-date find-mode history for an incognito-mode tab.
+getIncognitoRawQueryList = ->
+  for own id, map of tabInfoMap
+    return map.findModeRawQueryList if map.findModeRawQueryList
 
 refreshCompleter = (request) -> completers[request.name].refresh()
 
@@ -337,6 +346,8 @@ updateOpenTabs = (tab) ->
     scrollX: null
     scrollY: null
     deletor: null
+    incognito: tab.incognito
+    findModeRawQueryList: null
   # Frames are recreated on refresh
   delete frameIdsForTab[tab.id]
 
@@ -661,6 +672,7 @@ sendRequestHandlers =
   createMark: Marks.create.bind(Marks)
   gotoMark: Marks.goto.bind(Marks)
   setBadge: setBadge
+  getIncognitoRawQueryList: getIncognitoRawQueryList
 
 # Convenience function for development use.
 window.runTests = -> open(chrome.runtime.getURL('tests/dom_tests/dom_tests.html'))

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -170,7 +170,7 @@ upgradeNotificationClosed = (request) ->
 #
 # Copies some data (request.data) to the clipboard.
 #
-copyToClipboard = (request) -> Clipboard.copy(request.data)
+copyToClipboard = (request) -> Clipboard.copy(request.data); null
 
 #
 # Selects the tab with the ID specified in request.id

--- a/background_scripts/settings.coffee
+++ b/background_scripts/settings.coffee
@@ -116,7 +116,6 @@ root.Settings = Settings =
 
     settingsVersion: Utils.getCurrentVersion()
 
-
 # We use settingsVersion to coordinate any necessary schema changes.
 if Utils.compareVersions("1.42", Settings.get("settingsVersion")) != -1
   Settings.set("scrollStepSize", parseFloat Settings.get("scrollStepSize"))
@@ -124,8 +123,9 @@ Settings.set("settingsVersion", Utils.getCurrentVersion())
 
 # Migration (after 1.49, 2015/2/1).
 # Legacy setting: findModeRawQuery (a string).
-# New setting: findModeRawQueryList (a list of strings).
-unless Settings.has "findModeRawQueryList"
-  rawQuery = Settings.get "findModeRawQuery"
-  Settings.set "findModeRawQueryList", (if rawQuery then [ rawQuery ] else [])
+# New setting: findModeRawQueryList (a list of strings), now stored in chrome.storage.local (not localStorage).
+chrome.storage.local.get "findModeRawQueryList", (items) ->
+  unless chrome.runtime.lastError or items.findModeRawQueryList
+    rawQuery = Settings.get "findModeRawQuery"
+    chrome.storage.local.set findModeRawQueryList: (if rawQuery then [ rawQuery ] else [])
 

--- a/background_scripts/settings.coffee
+++ b/background_scripts/settings.coffee
@@ -116,6 +116,7 @@ root.Settings = Settings =
 
     settingsVersion: Utils.getCurrentVersion()
 
+
 # We use settingsVersion to coordinate any necessary schema changes.
 if Utils.compareVersions("1.42", Settings.get("settingsVersion")) != -1
   Settings.set("scrollStepSize", parseFloat Settings.get("scrollStepSize"))

--- a/background_scripts/settings.coffee
+++ b/background_scripts/settings.coffee
@@ -121,3 +121,11 @@ root.Settings = Settings =
 if Utils.compareVersions("1.42", Settings.get("settingsVersion")) != -1
   Settings.set("scrollStepSize", parseFloat Settings.get("scrollStepSize"))
 Settings.set("settingsVersion", Utils.getCurrentVersion())
+
+# Migration (after 1.49, 2015/2/1).
+# Legacy setting: findModeRawQuery (a string).
+# New setting: findModeRawQueryList (a list of strings).
+unless Settings.has "findModeRawQueryList"
+  rawQuery = Settings.get "findModeRawQuery"
+  Settings.set "findModeRawQueryList", (if rawQuery then [ rawQuery ] else [])
+

--- a/background_scripts/sync.coffee
+++ b/background_scripts/sync.coffee
@@ -42,7 +42,7 @@ root.Sync = Sync =
 
   # Only ever called from asynchronous synced-storage callbacks (fetchAsync and handleStorageUpdate).
   storeAndPropagate: (key, value) ->
-    return if not key of Settings.defaults
+    return unless key of Settings.defaults
     return if not @shouldSyncKey key
     return if value and key of localStorage and localStorage[key] is value
     defaultValue = Settings.defaults[key]

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -511,7 +511,7 @@ checkIfEnabledForUrl = ->
 
   chrome.runtime.sendMessage { handler: "isEnabledForUrl", url: url }, (response) ->
     isEnabledForUrl = response.isEnabledForUrl
-    passKeys = request.passKeys
+    passKeys = response.passKeys
     initializeWhenEnabled() if isEnabledForUrl
     else if (HUD.isReady())
       # Quickly hide any HUD we might already be showing, e.g. if we entered insert mode on page load.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -515,7 +515,8 @@ checkIfEnabledForUrl = ->
   chrome.runtime.sendMessage { handler: "isEnabledForUrl", url: url }, (response) ->
     isEnabledForUrl = response.isEnabledForUrl
     passKeys = response.passKeys
-    initializeWhenEnabled() if isEnabledForUrl
+    if isEnabledForUrl
+      initializeWhenEnabled()
     else if (HUD.isReady())
       # Quickly hide any HUD we might already be showing, e.g. if we entered insert mode on page load.
       HUD.hide()

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -74,7 +74,7 @@ settings =
     @init() unless @port
 
     @values[key] = value
-    @port.postMessage({ operation: "set", key: key, value: value })
+    @port.postMessage({ operation: "set", key: key, value: value, incognito: isIncognitoMode })
 
   load: ->
     @init() unless @port
@@ -575,7 +575,7 @@ FindModeHistory =
   saveQuery: (query) ->
     if 0 < query.length
       @updateRawQueryList query
-      settings.set "findModeRawQueryList", @rawQueryList unless isIncognitoMode
+      settings.set "findModeRawQueryList", @rawQueryList
 
 # should be called whenever rawQuery is modified.
 updateFindModeQuery = ->

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -41,9 +41,9 @@ settings =
   port: null
   values: {}
   loadedValues: 0
-  valuesToLoad: ["scrollStepSize", "linkHintCharacters", "linkHintNumbers", "filterLinkHints", "hideHud",
-    "previousPatterns", "nextPatterns", "findModeRawQuery", "findModeRawQueryList", "regexFindMode", "userDefinedLinkHintCss",
-    "helpDialog_showAdvancedCommands", "smoothScroll"]
+  valuesToLoad: [ "scrollStepSize", "linkHintCharacters", "linkHintNumbers", "filterLinkHints", "hideHud",
+    "previousPatterns", "nextPatterns", "findModeRawQuery", "findModeRawQueryList", "regexFindMode",
+    "userDefinedLinkHintCss", "helpDialog_showAdvancedCommands", "smoothScroll" ]
   isLoaded: false
   eventListeners: {}
 
@@ -537,23 +537,13 @@ isValidFirstKey = (keyChar) ->
 # queries, most recent first.
 FindModeHistory =
   getQuery: (index = 0) ->
-    @migration()
     recentQueries = settings.get "findModeRawQueryList"
     if index < recentQueries.length then recentQueries[index] else ""
 
   recordQuery: (query) ->
-    @migration()
     if 0 < query.length
       recentQueries = settings.get "findModeRawQueryList"
       settings.set "findModeRawQueryList", ([ query ].concat recentQueries.filter (q) -> q != query)[0..50]
-
-  # Migration (from 1.49, 2015/2/1).
-  # Legacy setting: findModeRawQuery (a string).
-  # New setting: findModeRawQueryList (a list of strings).
-  migration: ->
-    unless settings.get "findModeRawQueryList"
-      rawQuery = settings.get "findModeRawQuery"
-      settings.set "findModeRawQueryList", (if rawQuery then [ rawQuery ] else [])
 
 # should be called whenever rawQuery is modified.
 updateFindModeQuery = ->

--- a/tests/unit_tests/test_chrome_stubs.coffee
+++ b/tests/unit_tests/test_chrome_stubs.coffee
@@ -46,7 +46,9 @@ exports.chrome =
   storage:
     # chrome.storage.local
     local:
+      get: ->
       set: ->
+      remove: ->
 
     # chrome.storage.onChanged
     onChanged:


### PR DESCRIPTION
Following on from #1464, this ensures that find-mode queries do not leak out of incognito mode.

The approach is to track the history separately in every tab.  Only new queries from non-incognito mode tabs are pushed to the background page (via `settings.set`), and from there they are pushed out (synchronously) to all tabs (via a new message type, `updateSettings`).  This allows all tabs (including incognito tabs) to track the find history (synchronously).  However, in addition to the global history, incognito tabs also track their own queries (and in the correct order).

Considerations:
1. This changes the long-established behaviour whereby queries in incognito tabs leak (via `n`) to all other tabs.  This might be considered a bug fix.  Or, it might be a bad UX change for some users.
2. ~~Queries in incognito windows are not shared between tabs.  So, search for [booby](http://en.wikipedia.org/wiki/Blue-footed_booby) in one incognito tab, then switch to another incognito tab, and `n` doesn't do what the user might expect.~~

