### PR TITLE
Grab back focus when page auto-focuses an input (optionally)

### DIFF
--- a/background_scripts/settings.coffee
+++ b/background_scripts/settings.coffee
@@ -73,6 +73,7 @@ root.Settings = Settings =
     linkHintNumbers: "0123456789"
     filterLinkHints: false
     hideHud: false
+    grabBackfocus: false
     userDefinedLinkHintCss:
       """
       div > .vimiumHintMarker {

--- a/background_scripts/settings.coffee
+++ b/background_scripts/settings.coffee
@@ -113,12 +113,9 @@ root.Settings = Settings =
     # put in an example search engine
     searchEngines: "w: http://www.wikipedia.org/w/index.php?title=Special:Search&search=%s wikipedia"
     newTabUrl: "chrome://newtab"
+    grabBackFocus: false
 
     settingsVersion: Utils.getCurrentVersion()
-
-    # NOTE. This setting is accessed directly via chrome.storage.sync in the front end. There, we assume that
-    # the default value is false.
-    grabBackFocus: false
 
 
 # We use settingsVersion to coordinate any necessary schema changes.

--- a/background_scripts/settings.coffee
+++ b/background_scripts/settings.coffee
@@ -73,7 +73,6 @@ root.Settings = Settings =
     linkHintNumbers: "0123456789"
     filterLinkHints: false
     hideHud: false
-    grabBackfocus: false
     userDefinedLinkHintCss:
       """
       div > .vimiumHintMarker {
@@ -116,6 +115,10 @@ root.Settings = Settings =
     newTabUrl: "chrome://newtab"
 
     settingsVersion: Utils.getCurrentVersion()
+
+    # NOTE. This setting is accessed directly via chrome.storage.sync in the front end. There, we assume that
+    # the default value is false.
+    grabBackFocus: false
 
 
 # We use settingsVersion to coordinate any necessary schema changes.

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -257,6 +257,7 @@ initOptionsPage = ->
     regexFindMode: CheckBoxOption
     scrollStepSize: NumberOption
     smoothScroll: CheckBoxOption
+    grabBackfocus: CheckBoxOption
     searchEngines: TextOption
     searchUrl: NonEmptyTextOption
     userDefinedLinkHintCss: TextOption

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -257,7 +257,7 @@ initOptionsPage = ->
     regexFindMode: CheckBoxOption
     scrollStepSize: NumberOption
     smoothScroll: CheckBoxOption
-    grabBackfocus: CheckBoxOption
+    grabBackFocus: CheckBoxOption
     searchEngines: TextOption
     searchUrl: NonEmptyTextOption
     userDefinedLinkHintCss: TextOption

--- a/pages/options.html
+++ b/pages/options.html
@@ -133,12 +133,12 @@ b: http://b.com/?q=%s description
             <td verticalAlign="top" class="booleanOption">
               <div class="help">
                 <div class="example">
-                  Prevent the page from focusing an input on load
+                  Prevent pages from focusing an input on load (e.g. Google, Bing, etc.).
                 </div>
               </div>
               <label>
-                <input id="grabBackfocus" type="checkbox"/>
-                Grab back focus
+                <input id="grabBackFocus" type="checkbox"/>
+                Don't let pages steal the focus on load
               </label>
             </td>
           </tr>

--- a/pages/options.html
+++ b/pages/options.html
@@ -133,6 +133,20 @@ b: http://b.com/?q=%s description
             <td verticalAlign="top" class="booleanOption">
               <div class="help">
                 <div class="example">
+                  Prevent the page from focusing an input on load
+                </div>
+              </div>
+              <label>
+                <input id="grabBackfocus" type="checkbox"/>
+                Grab back focus
+              </label>
+            </td>
+          </tr>
+          <tr>
+            <td class="caption"></td>
+            <td verticalAlign="top" class="booleanOption">
+              <div class="help">
+                <div class="example">
                   When enabled, the HUD will not be displayed.
                 </div>
               </div>

--- a/tests/dom_tests/chrome.coffee
+++ b/tests/dom_tests/chrome.coffee
@@ -7,26 +7,23 @@ root.chromeMessages = []
 
 document.hasFocus = -> true
 
-root.chrome = {
-  runtime: {
-    connect: -> {
-      onMessage: {
+root.chrome =
+  runtime:
+    connect: ->
+      onMessage:
         addListener: ->
-      }
-      onDisconnect: {
+      onDisconnect:
         addListener: ->
-      }
       postMessage: ->
-    }
-    onMessage: {
+    onMessage:
       addListener: ->
-    }
     sendMessage: (message) -> chromeMessages.unshift message
     getManifest: ->
     getURL: (url) -> "../../#{url}"
-  }
   storage:
     local:
       get: ->
       set: ->
-}
+    sync:
+      get: ->
+      set: ->

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -354,24 +354,24 @@ context "Triggering insert mode",
     document.getElementById("test-div").innerHTML = ""
 
   should "trigger insert mode on focus of text input", ->
-    assert.isTrue Mode.top().name == "insert" and not Mode.top().isActive()
+    assert.isFalse InsertMode.permanentInstance.isActive()
     document.getElementById("first").focus()
-    assert.isTrue Mode.top().name == "insert" and Mode.top().isActive()
+    assert.isTrue InsertMode.permanentInstance.isActive()
 
   should "trigger insert mode on focus of password input", ->
-    assert.isTrue Mode.top().name == "insert" and not Mode.top().isActive()
+    assert.isFalse InsertMode.permanentInstance.isActive()
     document.getElementById("third").focus()
-    assert.isTrue Mode.top().name == "insert" and Mode.top().isActive()
+    assert.isTrue InsertMode.permanentInstance.isActive()
 
   should "trigger insert mode on focus of contentEditable elements", ->
-    assert.isTrue Mode.top().name == "insert" and not Mode.top().isActive()
+    assert.isFalse InsertMode.permanentInstance.isActive()
     document.getElementById("fourth").focus()
-    assert.isTrue Mode.top().name == "insert" and Mode.top().isActive()
+    assert.isTrue InsertMode.permanentInstance.isActive()
 
   should "not trigger insert mode on other elements", ->
-    assert.isTrue Mode.top().name == "insert" and not Mode.top().isActive()
+    assert.isFalse InsertMode.permanentInstance.isActive()
     document.getElementById("fifth").focus()
-    assert.isTrue Mode.top().name == "insert" and not Mode.top().isActive()
+    assert.isFalse InsertMode.permanentInstance.isActive()
 
 context "Mode utilities",
   setup ->
@@ -454,6 +454,10 @@ context "PostFindMode",
     testContent = "<input type='text' id='first'/>"
     document.getElementById("test-div").innerHTML = testContent
     document.getElementById("first").focus()
+    # For these tests, we need to push GrabBackFocus out of the way.  When it exits, it updates the badge,
+    # which interferes with event suppression within insert mode.  This cannot happen in normal operation,
+    # because GrabBackFocus exits on the first keydown.
+    Mode.top().exit()
     @postFindMode = new PostFindMode
 
   tearDown ->
@@ -466,7 +470,7 @@ context "PostFindMode",
 
   should "suppress unmapped printable keys", ->
     sendKeyboardEvent "m"
-    assert.equal pageKeyboardEventCount, 0
+    assert.equal 0, pageKeyboardEventCount
 
   should "be deactivated on click events", ->
     handlerStack.bubbleEvent "click", target: document.activeElement


### PR DESCRIPTION
Some pages (like [Google](https://www.google.ie/?gws_rd=ssl) and [Bing](http://www.bing.com/)) automatically focus an input on load.  This PR adds an option (off by default) to grab back the focus in such cases.  We only grab back the focus if the user has not yet interacted with the page (so, until the first `keydown` or `mousedown`).

This is an alternative to #1282.
Fixes #523.