### PR TITLE
Try to fix a problem about registerFrame, may caused by frame stack is not refreshed with frame freshing

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -275,6 +275,7 @@ BackgroundCommands =
   moveTabRight: (count) -> moveTab(null, count)
   nextFrame: (count,frameId) ->
     chrome.tabs.getSelected(null, (tab) ->
+      chrome.tabs.sendMessage(tab.id, {name: "registerFrame"}) # ask all frames in the tab re-register their frame_id 
       frames = frameIdsForTab[tab.id]
       # We can't always track which frame chrome has focussed, but here we learn that it's frameId; so add an
       # additional offset such that we do indeed start from frameId.

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -275,7 +275,7 @@ BackgroundCommands =
   moveTabRight: (count) -> moveTab(null, count)
   nextFrame: (count,frameId) ->
     chrome.tabs.getSelected(null, (tab) ->
-      chrome.tabs.sendMessage(tab.id, {name: "registerFrame"}) # ask all frames in the tab re-register their frame_id 
+      chrome.tabs.sendMessage(tab.id, {name: "registerFrame"})
       frames = frameIdsForTab[tab.id]
       # We can't always track which frame chrome has focussed, but here we learn that it's frameId; so add an
       # additional offset such that we do indeed start from frameId.
@@ -615,6 +615,7 @@ openOptionsPageInNewTab = ->
 
 registerFrame = (request, sender) ->
   (frameIdsForTab[sender.tab.id] ?= []).push request.frameId
+  (frameIdsForTab[sender.tab.id]=frameIdsForTab[sender.tab.id].filter (item, pos, self) -> self.indexOf(item) == pos).length
 
 unregisterFrame = (request, sender) ->
   tabId = sender.tab.id

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -275,7 +275,6 @@ BackgroundCommands =
   moveTabRight: (count) -> moveTab(null, count)
   nextFrame: (count,frameId) ->
     chrome.tabs.getSelected(null, (tab) ->
-      chrome.tabs.sendMessage(tab.id, {name: "registerFrame"})
       frames = frameIdsForTab[tab.id]
       # We can't always track which frame chrome has focussed, but here we learn that it's frameId; so add an
       # additional offset such that we do indeed start from frameId.
@@ -337,7 +336,7 @@ updateOpenTabs = (tab) ->
     scrollY: null
     deletor: null
   # Frames are recreated on refresh
-  delete frameIdsForTab[tab.id]
+  chrome.tabs.sendMessage(tab.id, {name: "registerFrame"})
 
 setBrowserActionIcon = (tabId,path) ->
   chrome.browserAction.setIcon({ tabId: tabId, path: path })

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -142,6 +142,7 @@ initializePreDomReady = ->
     showHUDforDuration: (request) -> HUD.showForDuration request.text, request.duration
     toggleHelpDialog: (request) -> toggleHelpDialog(request.dialogHtml, request.frameId)
     focusFrame: (request) -> if (frameId == request.frameId) then focusThisFrame(request.highlight)
+    registerFrame : -> registerFrame()
     refreshCompletionKeys: refreshCompletionKeys
     getScrollPosition: -> scrollX: window.scrollX, scrollY: window.scrollY
     setScrollPosition: (request) -> setScrollPosition request.scrollX, request.scrollY


### PR DESCRIPTION
Problem:
http://music.163.com/
What happens in this website is that when click a link in the main frame, "gf" would not work, because Vimium forget the frame on the bottom.

Fixing:
refresh the tab's frame stack in nextFrame function.

This might not the best solution, if you guys have better idea, please let me know.