### PR TITLE
[WIP] Remove badges and revert to HUD for mode indicator.

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -355,32 +355,12 @@ updateOpenTabs = (tab, deleteFrames = false) ->
   # Frames are recreated on refresh
   delete frameIdsForTab[tab.id] if deleteFrames
 
-chrome.browserAction.setBadgeBackgroundColor
-  # This is Vimium blue (from the icon).
-  # color: [102, 176, 226, 255]
-  # This is a slightly darker blue. It makes the badge more striking in the corner of the eye, and the symbol
-  # easier to read.
-  color: [82, 156, 206, 255]
-
-setBadge = do ->
-  current = null
-  timer = null
-  updateBadge = (badge, tabId) -> -> chrome.browserAction.setBadgeText text: badge, tabId: tabId
-  (request, sender) ->
-    badge = request.badge
-    if badge? and badge != current
-      current = badge
-      clearTimeout timer if timer
-      # We wait a few moments. This avoids badge flicker when there are rapid changes.
-      timer = setTimeout updateBadge(badge, sender.tab.id), 50
-
 # Here's how we set the page icon.  The default is "disabled", so if we do nothing else, then we get the
 # grey-out disabled icon.  Thereafter, we only set tab-specific icons, so there's no need to update the icon
 # when we visit a tab on which Vimium isn't running.
 #
 # For active tabs, when a frame starts, it requests its active state via isEnabledForUrl.  We also check the
-# state every time a frame gets the focus.  Once the frame learns its active state, it updates the current
-# tab's badge (but only if that frame has the focus).
+# state every time a frame gets the focus.  In both cases, the frame then updates the tab's icon accordingly.
 #
 # Exclusion rule changes (from either the options page or the page popup) propagate via the subsequent focus
 # change.  In particular, whenever a frame next gets the focus, it requests its new state and sets the icon
@@ -647,7 +627,6 @@ sendRequestHandlers =
   createMark: Marks.create.bind(Marks)
   gotoMark: Marks.goto.bind(Marks)
   setIcon: setIcon
-  setBadge: setBadge
 
 # We always remove chrome.storage.local/findModeRawQueryListIncognito on startup.
 chrome.storage.local.remove "findModeRawQueryListIncognito"

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -54,6 +54,15 @@ LinkHints =
       return
     @isActive = true
 
+    @hintMode = new Mode
+      name: "hint/#{mode.name}"
+      indicator: false
+      passInitialKeyupEvents: true
+      keydown: @onKeyDownInMode.bind(this, hintMarkers),
+      # trap all key events
+      keypress: -> false
+      keyup: -> false
+
     @setOpenLinkMode(mode)
     hintMarkers = (@createMarkerFor(el) for el in @getVisibleClickableElements())
     @getMarkerMatcher().fillInMarkers(hintMarkers)
@@ -63,14 +72,6 @@ LinkHints =
     # that if you scroll the page and the link has position=fixed, the marker will not stay fixed.
     @hintMarkerContainingDiv = DomUtils.addElementList(hintMarkers,
       { id: "vimiumHintMarkerContainer", className: "vimiumReset" })
-
-    @hintMode = new Mode
-      name: "hint/#{mode.name}"
-      passInitialKeyupEvents: true
-      keydown: @onKeyDownInMode.bind(this, hintMarkers),
-      # trap all key events
-      keypress: -> false
-      keyup: -> false
 
   setOpenLinkMode: (@mode) ->
     if @mode is OPEN_IN_NEW_BG_TAB or @mode is OPEN_IN_NEW_FG_TAB or @mode is OPEN_WITH_QUEUE

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -8,16 +8,15 @@
 # In 'filter' mode, our link hints are numbers, and the user can narrow down the range of possibilities by
 # typing the text of the link itself.
 #
-# The "name" property below is a short-form name to appear in the link-hints mode name.  Debugging only.  The
-# key appears in the mode's badge.
+# The "name" property below is a short-form name to appear in the link-hints mode's name.  It's for debug only.
 #
