### PR TITLE
Move the search-engine logic out of settings.coffee.

### DIFF
--- a/background_scripts/settings.coffee
+++ b/background_scripts/settings.coffee
@@ -33,7 +33,7 @@ root.Settings = Settings =
       root.refreshCompletionKeysAfterMappingSave()
 
     searchEngines: (value) ->
-      root.Settings.parseSearchEngines value
+      root.SearchEngineCompleter.parseSearchEngines value
 
     exclusionRules: (value) ->
       root.Exclusions.postUpdateHook value
@@ -41,27 +41,6 @@ root.Settings = Settings =
   # postUpdateHooks convenience wrapper
   performPostUpdateHook: (key, value) ->
     @postUpdateHooks[key] value if @postUpdateHooks[key]
-
-  # Here we have our functions that parse the search engines
-  # this is a map that we use to store our search engines for use.
-  searchEnginesMap: {}
-
-  # Parse the custom search engines setting and cache it.
-  parseSearchEngines: (searchEnginesText) ->
-    @searchEnginesMap = {}
-    for line in searchEnginesText.split /\n/
-      tokens = line.trim().split /\s+/
-      continue if tokens.length < 2 or tokens[0].startsWith('"') or tokens[0].startsWith("#")
-      keywords = tokens[0].split ":"
-      continue unless keywords.length == 2 and not keywords[1] # So, like: [ "w", "" ].
-      @searchEnginesMap[keywords[0]] =
-        url: tokens[1]
-        description: tokens[2..].join(" ")
-
-  # Fetch the search-engine map, building it if necessary.
-  getSearchEngines: ->
-    this.parseSearchEngines(@get("searchEngines") || "") if Object.keys(@searchEnginesMap).length == 0
-    @searchEnginesMap
 
   # options.coffee and options.html only handle booleans and strings; therefore all defaults must be booleans
   # or strings

--- a/tests/unit_tests/completion_test.coffee
+++ b/tests/unit_tests/completion_test.coffee
@@ -238,7 +238,7 @@ context "search engines",
     @completer = new SearchEngineCompleter()
     # note, I couldn't just call @completer.refresh() here as I couldn't set root.Settings without errors
     # workaround is below, would be good for someone that understands the testing system better than me to improve
-    @completer.searchEngines = Settings.getSearchEngines()
+    @completer.searchEngines = SearchEngineCompleter.getSearchEngines()
 
   should "return search engine suggestion without description", ->
     results = filterCompleter(@completer, ["foo", "hello"])

--- a/tests/unit_tests/settings_test.coffee
+++ b/tests/unit_tests/settings_test.coffee
@@ -73,7 +73,7 @@ context "settings",
   should "set search engines, retrieve them correctly and check that they have been parsed correctly", ->
     searchEngines = "foo: bar?q=%s\n# comment\nbaz: qux?q=%s baz description"
     Settings.set 'searchEngines', searchEngines
-    result = Settings.getSearchEngines()
+    result = SearchEngineCompleter.getSearchEngines()
     assert.equal Object.keys(result).length, 2
     assert.equal "bar?q=%s", result["foo"].url
     assert.isFalse result["foo"].description


### PR DESCRIPTION
The search-engine logic should never have been in `settings.coffee`.  This moves it to `completion.coffee`, where it belongs.

(This is a no-op in itself.  However, it cleans up the settings code preparatory to looking into moving settings from `localStorage` to `chrome.storage`.)