### PR TITLE
Do not include duplicated texts (from descendents) in link hints

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -231,6 +231,8 @@ LinkHints =
     # Remove rects from elements where another clickable element lies above it.
     nonOverlappingElements = []
     # Traverse the DOM from first to last, since later elements show above earlier elements.
+    # NOTE(smblott). filterHints.generateLinkText also assumes this order when generating the content text for
+    # each hint.  Specifically, we consider descendents before we consider their ancestors.
     visibleElements = visibleElements.reverse()
     while visibleElement = visibleElements.pop()
       rects = [visibleElement.rect]
@@ -469,7 +471,7 @@ filterHints =
       linkText = element.firstElementChild.alt || element.firstElementChild.title
       showLinkText = true if (linkText)
     else
-      linkText = element.textContent || element.innerHTML
+      linkText = DomUtils.textContent.get element
 
     { text: linkText, show: showLinkText }
 
@@ -479,6 +481,7 @@ filterHints =
 
   fillInMarkers: (hintMarkers) ->
     @generateLabelMap()
+    DomUtils.textContent.reset()
     for marker, idx in hintMarkers
       marker.hintString = @generateHintString(idx)
       linkTextObject = @generateLinkText(marker.clickableItem)

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -295,5 +295,24 @@ DomUtils =
       document.body.removeChild div
       coordinates
 
+  # Get the text content of an element (and its descendents), but omit the text content of previously-visited
+  # nodes.
+  # NOTE(smblott).  This is currently O(N^2) (when called on N elements).  An alternative would be to mark
+  # each node visited, and then clear the marks when we're done.
+  textContent: do ->
+    visitedNodes = null
+    reset: -> visitedNodes = []
+    get: (element) ->
+      nodes = document.createTreeWalker element, NodeFilter.SHOW_TEXT
+      texts =
+        while node = nodes.nextNode()
+          continue unless node.nodeType == 3
+          continue if node in visitedNodes
+          text = node.data.trim()
+          continue unless 0 < text.length
+          visitedNodes.push node
+          text
+      texts.join " "
+
 root = exports ? window
 root.DomUtils = DomUtils

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -296,7 +296,7 @@ DomUtils =
       coordinates
 
   # Get the text content of an element (and its descendents), but omit the text content of previously-visited
-  # nodes.
+  # nodes.  See #1514.
   # NOTE(smblott).  This is currently O(N^2) (when called on N elements).  An alternative would be to mark
   # each node visited, and then clear the marks when we're done.
   textContent: do ->


### PR DESCRIPTION
This only affects link hints with *Use the link's name and numbers for link-hint filtering* enabled.

Currently, we match the *entire text content* of each link-hint element.

With two (or more) hints, and with one of the elements a descendent of the other, we use the entire text content of the outer node, which includes the text content of the inner node.  This leads to odd situations where the inner element cannot be selected just by typing its text, because its text is a substring of the outer element's text, so any text matching the inner hint also matches the outer hint.

For example, on Google calendar, the "Today" button shows up as two hints, one inside the other.  Typing "today" never disambiguates the hint.  You always have to hit enter.

There's another nasty example on feedly, where an outer container is clickable, but its text contains all of the (many) texts of the (many) contained links.  So the inner hint (the one you most likely want) always has to be selected manually.  This case is worse (I think), because you end up having to specifically choose the *second* hint (so `Enter` doesn't help).

In this PR, when generating the text for a hint, we exclude the texts from any descendent node which has already been considered.

Note: this also drops the inclusion of `innerHTML` if `textContent` is empty.  It's not clear why you would want to match against the HTML.  But there must have been a reason for including this originally, so...