-OPEN_IN_CURRENT_TAB = { name: "curr-tab", key: "" }
-OPEN_IN_NEW_BG_TAB = { name: "bg-tab", key: "B" }
-OPEN_IN_NEW_FG_TAB = { name: "fg-tab", key: "F" }
-OPEN_WITH_QUEUE = { name: "queue", key: "Q" }
-COPY_LINK_URL = { name: "link", key: "C" }
-OPEN_INCOGNITO = { name: "incognito", key: "I" }
-DOWNLOAD_LINK_URL = { name: "download", key: "D" }
+OPEN_IN_CURRENT_TAB = name: "curr-tab"
+OPEN_IN_NEW_BG_TAB = name: "bg-tab"
+OPEN_IN_NEW_FG_TAB = name: "fg-tab"
+OPEN_WITH_QUEUE = name: "queue"
+COPY_LINK_URL = name: "link"
+OPEN_INCOGNITO = name: "incognito"
+DOWNLOAD_LINK_URL = name: "download"
 
 LinkHints =
   hintMarkerContainingDiv: null
@@ -67,7 +66,6 @@ LinkHints =
 
     @hintMode = new Mode
       name: "hint/#{mode.name}"
-      badge: "#{mode.key}?"
       passInitialKeyupEvents: true
       keydown: @onKeyDownInMode.bind(this, hintMarkers),
       # trap all key events

--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -6,13 +6,6 @@
 # name:
 #   A name for this mode.
 #
-# badge:
-#   A badge (to appear on the browser popup).
-#   Optional.  Define a badge if the badge is constant; for example, in find mode the badge is always "/".
-#   Otherwise, do not define a badge, but instead override the updateBadge method; for example, in passkeys
-#   mode, the badge may be "P" or "", depending on the configuration state.  Or, if the mode *never* shows a
-#   badge, then do neither.
-#
 # keydown:
 # keypress:
 # keyup:
@@ -48,7 +41,6 @@ class Mode
     @handlers = []
     @exitHandlers = []
     @modeIsActive = true
-    @badge = @options.badge || ""
     @name = @options.name || "anonymous"
 
     @count = ++count
@@ -59,7 +51,6 @@ class Mode
       keydown: @options.keydown || null
       keypress: @options.keypress || null
       keyup: @options.keyup || null
-      updateBadge: (badge) => @alwaysContinueBubbling => @updateBadge badge
 
     # If @options.exitOnEscape is truthy, then the mode will exit when the escape key is pressed.
     if @options.exitOnEscape
@@ -131,7 +122,6 @@ class Mode
           if KeyboardUtils.isPrintable event then @stopBubblingAndFalse else @stopBubblingAndTrue
 
     Mode.modes.push @
-    Mode.updateBadge()
     @logModes()
     # End of Mode constructor.
 
@@ -152,16 +142,10 @@ class Mode
       handler() for handler in @exitHandlers
       handlerStack.remove handlerId for handlerId in @handlers
       Mode.modes = Mode.modes.filter (mode) => mode != @
-      Mode.updateBadge()
       @modeIsActive = false
 
   deactivateSingleton: (singleton) ->
     Mode.singletons?[Utils.getIdentity singleton]?.exit()
-
-  # The badge is chosen by bubbling an "updateBadge" event down the handler stack allowing each mode the
-  # opportunity to choose a badge. This is overridden in sub-classes.
-  updateBadge: (badge) ->
-    badge.badge ||= @badge
 
   # Shorthand for an otherwise long name.  This wraps a handler with an arbitrary return value, and always
   # yields @continueBubbling instead.  This simplifies handlers if they always continue bubbling (a common
@@ -173,14 +157,6 @@ class Mode
   cloneMode: ->
     delete @options[key] for key in [ "keydown", "keypress", "keyup" ]
     new @constructor @options
-
-  # Static method.  Used externally and internally to initiate bubbling of an updateBadge event and to send
-  # the resulting badge to the background page.  We only update the badge if this document (hence this frame)
-  # has the focus.
-  @updateBadge: ->
-    if document.hasFocus()
-      handlerStack.bubbleEvent "updateBadge", badge = badge: ""
-      chrome.runtime.sendMessage { handler: "setBadge", badge: badge.badge }, ->
 
   # Debugging routines.
   logModes: ->
