### PR TITLE
Fix vomnibar visibility

### DIFF
--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -46,7 +46,7 @@ class UIComponent
   hide: (focusWindow = true)->
     @iframeElement.classList.remove "vimiumUIComponentShowing"
     @iframeElement.classList.add "vimiumUIComponentHidden"
-    window.removeEventListener @onFocus if @onFocus
+    window.removeEventListener "focus", @onFocus if @onFocus
     @onFocus = null
     window.focus() if focusWindow
     @showing = false

--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -38,7 +38,10 @@ Vomnibar =
   init: ->
     unless @vomnibarUI?
       @vomnibarUI = new UIComponent "pages/vomnibar.html", "vomnibarFrame", (event) =>
-        @vomnibarUI.hide() if event.data == "hide"
+        if event.data == "hide"
+          @vomnibarUI.hide()
+          @vomnibarUI.postMessage "hidden"
+
 
   # This function opens the vomnibar. It accepts options, a map with the values:
   #   completer   - The completer to fetch results from.


### PR DESCRIPTION
Delay calling any action from the vomnibar until after it has closed.  This prevents flicker/late visibility when we return to a tab from which the vomnibar previously opened a new foreground tab.

Fixes #1485.