### PR TITLE
Rework exclusion rule popup population, propagation and page icon

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -26,6 +26,7 @@ validFirstKeys = {}
 singleKeyCommands = []
 focusedFrame = null
 frameIdsForTab = {}
+root.urlForTab = {}
 
 # Keys are either literal characters, or "named" - for example <a-b> (alt+b), <left> (left arrow) or <f12>
 # This regular expression captures two groups: the first is a named key, the second is the remainder of
@@ -462,6 +463,7 @@ chrome.tabs.onRemoved.addListener (tabId) ->
   tabInfoMap.deletor = -> delete tabInfoMap[tabId]
   setTimeout tabInfoMap.deletor, 1000
   delete frameIdsForTab[tabId]
+  delete urlForTab[tabId]
 
 chrome.tabs.onActiveChanged.addListener (tabId, selectInfo) -> updateActiveState(tabId)
 
@@ -647,6 +649,7 @@ unregisterFrame = (request, sender) ->
 
 handleFrameFocused = (request, sender) ->
   tabId = sender.tab.id
+  urlForTab[tabId] = request.url
   if frameIdsForTab[tabId]?
     frameIdsForTab[tabId] =
       [request.frameId, (frameIdsForTab[tabId].filter (id) -> id != request.frameId)...]

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -398,7 +398,8 @@ root.updateActiveState = updateActiveState = (tabId) ->
       if response
         isCurrentlyEnabled = response.enabled
         currentPasskeys = response.passKeys
-        config = isEnabledForUrl { url: tab.url }, { tab: tab }
+        currentURL = response.url
+        config = isEnabledForUrl { url: currentURL }, { tab: tab }
         enabled = config.isEnabledForUrl
         passKeys = config.passKeys
         if (enabled and passKeys)

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -150,7 +150,7 @@ initializePreDomReady = ->
   settings.load()
 
   initializeModes()
-  checkIfEnabledForUrl true # true means checkIfEnabledForUrl is being called on start up.
+  checkIfEnabledForUrl()
   refreshCompletionKeys()
 
   # Send the key to the key handler in the background page.
@@ -547,7 +547,7 @@ onKeyup = (event) ->
   DomUtils.suppressPropagation(event)
   @stopBubblingAndTrue
 
-checkIfEnabledForUrl = (onStartUp = false) ->
+checkIfEnabledForUrl = ->
   url = window.location.toString()
 
   chrome.runtime.sendMessage { handler: "isEnabledForUrl", url: url }, (response) ->
@@ -556,7 +556,7 @@ checkIfEnabledForUrl = (onStartUp = false) ->
     isIncognitoMode = response.incognito
     if isEnabledForUrl
       initializeWhenEnabled()
-    else if onStartUp and HUD.isReady()
+    else if HUD.isReady()
       # Quickly hide any HUD we might already be showing, e.g. if we entered insert mode on page load.
       HUD.hide()
     handlerStack.bubbleEvent "registerStateChange",

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -209,7 +209,7 @@ window.initializeWhenEnabled = ->
     for type in [ "keydown", "keypress", "keyup", "click", "focus", "blur", "mousedown" ]
       do (type) -> installListener window, type, (event) -> handlerStack.bubbleEvent type, event
     installListener document, "DOMActivate", (event) -> handlerStack.bubbleEvent 'DOMActivate', event
-    installListener document, "focus", detectFocus
+    installListener window, "focus", registerFocus
     installedListeners = true
     FindModeHistory.init()
 
@@ -229,7 +229,7 @@ getActiveState = ->
 #
 # The backend needs to know which frame has focus.
 #
-detectFocus = ->
+registerFocus = ->
   # settings may have changed since the frame last had focus
   settings.load()
   chrome.runtime.sendMessage({ handler: "frameFocused", frameId: frameId })

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -190,6 +190,7 @@ initializePreDomReady = ->
     # Ensure the sendResponse callback is freed.
     false
 
+
 # Wrapper to install event listeners.  Syntactic sugar.
 installListener = (element, event, callback) ->
   element.addEventListener(event, ->
@@ -227,12 +228,12 @@ getActiveState = ->
   return { enabled: isEnabledForUrl, passKeys: passKeys }
 
 #
-# The backend needs to know which frame has focus.
+# The backend needs to know which frame has focus, and the active URL.
 #
 registerFocus = ->
   # settings may have changed since the frame last had focus
   settings.load()
-  chrome.runtime.sendMessage({ handler: "frameFocused", frameId: frameId })
+  chrome.runtime.sendMessage handler: "frameFocused", frameId: frameId, url: window.location.toString()
 
 #
 # Initialization tasks that must wait for the document to be ready.

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -271,8 +271,12 @@ initPopupPage = ->
     exclusions = null
     document.getElementById("optionsLink").setAttribute "href", chrome.runtime.getURL("pages/options.html")
 
+    # As the active URL, we choose the most recently registered URL from a frame in the tab, or the tab's own
+    # URL.
+    url = chrome.extension.getBackgroundPage().urlForTab[tab.id] || tab.url
+
     updateState = ->
-      rule = bgExclusions.getRule tab.url, exclusions.readValueFromElement()
+      rule = bgExclusions.getRule url, exclusions.readValueFromElement()
       $("state").innerHTML = "Vimium will " +
         if rule and rule.passKeys
           "exclude <span class='code'>#{rule.passKeys}</span>"
@@ -302,7 +306,7 @@ initPopupPage = ->
         window.close()
 
     # Populate options. Just one, here.
-    exclusions = new ExclusionRulesOnPopupOption(tab.url, "exclusionRules", onUpdated)
+    exclusions = new ExclusionRulesOnPopupOption(url, "exclusionRules", onUpdated)
 
     updateState()
     document.addEventListener "keyup", updateState

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -304,7 +304,7 @@ initPopupPage = ->
         window.close()
 
     # Populate options. Just one, here.
-    exclusions = new ExclusionRulesOnPopupOption(url, "exclusionRules", onUpdated)
+    exclusions = new ExclusionRulesOnPopupOption url, "exclusionRules", onUpdated
 
     updateState()
     document.addEventListener "keyup", updateState

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -295,8 +295,6 @@ initPopupPage = ->
       Option.saveOptions()
       $("saveOptions").innerHTML = "Saved"
       $("saveOptions").disabled = true
-      chrome.tabs.query { windowId: chrome.windows.WINDOW_ID_CURRENT, active: true }, (tabs) ->
-        chrome.extension.getBackgroundPage().updateActiveState(tabs[0].id)
 
     $("saveOptions").addEventListener "click", saveOptions
 


### PR DESCRIPTION
Edit: Actually, it now does considerably more.  See second post.  The following is out of date.

This PR does two related things:

1. 3876a4f06de77d190fdaecc6cf99eb57134d0372 populates the page popup with the active frame's URL (as opposed to the tab's URL).

2. ea05de3f114dcc81a91bf863538f20754641cadd ensures changes to exclusion rules are propagated to all frames, not just the first to respond.  This is a long-standing bug.

With these changes, we can now - for example - set and (immediately) use exclusion rules in the hangouts frame on gmail.

There are a lot of long-standing issues around how frames, exclusion rules and the page icon are handled.  This is a first step towards fixing some of these.  A better way to fix all of this would be to propagate options via `chrome.storage`.