@@ -200,31 +176,5 @@ class Mode
     mode.exit() for mode in @modes
     @modes = []
 
-# BadgeMode is a pseudo mode for triggering badge updates on focus changes and state updates. It sits at the
-# bottom of the handler stack, and so it receives state changes *after* all other modes, and can override the
-# badge choice of the other modes.
-class BadgeMode extends Mode
-  constructor: () ->
-    super
-      name: "badge"
-      trackState: true
-
-    # FIXME(smblott) BadgeMode is currently triggering an updateBadge event on every focus event.  That's a
-    # lot, considerably more than necessary.  Really, it only needs to trigger when we change frame, or when
-    # we change tab.
-    @push
-      _name: "mode-#{@id}/focus"
-      "focus": => @alwaysContinueBubbling -> Mode.updateBadge()
-
-  updateBadge: (badge) ->
-    # If we're not enabled, then post an empty badge.
-    badge.badge = "" unless @enabled
-
-  # When the registerStateChange event bubbles to the bottom of the stack, all modes have been notified.  So
-  # it's now time to update the badge.
-  registerStateChange: ->
-    Mode.updateBadge()
-
 root = exports ? window
 root.Mode = Mode
-root.BadgeMode = BadgeMode

--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -51,6 +51,14 @@ class Mode
       keydown: @options.keydown || null
       keypress: @options.keypress || null
       keyup: @options.keyup || null
+      indicator: =>
+        # Update the mode indicator.  Setting @options.indicator to a string shows a mode indicator in the
+        # HUD.  Setting @options.indicator to 'false' forces no mode indicator.  If @options.indicator is
+        # undefined, then the request propagates to the next mode.
+        if @options.indicator?
+          if @options.indicator then HUD?.show @options.indicator else HUD?.hide true, false
+          @stopBubblingAndTrue
+        else @continueBubbling
 
     # If @options.exitOnEscape is truthy, then the mode will exit when the escape key is pressed.
     if @options.exitOnEscape
@@ -122,6 +130,7 @@ class Mode
           if KeyboardUtils.isPrintable event then @stopBubblingAndFalse else @stopBubblingAndTrue
 
     Mode.modes.push @
+    handlerStack.bubbleEvent 'indicator'
     @logModes()
     # End of Mode constructor.
 
@@ -143,6 +152,7 @@ class Mode
       handlerStack.remove handlerId for handlerId in @handlers
       Mode.modes = Mode.modes.filter (mode) => mode != @
       @modeIsActive = false
+      handlerStack.bubbleEvent 'indicator'
 
   deactivateSingleton: (singleton) ->
     Mode.singletons?[Utils.getIdentity singleton]?.exit()

--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -55,6 +55,7 @@ class Mode
         # Update the mode indicator.  Setting @options.indicator to a string shows a mode indicator in the
         # HUD.  Setting @options.indicator to 'false' forces no mode indicator.  If @options.indicator is
         # undefined, then the request propagates to the next mode.
+        # The active indicator can also be changed with @setIndicator().
         if @options.indicator?
           if @options.indicator then HUD?.show @options.indicator else HUD?.hide true, false
           @stopBubblingAndTrue
@@ -130,9 +131,16 @@ class Mode
           if KeyboardUtils.isPrintable event then @stopBubblingAndFalse else @stopBubblingAndTrue
 
     Mode.modes.push @
-    handlerStack.bubbleEvent 'indicator'
+    @setIndicator()
     @logModes()
     # End of Mode constructor.
+
+  setIndicator: (indicator = @options.indicator) ->
+    @options.indicator = indicator
+    Mode.setIndicator()
+
+  @setIndicator: ->
+    handlerStack.bubbleEvent "indicator"
 
   push: (handlers) ->
     handlers._name ||= "mode-#{@id}"
@@ -152,7 +160,7 @@ class Mode
       handlerStack.remove handlerId for handlerId in @handlers
       Mode.modes = Mode.modes.filter (mode) => mode != @
       @modeIsActive = false
