### PR TITLE
Remove condition from getVisibleClientRect().

### DIFF
--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -54,7 +54,7 @@ DomUtils =
     clientRects = (Rect.copy clientRect for clientRect in element.getClientRects())
 
     for clientRect in clientRects
-      # If the link has zero dimensions, it may neverthe less be wrapping visible elements.
+      # If the link has zero dimensions, it may nevertheless be wrapping visible elements.
       if (clientRect.width == 0 || clientRect.height == 0)
         for child in element.children
           childClientRect = @getVisibleClientRect(child)

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -54,15 +54,9 @@ DomUtils =
     clientRects = (Rect.copy clientRect for clientRect in element.getClientRects())
 
     for clientRect in clientRects
-      # If the link has zero dimensions, it may be wrapping visible
-      # but floated elements. Check for this.
+      # If the link has zero dimensions, it may neverthe less be wrapping visible elements.
       if (clientRect.width == 0 || clientRect.height == 0)
         for child in element.children
-          computedStyle = window.getComputedStyle(child, null)
-          # Ignore child elements which are not floated and not absolutely positioned for parent elements with
-          # zero width/height
-          continue if (computedStyle.getPropertyValue('float') == 'none' &&
-            computedStyle.getPropertyValue('position') != 'absolute')
           childClientRect = @getVisibleClientRect(child)
           continue if childClientRect == null or childClientRect.width < 3 or childClientRect.height < 3
           return childClientRect


### PR DESCRIPTION
@mrmr1993.  Please see the diff.  Basically, this PR removes the requirement that we only consider children (of zero-height/width elements) which are not floated or not positioned absolutely.

Why do we need this condition?

An example came up in #1554.  On [this site](https://www.tipranks.com/) there are these clickable features:

![snapshot](https://cloud.githubusercontent.com/assets/2641335/7100840/72af61bc-e030-11e4-9b12-47c162d0f807.png)

The DOM looks like:

![snapshot](https://cloud.githubusercontent.com/assets/2641335/7100847/a3bdfaf2-e030-11e4-9baa-05c4884ffe8b.png)

We don't currently pick them up as hints because the `<a>` is of zero height while the `<span>` is not (and is not floated or fixed).

That's one example where this PR is the right thing to do.  Are there examples where this PR would be the wrong thing to do?