### PR TITLE
Ensure incognito-mode flag and find-mode-history are initialised.

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -77,11 +77,12 @@ getCurrentTabUrl = (request, sender) -> sender.tab.url
 # Checks the user's preferences in local storage to determine if Vimium is enabled for the given URL, and
 # whether any keys should be passed through to the underlying page.
 #
-root.isEnabledForUrl = isEnabledForUrl = (request) ->
+root.isEnabledForUrl = isEnabledForUrl = (request, sender) ->
   rule = Exclusions.getRule(request.url)
   {
     isEnabledForUrl: not rule or rule.passKeys
     passKeys: rule?.passKeys or ""
+    incognito: sender.tab.incognito
   }
 
 # Retrieves the help dialog HTML template from a file, and populates it with the latest keybindings.
@@ -371,7 +372,7 @@ root.updateActiveState = updateActiveState = (tabId) ->
       if response
         isCurrentlyEnabled = response.enabled
         currentPasskeys = response.passKeys
-        config = isEnabledForUrl({url: tab.url})
+        config = isEnabledForUrl { url: tab.url }, { tab: tab }
         enabled = config.isEnabledForUrl
         passKeys = config.passKeys
         if (enabled and passKeys)

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -562,6 +562,7 @@ checkIfEnabledForUrl = ->
   chrome.runtime.sendMessage { handler: "isEnabledForUrl", url: url }, (response) ->
     isEnabledForUrl = response.isEnabledForUrl
     passKeys = response.passKeys
+    isIncognitoMode = response.incognito
     if isEnabledForUrl
       initializeWhenEnabled()
     else if (HUD.isReady())

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -211,13 +211,13 @@ window.initializeWhenEnabled = ->
       do (type) -> installListener window, type, (event) -> handlerStack.bubbleEvent type, event
     installListener document, "DOMActivate", (event) -> handlerStack.bubbleEvent 'DOMActivate', event
     installedListeners = true
+    FindModeHistory.init()
 
 setState = (request) ->
   isEnabledForUrl = request.enabled
   passKeys = request.passKeys
   isIncognitoMode = request.incognito
   initializeWhenEnabled() if isEnabledForUrl
-  FindModeHistory.init()
   handlerStack.bubbleEvent "registerStateChange",
     enabled: isEnabledForUrl
     passKeys: passKeys

--- a/tests/dom_tests/chrome.coffee
+++ b/tests/dom_tests/chrome.coffee
@@ -27,3 +27,5 @@ root.chrome =
     sync:
       get: ->
       set: ->
+    onChanged:
+      addListener: ->

--- a/tests/unit_tests/exclusion_test.coffee
+++ b/tests/unit_tests/exclusion_test.coffee
@@ -21,6 +21,10 @@ extend(global, require "../../background_scripts/exclusions.js")
 extend(global, require "../../background_scripts/commands.js")
 extend(global, require "../../background_scripts/main.js")
 
+dummyTab =
+  tab:
+    incognito: false
+
 # These tests cover only the most basic aspects of excluded URLs and passKeys.
 #
 context "Excluded URLs and pass keys",
@@ -36,22 +40,22 @@ context "Excluded URLs and pass keys",
       ])
 
   should "be disabled for excluded sites", ->
-    rule = isEnabledForUrl({ url: 'http://mail.google.com/calendar/page' })
+    rule = isEnabledForUrl({ url: 'http://mail.google.com/calendar/page' }, dummyTab)
     assert.isFalse rule.isEnabledForUrl
     assert.isFalse rule.passKeys
 
   should "be disabled for excluded sites, one exclusion", ->
-    rule = isEnabledForUrl({ url: 'http://www.bbc.com/calendar/page' })
+    rule = isEnabledForUrl({ url: 'http://www.bbc.com/calendar/page' }, dummyTab)
     assert.isFalse rule.isEnabledForUrl
     assert.isFalse rule.passKeys
 
   should "be enabled, but with pass keys", ->
-    rule = isEnabledForUrl({ url: 'https://www.facebook.com/something' })
+    rule = isEnabledForUrl({ url: 'https://www.facebook.com/something' }, dummyTab)
     assert.isTrue rule.isEnabledForUrl
     assert.equal rule.passKeys, 'abcd'
 
   should "be enabled", ->
-    rule = isEnabledForUrl({ url: 'http://www.twitter.com/pages' })
+    rule = isEnabledForUrl({ url: 'http://www.twitter.com/pages' }, dummyTab)
     assert.isTrue rule.isEnabledForUrl
     assert.isFalse rule.passKeys
 


### PR DESCRIPTION
This fixes the most basic race-condition issues around the initialisation of the incognito-mode flag and find-mode history from #1494.  It does the small and obvious part of #1495 (that part which doesn't really require discussion -- I think?).

@mrmr1993.  Should we merge this and take some time to think about what to do with #1496 and #1453?