-      handlerStack.bubbleEvent 'indicator'
+      @setIndicator()
 
   deactivateSingleton: (singleton) ->
     Mode.singletons?[Utils.getIdentity singleton]?.exit()

--- a/content_scripts/mode_find.coffee
+++ b/content_scripts/mode_find.coffee
@@ -33,8 +33,6 @@ class PostFindMode extends SuppressPrintable
 
     super
       name: "post-find"
-      # We show a "?" badge, but only while an Escape activates insert mode.
-      badge: "?"
       # PostFindMode shares a singleton with the modes launched by focusInput; each displaces the other.
       singleton: element
       exitOnBlur: element
@@ -54,14 +52,7 @@ class PostFindMode extends SuppressPrintable
           @suppressEvent
         else
           handlerStack.remove()
-          @badge = ""
-          Mode.updateBadge()
           @continueBubbling
-
-  updateBadge: (badge) ->
-    badge.badge ||= @badge
-    # Suppress the "I" badge from insert mode.
-    InsertMode.suppressEvent badge # Always truthy.
 
 root = exports ? window
 root.PostFindMode = PostFindMode

--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -68,18 +68,13 @@ class InsertMode extends Mode
   activateOnElement: (element) ->
     @log "#{@id}: activating (permanent)" if @debug and @permanent
     @insertModeLock = element
-    Mode.updateBadge()
 
   exit: (_, target)  ->
     if (target and target == @insertModeLock) or @global or target == undefined
       @log "#{@id}: deactivating (permanent)" if @debug and @permanent and @insertModeLock
       @insertModeLock = null
       # Exit, but only if this isn't the permanently-installed instance.
-      if @permanent then Mode.updateBadge() else super()
-
-  updateBadge: (badge) ->
-    badge.badge ||= @badge if @badge
-    badge.badge ||= "I" if @isActive badge
+      super() unless @permanent
 
   # Static stuff. This allows PostFindMode to suppress the permanently-installed InsertMode instance.
   @suppressedEvent: null

--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -24,7 +24,7 @@ class InsertMode extends Mode
 
     defaults =
       name: "insert"
-      indicator: if @global then "Insert mode" else null
+      indicator: if @permanent then null else "Insert mode"
       keypress: handleKeyEvent
       keyup: handleKeyEvent
       keydown: handleKeyEvent

--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -24,6 +24,7 @@ class InsertMode extends Mode
 
     defaults =
       name: "insert"
+      indicator: if @global then "Insert mode" else null
       keypress: handleKeyEvent
       keyup: handleKeyEvent
       keydown: handleKeyEvent

--- a/content_scripts/mode_passkeys.coffee
+++ b/content_scripts/mode_passkeys.coffee
@@ -16,9 +16,5 @@ class PassKeysMode extends Mode
     else
       @continueBubbling
 
-  # Disabled, pending experimentation with how/whether to use badges (smblott, 2015/01/17).
-  # updateBadge: (badge) ->
-  #   badge.badge ||= "P" if @passKeys and not @keyQueue
-
 root = exports ? window
 root.PassKeysMode = PassKeysMode

--- a/content_scripts/mode_visual_edit.coffee
+++ b/content_scripts/mode_visual_edit.coffee
@@ -376,10 +376,10 @@ class Movement extends CountPrefix
     message = @yankedText.replace /\s+/g, " "
     message = message[...12] + "..." if 15 < @yankedText.length
     plural = if @yankedText.length == 1 then "" else "s"
-    HUD.showForDuration "Yanked #{@yankedText.length} character#{plural}: \"#{message}\".", 2500
 
     @options.onYank?.call @, @yankedText
     @exit()
+    HUD.showForDuration "Yanked #{@yankedText.length} character#{plural}: \"#{message}\".", 2500
     @yankedText
 
   exit: (event, target) ->
@@ -466,6 +466,7 @@ class VisualMode extends Movement
 
     defaults =
       name: "visual"
+      indicator: if options.indicator? then options.indicator else "Visual mode"
       singleton: VisualMode
       exitOnEscape: true
     super extend defaults, options
