### PR TITLE
Fix undefined domain completion

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -42,5 +42,6 @@ Contributors:
   Werner Laurensse (github: ab3)
   Timo Sand <timo.j.sand@gmail.com> (github: deiga)
   Shiyong Chen <billbill290@gmail.com> (github: UncleBill)
+  Utkarsh Upadhyay <musically.ut@gmail.com) (github: musically-ut)
 
 Feel free to add real names in addition to GitHub usernames.

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -204,7 +204,7 @@ class DomainCompleter
   domains: null
 
   filter: (queryTerms, onComplete) ->
-    return onComplete([]) if queryTerms.length > 1
+    return onComplete([]) if queryTerms.length > 1 or queryTerms.length == 0
     if @domains
       @performSearch(queryTerms, onComplete)
     else

--- a/tests/unit_tests/completion_test.coffee
+++ b/tests/unit_tests/completion_test.coffee
@@ -152,8 +152,9 @@ context "domain completer",
   setup ->
     @history1 = { title: "history1", url: "http://history1.com", lastVisitTime: hours(1) }
     @history2 = { title: "history2", url: "http://history2.com", lastVisitTime: hours(1) }
+    @undef    = { title: "history2", url: "http://undefined.net", lastVisitTime: hours(1) }
 
-    stub(HistoryCache, "use", (onComplete) => onComplete([@history1, @history2]))
+    stub(HistoryCache, "use", (onComplete) => onComplete([@history1, @history2, @undef]))
     global.chrome.history =
       onVisited: { addListener: -> }
       onVisitRemoved: { addListener: -> }
@@ -173,6 +174,9 @@ context "domain completer",
 
   should "returns no results when there's more than one query term, because clearly it's not a domain", ->
     assert.arrayEqual [], filterCompleter(@completer, ["his", "tory"])
+
+  should "not return any results for empty queries", ->
+    assert.arrayEqual [], filterCompleter(@completer, [])
 
 context "domain completer (removing entries)",
   setup ->


### PR DESCRIPTION
If one visits a site with `undefined` in its domain name (say, `http://undefined.io`), then upon opening the ViOmniBox, immediately that domain name would pop up.

This pull requests fixes that behavior. 