### PR TITLE
Reinstate "Insert mode" indicator in HUD.

### DIFF
--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -7,6 +7,7 @@ class InsertMode extends Mode
 
     # If truthy, then we were activated by the user (with "i").
     @global = options.global
+    HUD.show "Insert mode" if @global
 
     handleKeyEvent = (event) =>
       return @continueBubbling unless @isActive event
@@ -74,6 +75,7 @@ class InsertMode extends Mode
     if (target and target == @insertModeLock) or @global or target == undefined
       @log "#{@id}: deactivating (permanent)" if @debug and @permanent and @insertModeLock
       @insertModeLock = null
+      HUD.hide() if @global
       # Exit, but only if this isn't the permanently-installed instance.
       if @permanent then Mode.updateBadge() else super()
 


### PR DESCRIPTION
When entering insert mode with `i`, this reinstates the `Insert mode` indicator in the HUD.  This may appease those who are used to looking to the bottom right to check whether they are in insert mode or not.

Note:  This implementation differs slightly from the legacy indicator.  When, after entering insert mode with `i`, the user clicks on an input, the HUD indicator now disappears immediately.  Previously, the indicator remained visible until the user leaves (blurs) the input.