@@ -566,7 +567,7 @@ class VisualMode extends Movement
 
 class VisualLineMode extends VisualMode
   constructor: (options = {}) ->
-    super extend { name: "visual/line" }, options
+    super extend { name: "visual/line", indicator: "Visual mode (line)" }, options
     @extendSelection()
     @commands.v = -> @changeMode VisualMode
 
@@ -586,6 +587,7 @@ class CaretMode extends Movement
 
     defaults =
       name: "caret"
+      indicator: "Caret mode"
       singleton: VisualMode
       exitOnEscape: true
     super extend defaults, options
@@ -650,6 +652,7 @@ class EditMode extends Movement
 
     defaults =
       name: "edit"
+      indicator: "Edit mode"
       exitOnEscape: true
       exitOnBlur: @element
     super extend defaults, options

--- a/content_scripts/mode_visual_edit.coffee
+++ b/content_scripts/mode_visual_edit.coffee
@@ -466,7 +466,6 @@ class VisualMode extends Movement
 
     defaults =
       name: "visual"
-      badge: "V"
       singleton: VisualMode
       exitOnEscape: true
     super extend defaults, options
@@ -587,7 +586,6 @@ class CaretMode extends Movement
 
     defaults =
       name: "caret"
-      badge: "C"
       singleton: VisualMode
       exitOnEscape: true
     super extend defaults, options
@@ -652,7 +650,6 @@ class EditMode extends Movement
 
     defaults =
       name: "edit"
-      badge: "E"
       exitOnEscape: true
       exitOnBlur: @element
     super extend defaults, options
@@ -748,7 +745,6 @@ class EditMode extends Movement
   # and (possibly) deletes it.
   enterVisualModeForMovement: (count, options = {}) ->
     @launchSubMode VisualMode, extend options,
-      badge: "M"
       initialCountPrefix: count
       oneMovementOnly: true
 

--- a/content_scripts/mode_visual_edit.coffee
+++ b/content_scripts/mode_visual_edit.coffee
@@ -489,8 +489,8 @@ class VisualMode extends Movement
             @selection.removeAllRanges()
 
         if @selection.type != "Range"
-          HUD.showForDuration "No usable selection, entering caret mode...", 2500
           @changeMode CaretMode
+          HUD.showForDuration "No usable selection, entering caret mode...", 2500
           return
 
     @push
@@ -597,8 +597,8 @@ class CaretMode extends Movement
       when "None"
         @establishInitialSelectionAnchor()
         if @selection.type == "None"
-          HUD.showForDuration "Create a selection before entering visual mode.", 2500
           @exit()
+          HUD.showForDuration "Create a selection before entering visual mode.", 2500
           return
       when "Range"
         @collapseSelectionToAnchor()

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -706,7 +706,6 @@ handleEscapeForFindMode = ->
 handleDeleteForFindMode = ->
   if findModeQuery.rawQuery.length == 0
     HUD.hide()
-    performFindInPlace()
     false
   else
     updateQueryForFindMode findModeQuery.rawQuery.substring(0, findModeQuery.rawQuery.length - 1)
@@ -990,7 +989,7 @@ findModeRestoreSelection = (range = findModeInitialRange) ->
 window.enterFindMode = ->
   # Save the selection, so performFindInPlace can restore it.
   findModeSaveSelection()
-  findModeQuery = { rawQuery: "" }
+  findModeQuery = rawQuery: ""
   findMode = new FindMode()
   HUD.show "/"
   findMode

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -135,7 +135,6 @@ window.initializeModes = ->
 
   # Install the permanent modes.  The permanently-installed insert mode tracks focus/blur events, and
   # activates/deactivates itself accordingly.
-  new BadgeMode
   new NormalMode
   new PassKeysMode
   new InsertMode permanent: true
@@ -391,7 +390,6 @@ extend window,
         constructor: ->
           super
             name: "focus-selector"
-            badge: "?"
             exitOnClick: true
             keydown: (event) =>
               if event.keyCode == KeyboardUtils.keyCodes.tab
@@ -729,7 +727,6 @@ class FindMode extends Mode
     @partialQuery = ""
     super
       name: "find"
