### PR TITLE
Retain frame data for a tab unless the top frame tells us its closing

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -324,7 +324,7 @@ selectTab = (callback, direction) ->
       selectionChangedHandlers.push(callback)
       chrome.tabs.update(toSelect.id, { selected: true })))
 
-updateOpenTabs = (tab) ->
+updateOpenTabs = (tab, deleteFrames = false) ->
   # Chrome might reuse the tab ID of a recently removed tab.
   if tabInfoMap[tab.id]?.deletor
     clearTimeout tabInfoMap[tab.id].deletor
@@ -336,7 +336,7 @@ updateOpenTabs = (tab) ->
     scrollY: null
     deletor: null
   # Frames are recreated on refresh
-  delete frameIdsForTab[tab.id]
+  delete frameIdsForTab[tab.id] if deleteFrames
 
 setBrowserActionIcon = (tabId,path) ->
   chrome.browserAction.setIcon({ tabId: tabId, path: path })
@@ -619,7 +619,7 @@ unregisterFrame = (request, sender) ->
   tabId = sender.tab.id
   if frameIdsForTab[tabId]?
     if request.tab_is_closing
-      updateOpenTabs sender.tab
+      updateOpenTabs sender.tab, true
     else
       frameIdsForTab[tabId] = frameIdsForTab[tabId].filter (id) -> id != request.frameId
 


### PR DESCRIPTION
When
* a tab's URL changes without a new page loading (eg. `history.pushState`), and
* some resources are being loaded (eg. images/iframes) when we get the `chrome.tabs.onUpdated` in the background page

then we clear our record of frames in the tab. This PR changes our behaviour so that we only clear the frames for a tab when the top-level frame says it's going away.


This fixes the issue mentioned in PR #1475.