### PR TITLE
Remove the setState function and rework the code for setting the browser icon

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -77,11 +77,12 @@ getCurrentTabUrl = (request, sender) -> sender.tab.url
 # Checks the user's preferences in local storage to determine if Vimium is enabled for the given URL, and
 # whether any keys should be passed through to the underlying page.
 #
-root.isEnabledForUrl = isEnabledForUrl = (request) ->
+root.isEnabledForUrl = isEnabledForUrl = (request, sender) ->
   rule = Exclusions.getRule(request.url)
   {
     isEnabledForUrl: not rule or rule.passKeys
     passKeys: rule?.passKeys or ""
+    incognito: sender?.tab.incognito
   }
 
 # Retrieves the help dialog HTML template from a file, and populates it with the latest keybindings.
@@ -371,8 +372,7 @@ root.updateActiveState = updateActiveState = (tabId) ->
     setBadge badge: ""
     chrome.tabs.sendMessage tabId, { name: "getActiveState" }, (response) ->
       if response
-        isCurrentlyEnabled = response.enabled
-        currentPasskeys = response.passKeys
+        # The top frame of the page is responding.
         config = isEnabledForUrl({url: tab.url})
         enabled = config.isEnabledForUrl
         passKeys = config.passKeys
@@ -382,10 +382,6 @@ root.updateActiveState = updateActiveState = (tabId) ->
           setBrowserActionIcon(tabId,enabledIcon)
         else
           setBrowserActionIcon(tabId,disabledIcon)
-        # Propagate the new state only if it has changed.
-        if (isCurrentlyEnabled != enabled || currentPasskeys != passKeys)
-          chrome.tabs.sendMessage(tabId, { name: "setState", enabled: enabled, passKeys: passKeys, incognito: tab.incognito })
-
 
 handleUpdateScrollPosition = (request, sender) ->
   updateScrollPosition(sender.tab, request.scrollX, request.scrollY)
@@ -401,8 +397,9 @@ chrome.tabs.onUpdated.addListener (tabId, changeInfo, tab) ->
     code: Settings.get("userDefinedLinkHintCss")
     runAt: "document_start"
   chrome.tabs.insertCSS tabId, cssConf, -> chrome.runtime.lastError
-  updateOpenTabs(tab) if changeInfo.url?
-  updateActiveState(tabId)
+  updateOpenTabs tab if changeInfo.url?
+  updateActiveState tabId
+  chrome.tabs.sendMessage tabId, {name: "checkIfEnabledForUrl"}
 
 chrome.tabs.onAttached.addListener (tabId, attachedInfo) ->
   # We should update all the tabs in the old window and the new window.

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -366,7 +366,8 @@ root.updateActiveState = updateActiveState = (tabId) ->
   disabledIcon = "icons/browser_action_disabled.png"
   partialIcon = "icons/browser_action_partial.png"
   chrome.tabs.get tabId, (tab) ->
-    setBrowserActionIcon tabId, enabledIcon
+    # Default to disabled state in case we can't connect to Vimium, primarily for the "New Tab" page.
+    setBrowserActionIcon(tabId,disabledIcon)
     setBadge badge: ""
     chrome.tabs.sendMessage tabId, { name: "getActiveState" }, (response) ->
       if response
@@ -384,8 +385,7 @@ root.updateActiveState = updateActiveState = (tabId) ->
         # Propagate the new state only if it has changed.
         if (isCurrentlyEnabled != enabled || currentPasskeys != passKeys)
           chrome.tabs.sendMessage(tabId, { name: "setState", enabled: enabled, passKeys: passKeys, incognito: tab.incognito })
-      else
-        setBrowserActionIcon tabId, disabledIcon
+
 
 handleUpdateScrollPosition = (request, sender) ->
   updateScrollPosition(sender.tab, request.scrollX, request.scrollY)

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -586,7 +586,7 @@ checkKeyQueue = (keysToCheck, tabId, frameId) ->
 #
 # Message all tabs. Args should be the arguments hash used by the Chrome sendRequest API.
 #
-sendRequestToAllTabs = (args) ->
+window.sendRequestToAllTabs = (args) ->
   chrome.windows.getAll({ populate: true }, (windows) ->
     for window in windows
       for tab in window.tabs

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -366,6 +366,7 @@ root.updateActiveState = updateActiveState = (tabId) ->
   disabledIcon = "icons/browser_action_disabled.png"
   partialIcon = "icons/browser_action_partial.png"
   chrome.tabs.get tabId, (tab) ->
+    setBrowserActionIcon tabId, enabledIcon
     setBadge badge: ""
     chrome.tabs.sendMessage tabId, { name: "getActiveState" }, (response) ->
       if response

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -292,7 +292,7 @@ initPopupPage = ->
       $("saveOptions").innerHTML = "Saved"
       $("saveOptions").disabled = true
       # Update the enabled/passkeys state of every frame in every tab.
-      chrome.extension.getBackgroundPage().sendRequestToAllTabs, {name: "checkIfEnabledForUrl"}
+      chrome.extension.getBackgroundPage().sendRequestToAllTabs {name: "checkIfEnabledForUrl"}
       # Update the status of the Vimium icon for every window.
       chrome.tabs.query { active: true }, (tabs) ->
         for tab in tabs

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -291,8 +291,12 @@ initPopupPage = ->
       Option.saveOptions()
       $("saveOptions").innerHTML = "Saved"
       $("saveOptions").disabled = true
-      chrome.tabs.query { windowId: chrome.windows.WINDOW_ID_CURRENT, active: true }, (tabs) ->
-        chrome.extension.getBackgroundPage().updateActiveState(tabs[0].id)
+      # Update the enabled/passkeys state of every frame in every tab.
+      chrome.extension.getBackgroundPage().sendRequestToAllTabs, {name: "checkIfEnabledForUrl"}
+      # Update the status of the Vimium icon for every window.
+      chrome.tabs.query { active: true }, (tabs) ->
+        for tab in tabs
+          chrome.extension.getBackgroundPage().updateActiveState tab.id
 
     $("saveOptions").addEventListener "click", saveOptions
 

--- a/tests/dom_tests/chrome.coffee
+++ b/tests/dom_tests/chrome.coffee
@@ -27,3 +27,5 @@ root.chrome =
     sync:
       get: ->
       set: ->
+    onChanged:
+      addListener: ->


### PR DESCRIPTION
This PR fixes #1494 so that our behaviour is consistent and as the user would expect (ie. an URL matching an exclusion/passkey rule has that rule enforced regardless of whether it is in a frame or not). More importantly, this fixes the issue with `FindModeHistory.init` sometimes not being called, which broke the extension after searches.

This also reverted a couple of commits which were attempting to improve the UX of the browser action icon, since they weren't compatible with these changes, and (I think) this is more important.

@smblott-github can you take a look at this? The `FindModeHistory` bug keeps messing things up while I'm trying to test my newest version of #1490.