### PR TITLE
Use chrome.notifications for upgrade notifications.

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -699,7 +699,7 @@ showUpgradeMessage = ->
       type: "basic"
       iconUrl: chrome.runtime.getURL "icons/vimium.png"
       title: "Vimium Upgrade"
-      message: "Vimium has been upgraded to version #{currentVersion}. Click here for more information"
+      message: "Vimium has been upgraded to version #{currentVersion}. Click here for more information."
       isClickable: true
     chrome.notifications.create notificationId, notification, ->
       unless chrome.runtime.lastError

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -165,8 +165,6 @@ initializePreDomReady = ->
     window.removeEventListener "focus", onFocus
 
   requestHandlers =
-    hideUpgradeNotification: -> HUD.hideUpgradeNotification()
-    showUpgradeNotification: (request) -> HUD.showUpgradeNotification(request.version)
     showHUDforDuration: (request) -> HUD.showForDuration request.text, request.duration
     toggleHelpDialog: (request) -> toggleHelpDialog(request.dialogHtml, request.frameId)
     focusFrame: (request) -> if (frameId == request.frameId) then focusThisFrame(request.highlight)
@@ -1069,7 +1067,6 @@ toggleHelpDialog = (html, fid) ->
 HUD =
   _tweenId: -1
   _displayElement: null
-  _upgradeNotificationElement: null
 
   # This HUD is styled to precisely mimick the chrome HUD on Mac. Use the "has_popup_and_link_hud.html"
   # test harness to tweak these styles to match Chrome's. One limitation of our HUD display is that
@@ -1087,26 +1084,6 @@ HUD =
     HUD._tweenId = Tween.fade(HUD.displayElement(), 1.0, 150)
     HUD.displayElement().style.display = ""
 
-  showUpgradeNotification: (version) ->
-    HUD.upgradeNotificationElement().innerHTML = "Vimium has been upgraded to #{version}. See
-      <a class='vimiumReset' target='_blank'
-      href='https://github.com/philc/vimium#release-notes'>
-      what's new</a>.<a class='vimiumReset close-button' href='#'>&times;</a>"
-    links = HUD.upgradeNotificationElement().getElementsByTagName("a")
-    links[0].addEventListener("click", HUD.onUpdateLinkClicked, false)
-    links[1].addEventListener "click", (event) ->
-      event.preventDefault()
-      HUD.onUpdateLinkClicked()
-    Tween.fade(HUD.upgradeNotificationElement(), 1.0, 150)
-
-  onUpdateLinkClicked: (event) ->
-    HUD.hideUpgradeNotification()
-    chrome.runtime.sendMessage({ handler: "upgradeNotificationClosed" })
-
-  hideUpgradeNotification: (clickEvent) ->
-    Tween.fade(HUD.upgradeNotificationElement(), 0, 150,
-      -> HUD.upgradeNotificationElement().style.display = "none")
-
   #
   # Retrieves the HUD HTML element.
   #
@@ -1116,13 +1093,6 @@ HUD =
       # Keep this far enough to the right so that it doesn't collide with the "popups blocked" chrome HUD.
       HUD._displayElement.style.right = "150px"
     HUD._displayElement
-
-  upgradeNotificationElement: ->
-    if (!HUD._upgradeNotificationElement)
-      HUD._upgradeNotificationElement = HUD.createHudElement()
-      # Position this just to the left of our normal HUD.
-      HUD._upgradeNotificationElement.style.right = "315px"
-    HUD._upgradeNotificationElement
 
   createHudElement: ->
     element = document.createElement("div")

--- a/manifest.json
+++ b/manifest.json
@@ -27,6 +27,7 @@
     "clipboardRead",
     "storage",
     "sessions",
+    "notifications",
     "<all_urls>"
   ],
   "content_scripts": [


### PR DESCRIPTION
Instead of using the HUD for upgrade notifications, this uses `chrome.notifications`, which just seems like a more "chrome-y" way of doing things:

![snapshot](https://cloud.githubusercontent.com/assets/2641335/6769007/4cac46fc-d080-11e4-9f7b-ab42640b95aa.png)

Clicking on the notification takes you to the release notes, as currently.

Notes:
- A notification is shown separately on each chrome installation (so, you get the notification on your laptop, and again on your desktop, and so on).  This is the same as the current HUD notification.
- We do not re-show the notification, or expect the user to acknowledge it.  We show it once, and are done.  This is a change from the status quo.

To do:
- ~~If the user has to explicitly accept the "notifications" permission, then we lose the notification until the next time Vimium starts.  (Fix coming.)~~ Done.