-      badge: "/"
       exitOnEscape: true
       exitOnClick: true
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -1103,7 +1103,7 @@ HUD =
     clearInterval(HUD._tweenId)
     if immediate
       HUD.displayElement().style.display = "none" unless updateIndicator
-      handlerStack.bubbleEvent "indicator" if updateIndicator
+      Mode.setIndicator() if updateIndicator
     else
       HUD._tweenId = Tween.fade HUD.displayElement(), 0, 150, -> HUD.hide true, updateIndicator
 

--- a/lib/handler_stack.coffee
+++ b/lib/handler_stack.coffee
@@ -84,10 +84,8 @@ class HandlerStack
 
   # Debugging.
   logResult: (eventNumber, type, event, handler, result) ->
-    # FIXME(smblott).  Badge updating is too noisy, so we filter it out.  However, we do need to look at how
-    # many badge update events are happening.  It seems to be more than necessary. We also filter out
-    # registerKeyQueue as unnecessarily noisy and not particularly helpful.
-    return if type in [ "updateBadge", "registerKeyQueue" ]
+    # Key queue events aren't usually useful for debugging, so we filter them out.
+    return if type in [ "registerKeyQueue" ]
     label =
       switch result
         when @stopBubblingAndTrue then "stop/true"

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -495,10 +495,6 @@ context "PostFindMode",
     testContent = "<input type='text' id='first'/>"
     document.getElementById("test-div").innerHTML = testContent
     document.getElementById("first").focus()
-    # For these tests, we need to push GrabBackFocus out of the way.  When it exits, it updates the badge,
-    # which interferes with event suppression within insert mode.  This cannot happen in normal operation,
-    # because GrabBackFocus exits on the first keydown.
-    Mode.top().exit()
     @postFindMode = new PostFindMode
 
   tearDown ->
@@ -526,56 +522,4 @@ context "PostFindMode",
     sendKeyboardEvent "a"
     sendKeyboardEvent "escape"
     assert.isTrue @postFindMode.modeIsActive
-
-context "Mode badges",
-  setup ->
-    initializeModeState()
-    testContent = "<input type='text' id='first'/>"
-    document.getElementById("test-div").innerHTML = testContent
-
-  tearDown ->
-    document.getElementById("test-div").innerHTML = ""
-
-  should "have no badge in normal mode", ->
-    Mode.updateBadge()
-    assert.isTrue chromeMessages[0].badge == ""
-
-  should "have an I badge in insert mode by focus", ->
-    document.getElementById("first").focus()
-    # Focus triggers an event in the handler stack, so we check element "1", here.
-    assert.isTrue chromeMessages[1].badge == "I"
-
-  should "have no badge after leaving insert mode by focus", ->
-    document.getElementById("first").focus()
-    document.getElementById("first").blur()
-    assert.isTrue chromeMessages[0].badge == ""
-
-  should "have an I badge in global insert mode", ->
-    new InsertMode global: true
-    assert.isTrue chromeMessages[0].badge == "I"
-
-  should "have no badge after leaving global insert mode", ->
-    mode = new InsertMode global: true
-    mode.exit()
-    assert.isTrue chromeMessages[0].badge == ""
-
-  should "have a ? badge in PostFindMode (immediately)", ->
-    document.getElementById("first").focus()
-    new PostFindMode
-    assert.isTrue chromeMessages[0].badge == "?"
-
-  should "have no badge in PostFindMode (subsequently)", ->
-    document.getElementById("first").focus()
-    new PostFindMode
-    sendKeyboardEvent "a"
-    assert.isTrue chromeMessages[0].badge == ""
-
-  should "have no badge when disabled", ->
-    handlerStack.bubbleEvent "registerStateChange",
-      enabled: false
-      passKeys: ""
-
-    document.getElementById("first").focus()
-    # Focus triggers an event in the handler stack, so we check element "1", here.
-    assert.isTrue chromeMessages[1].badge == ""
 


### PR DESCRIPTION
After much discussion and trying-it-out-in-the-wild, it looks like we're going back to using the HUD for mode indications.  This PR begins that process (and fixes #1569 in passing).