### PR TITLE
Flash a frame's border when it receives the focus.

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -304,13 +304,13 @@ BackgroundCommands =
   moveTabLeft: (count) -> moveTab(null, -count)
   moveTabRight: (count) -> moveTab(null, count)
   nextFrame: (count,frameId) ->
-    chrome.tabs.getSelected(null, (tab) ->
+    chrome.tabs.getSelected null, (tab) ->
       frames = frameIdsForTab[tab.id]
       # We can't always track which frame chrome has focussed, but here we learn that it's frameId; so add an
       # additional offset such that we do indeed start from frameId.
       count = (count + Math.max 0, frameIdsForTab[tab.id].indexOf frameId) % frames.length
       frames = frameIdsForTab[tab.id] = [frames[count..]..., frames[0...count]...]
-      chrome.tabs.sendMessage(tab.id, { name: "focusFrame", frameId: frames[0], highlight: true }))
+      chrome.tabs.sendMessage tab.id, name: "focusFrame", frameId: frames[0]
 
   closeTabsOnLeft: -> removeTabsRelative "before"
   closeTabsOnRight: -> removeTabsRelative "after"

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -168,7 +168,7 @@ initializePreDomReady = ->
     showUpgradeNotification: (request) -> HUD.showUpgradeNotification(request.version)
     showHUDforDuration: (request) -> HUD.showForDuration request.text, request.duration
     toggleHelpDialog: (request) -> toggleHelpDialog(request.dialogHtml, request.frameId)
-    focusFrame: (request) -> if (frameId == request.frameId) then focusThisFrame(request.highlight)
+    focusFrame: (request) -> if (frameId == request.frameId) then focusThisFrame()
     refreshCompletionKeys: refreshCompletionKeys
     getScrollPosition: -> scrollX: window.scrollX, scrollY: window.scrollY
     setScrollPosition: (request) -> setScrollPosition request.scrollX, request.scrollY
@@ -274,7 +274,7 @@ setScrollPosition = (scrollX, scrollY) ->
 #
 # Called from the backend in order to change frame focus.
 #
-window.focusThisFrame = (shouldHighlight) ->
+window.focusThisFrame = ->
   if window.innerWidth < 3 or window.innerHeight < 3
     # This frame is too small to focus. Cancel and tell the background frame to focus the next one instead.
     # This affects sites like Google Inbox, which have many tiny iframes. See #1317.
@@ -282,7 +282,15 @@ window.focusThisFrame = (shouldHighlight) ->
     chrome.runtime.sendMessage({ handler: "nextFrame", frameId: frameId })
     return
   window.focus()
-  if (document.body && shouldHighlight)
+  # We only flash the top frame, here.  Other frames are flashed by their focus listeners (below).
+  flashFrame() if document.body and window.top == window
+
+# We always flash the frame of non-top windows when they receive the focus.  That way, the user gets visual
+# feedback as to which frame is focused when they return to a tab.
+installListener window, "focus", (event) ->
+  flashFrame() if event.target == window and window != window.top
+
+flashFrame = ->
     borderWas = document.body.style.border
     document.body.style.border = '5px solid yellow'
     setTimeout((-> document.body.style.border = borderWas), 200)


### PR DESCRIPTION
When the focus is in a frame other than the main frame (e.g. in a Google Hangouts frame), we get no visual feedback as to which frame has the focus when we return to a tab.

This flashes the (non-main) frame's border when it receives the focus.

However, having tried this out, it seems to be too noisy.  The frame flashes even when we just change window, or when the vomnibar closes.  So not a great idea.  I'm not proposing to merge this.

Are there any better ideas as to how to provide visual feedback as to the active frame?