### PR TITLE
Updated README.md readability -- missed two lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Release Notes
 
 1.36 (2012-07-07)
 
-- 'b' brings up a bookmark-only Vomnibar.
+- `b` brings up a bookmark-only Vomnibar.
 - Better support for some bookmarklets.
 
 1.35 (2012-07-05)
@@ -237,7 +237,7 @@ Release Notes
 - Improve style of link hints, and use fewer characters for hints.
 - Add an option to hide the heads up display (HUD). Notably, the HUD obscures Facebook Chat's textbox.
 - Detection and following of next / previous links has been improved.
-- Addition of 'g0' and 'g$' commands, for switching tabs.
+- Addition of `g0` and `g$` commands, for switching tabs.
 - Addition of `p`/`P` commands for URL pasting.
 - A new find mode which optionally supports case sensitivity and regular expressions.
 - Bug fixes.


### PR DESCRIPTION
Missed two lines from my original pull request (https://github.com/philc/vimium/pull/1481). Basically:
Changed references to vimiim commands that were either in single-quotes or not otherwise distinguished easily to the reader as a command to be wrapped around backtick quotes so they will stand out. Here is a list of all changes made:

Line 215, 'b' updated to `b`
Line 240, 'g0' updated to `g0` and 'g$' updated to `g$`