### PR TITLE
Move "show-advanced-options" to a fixed-position button.

### DIFF
--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -208,14 +208,13 @@ initOptionsPage = ->
       (event) ->
         if advancedMode
           $("advancedOptions").style.display = "none"
-          $("advancedOptionsLink").innerHTML = "Show advanced options&hellip;"
+          $("advancedOptionsButton").innerHTML = "Show Advanced Options"
         else
           $("advancedOptions").style.display = "table-row-group"
-          $("advancedOptionsLink").innerHTML = "Hide advanced options"
+          $("advancedOptionsButton").innerHTML = "Hide Advanced Options"
         advancedMode = !advancedMode
+        $("advancedOptionsButton").blur()
         event.preventDefault()
-        # Prevent the "advanced options" link from retaining the focus.
-        document.activeElement.blur()
 
   activateHelpDialog = ->
     showHelpDialog chrome.extension.getBackgroundPage().helpDialogHtml(true, true, "Command Listing"), frameId
@@ -228,7 +227,7 @@ initOptionsPage = ->
     $("saveOptions").innerHTML = "No Changes"
 
   $("saveOptions").addEventListener "click", saveOptions
-  $("advancedOptionsLink").addEventListener "click", toggleAdvancedOptions
+  $("advancedOptionsButton").addEventListener "click", toggleAdvancedOptions
   $("showCommands").addEventListener "click", activateHelpDialog
   $("filterLinkHints").addEventListener "click", maintainLinkHintsView
 

--- a/pages/options.css
+++ b/pages/options.css
@@ -136,7 +136,7 @@ input#searchUrl {
 }
 #buttonsPanel { width: 100%; }
 #advancedOptions { display: none; }
-#advancedOptionsLink { line-height: 24px; }
+#advancedOptionsButton { width: 170px; }
 .help {
   position: absolute;
   right: -320px;

--- a/pages/options.html
+++ b/pages/options.html
@@ -66,9 +66,6 @@ b: http://b.com/?q=%s description
               <textarea id="searchEngines"></textarea>
           </td>
         </tr>
-        <tr>
-           <td colspan="2"><a href="#" id="advancedOptionsLink">Show advanced options&hellip;</a></td>
-        </tr>
         <tbody id='advancedOptions'>
           <tr>
             <td class="caption">Scroll step size</td>
@@ -246,12 +243,13 @@ b: http://b.com/?q=%s description
           <tr>
             <td id="footerTableData">
               <span id="helpText">
-                Type <strong>?</strong> to show the Vimium help dialog.
+                Type <strong>?</strong> to show the help dialog.
                 <br/>
                 Type <strong>Ctrl-Enter</strong> to save <i>all</i> options.
               </span>
             </td>
-            <td id="saveOptionsTableData">
+            <td id="saveOptionsTableData" nowrap>
+              <button id="advancedOptionsButton">Show Advanced Options</button>
               <button id="saveOptions" disabled="true">No Changes</button>
             </td>
           </tr>


### PR DESCRIPTION
What about replacing this...

![sss](https://cloud.githubusercontent.com/assets/2641335/6204006/af832368-b532-11e4-8c3f-ea1222d2a524.png)

With this...

![snapshot](https://cloud.githubusercontent.com/assets/2641335/6204008/bf07ab88-b532-11e4-9b0d-d329b5c63c06.png)

Why? The show-advanced options link/button should be in a fixed place.  On my Chromebook, I have to scroll to see it.