### PR TITLE
Reload content scripts after install/update.

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -1,26 +1,22 @@
 root = exports ? window
 
-currentVersion = Utils.getCurrentVersion()
-
-# Iterate over existing tabs and inject the necessary javascript/css into each.
-injectContentScriptsIntoOpenTabs = ->
+# The browser may have tabs already open. We inject the content scripts immediately so that they work straight
+# away.
+chrome.runtime.onInstalled.addListener ->
   manifest = chrome.runtime.getManifest()
   # Content scripts loaded on every page should be in the same group. We assume it is the first.
   contentScripts = manifest.content_scripts[0]
+  jobs = [ [ chrome.tabs.executeScript, contentScripts.js ], [ chrome.tabs.insertCSS, contentScripts.css ] ]
+  # Chrome complains if we don't evaluate chrome.runtime.lastError on errors (and we get errors for tabs on
+  # which Vimium cannot run).
+  checkLastRuntimeError = -> chrome.runtime.lastError
   chrome.tabs.query { status: "complete" }, (tabs) ->
-    jobs = [ [ chrome.tabs.executeScript, contentScripts.js ], [ chrome.tabs.insertCSS, contentScripts.css ] ]
-    # Chrome complains if we don't evaluate chrome.runtime.lastError on errors (and we get errors for tabs on
-    # which Vimium cannot run).
-    checkLastRuntimeError = -> chrome.runtime.lastError
     for tab in tabs
       for [ func, files ] in jobs
         for file in files
           func tab.id, { file: file, allFrames: contentScripts.allFrames }, checkLastRuntimeError
 
-# The browser may have tabs already open. We inject the content scripts immediately so that they work straight
-# away.
-chrome.runtime.onInstalled.addListener injectContentScriptsIntoOpenTabs
-
+currentVersion = Utils.getCurrentVersion()
 tabQueue = {} # windowId -> Array
 tabInfoMap = {} # tabId -> object with various tab properties
 keyQueue = "" # Queue of keys typed

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -210,6 +210,7 @@ window.initializeWhenEnabled = ->
     for type in [ "keydown", "keypress", "keyup", "click", "focus", "blur", "mousedown" ]
       do (type) -> installListener window, type, (event) -> handlerStack.bubbleEvent type, event
     installListener document, "DOMActivate", (event) -> handlerStack.bubbleEvent 'DOMActivate', event
+    installListener document, "focus", detectFocus
     installedListeners = true
     FindModeHistory.init()
 
@@ -229,7 +230,7 @@ getActiveState = ->
 #
 # The backend needs to know which frame has focus.
 #
-window.addEventListener "focus", ->
+detectFocus = ->
   # settings may have changed since the frame last had focus
   settings.load()
   chrome.runtime.sendMessage({ handler: "frameFocused", frameId: frameId })

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -542,7 +542,7 @@ context "Mode badges",
 
   should "have an I badge in insert mode by focus", ->
     document.getElementById("first").focus()
-    assert.isTrue chromeMessages[0].badge == "I"
+    assert.isTrue chromeMessages[1].badge == "I"
 
   should "have no badge after leaving insert mode by focus", ->
     document.getElementById("first").focus()
@@ -575,5 +575,5 @@ context "Mode badges",
       passKeys: ""
 
     document.getElementById("first").focus()
-    assert.isTrue chromeMessages[0].badge == ""
+    assert.isTrue chromeMessages[1].badge == ""
 

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -542,6 +542,7 @@ context "Mode badges",
 
   should "have an I badge in insert mode by focus", ->
     document.getElementById("first").focus()
+    # Focus triggers an event in the handler stack, so we check element "1", here.
     assert.isTrue chromeMessages[1].badge == "I"
 
   should "have no badge after leaving insert mode by focus", ->
@@ -575,5 +576,6 @@ context "Mode badges",
       passKeys: ""
 
     document.getElementById("first").focus()
+    # Focus triggers an event in the handler stack, so we check element "1", here.
     assert.isTrue chromeMessages[1].badge == ""
 

--- a/tests/unit_tests/test_chrome_stubs.coffee
+++ b/tests/unit_tests/test_chrome_stubs.coffee
@@ -16,6 +16,8 @@ exports.chrome =
       addListener: () -> true
     onMessage:
       addListener: () -> true
+    onInstalled:
+      addListener: ->
 
   tabs:
     onSelectionChanged:


### PR DESCRIPTION
This is @mrmr1993's work from #1041.

Reload content scripts when vimium is installed or updates.

(@mrmr1993:  The automatic merge was really messy (or, at least, I couldn't figure out what was going on).  Since the bulk of #1041 was actually quite compact, I took the liberty of just copying it in.  Hope you don't mind.  There are also a couple of small fixes here, e.g. checking `chrome.runtime.lastError`.)