### PR TITLE
Hide the vomnibar on blur

### DIFF
--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -29,13 +29,7 @@ class UIComponent
 
   activate: (message) ->
     @postMessage message if message?
-    if @showing
-      # NOTE(smblott) Experimental.  Not sure this is a great idea. If the iframe was already showing, then
-      # the user gets no visual feedback when it is re-focused.  So flash its border.
-      @iframeElement.classList.add "vimiumUIComponentReactivated"
-      setTimeout((=> @iframeElement.classList.remove "vimiumUIComponentReactivated"), 200)
-    else
-      @show()
+    @show() unless @showing
     @iframeElement.focus()
 
   show: (message) ->

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -180,7 +180,7 @@ class VomnibarUI
     @completionList.style.display = ""
 
     @input.focus()
-    @input.addEventListener "blur", => @hide()
+    window.addEventListener "blur", => @?hide()
 
 #
 # Sends filter and refresh requests to a Vomnibox completer on the background page.

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -179,7 +179,8 @@ class VomnibarUI
     @completionList = @box.querySelector("ul")
     @completionList.style.display = ""
 
-    window.addEventListener "focus", => @input.focus()
+    @input.focus()
+    @input.addEventListener "blur", => @hide()
 
 #
 # Sends filter and refresh requests to a Vomnibox completer on the background page.


### PR DESCRIPTION
@mrmr1993:  Could you take a look at this, please?  It's intended to implement your suggestion from #1506.

Considerations:

- ~~The tests fail.  @mrmr1993: I don't understand these tests.  Would you be able to take this and fix it?  Or submit an alternative?~~

- This removes the ability to select text with the mouse while the vomnibar is active.  Is that such a loss?  Probably not... The vomnibar already obscures the "focus" of the page.

- ~~Edit.  And, clicking anywhere on the vomnibar closes the vomnibar.  That's bad UX.~~

In #1506, @mrmr1993 wrote:

> (@smblott-github, this sounds like an easy fix for a part of the problem we discussed over email, too.)

Nice observation. I think this fixes the most serious part.