### PR TITLE
Fix regression for regex search.

### DIFF
--- a/content_scripts/mode_visual_edit.coffee
+++ b/content_scripts/mode_visual_edit.coffee
@@ -347,7 +347,7 @@ class Movement extends CountPrefix
     unless @options.parentMode or options.oneMovementOnly
       do =>
         executeFind = (count, findBackwards) =>
-          if query = getFindModeQuery()
+          if query = getFindModeQuery findBackwards
             initialRange = @selection.getRangeAt(0).cloneRange()
             for [0...count]
               unless window.find query, Utils.hasUpperCase(query), findBackwards, true, false, true, false

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -801,7 +801,7 @@ getNextQueryFromRegexMatches = (stepSize) ->
 
   findModeQuery.regexMatches[findModeQuery.activeRegexIndex]
 
-window.getFindModeQuery  = ->
+window.getFindModeQuery = (backwards) ->
   # check if the query has been changed by a script in another frame
   mostRecentQuery = FindModeHistory.getQuery()
   if (mostRecentQuery != findModeQuery.rawQuery)
@@ -814,7 +814,7 @@ window.getFindModeQuery  = ->
     findModeQuery.parsedQuery
 
 findAndFocus = (backwards) ->
-  query = getFindModeQuery()
+  query = getFindModeQuery backwards
 
   findModeQueryHasResults =
     executeFind(query, { backwards: backwards, caseSensitive: !findModeQuery.ignoreCase })


### PR DESCRIPTION
Oops, @mrmr1993.  My bad.
This is the fix, yes?

Fixes regression from 05351d4650ace35574bf4f9c55cced65950252f5.
Fixes #1477.