### PR TITLE
Pass keyup events after entering link-hint mode.

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -68,6 +68,7 @@ LinkHints =
     @hintMode = new Mode
       name: "hint/#{mode.name}"
       badge: "#{mode.key}?"
+      passInitialKeyupEvents: true
       keydown: @onKeyDownInMode.bind(this, hintMarkers),
       # trap all key events
       keypress: -> false

--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -120,6 +120,16 @@ class Mode
             @registerStateChange?()
         registerKeyQueue: ({ keyQueue: keyQueue }) => @alwaysContinueBubbling => @keyQueue = keyQueue
 
+    # If @options.passInitialKeyupEvents is set, then we pass initial non-printable keyup events to the page
+    # or to other extensions (because the corresponding keydown events were passed).  This is used when
+    # activating link hints, see #1522.
+    if @options.passInitialKeyupEvents
+      @push
+        _name: "mode-#{@id}/passInitialKeyupEvents"
+        keydown: => @alwaysContinueBubbling -> handlerStack.remove()
+        keyup: (event) =>
+          if KeyboardUtils.isPrintable event then @stopBubblingAndFalse else @stopBubblingAndTrue
+
     Mode.modes.push @
     Mode.updateBadge()
     @logModes()


### PR DESCRIPTION
When we enter link-hints mode with a key such as `F`, the page (or another extension) sees the `keydown` event for `Shift`.  We need to also pass the corresponding `keyup` event, otherwise the page/extension can get confused.

Fixes #1522.