### PR TITLE
Add mainFrame command to select main/top window

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Navigating the current page:
     yy      copy the current url to the clipboard
     yf      copy a link url to the clipboard
     gf      cycle forward to the next frame
+    gF      focus the main/top frame
 
 Navigating to new pages:
 

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -129,6 +129,7 @@ Commands =
       "goPrevious",
       "goNext",
       "nextFrame",
+      "mainFrame",
       "Marks.activateCreateMode",
       "Vomnibar.activateEditUrl",
       "Vomnibar.activateEditUrlInNewTab",
@@ -255,6 +256,7 @@ defaultKeyMappings =
   "gE": "Vomnibar.activateEditUrlInNewTab"
 
   "gf": "nextFrame"
+  "gF": "mainFrame"
 
   "m": "Marks.activateCreateMode"
   "`": "Marks.activateGotoMode"
@@ -350,6 +352,7 @@ commandDescriptions =
   "Vomnibar.activateEditUrlInNewTab": ["Edit the current URL and open in a new tab", { noRepeat: true }]
 
   nextFrame: ["Cycle forward to the next frame on the page", { background: true, passCountToFunction: true }]
+  mainFrame: ["Select the tab's main/top frame", { background: true, noRepeat: true }]
 
   "Marks.activateCreateMode": ["Create a new mark", { noRepeat: true }]
   "Marks.activateGotoMode": ["Go to a mark", { noRepeat: true }]

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -623,7 +623,6 @@ sendRequestHandlers =
   unregisterFrame: unregisterFrame
   frameFocused: handleFrameFocused
   nextFrame: (request) -> BackgroundCommands.nextFrame 1, request.frameId
-  mainFrame: BackgroundCommands.mainFrame
   updateScrollPosition: handleUpdateScrollPosition
   copyToClipboard: copyToClipboard
   pasteFromClipboard: pasteFromClipboard

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -298,6 +298,11 @@ BackgroundCommands =
       count = (count + Math.max 0, frameIdsForTab[tab.id].indexOf frameId) % frames.length
       frames = frameIdsForTab[tab.id] = [frames[count..]..., frames[0...count]...]
       chrome.tabs.sendMessage(tab.id, { name: "focusFrame", frameId: frames[0], highlight: true }))
+  mainFrame: ->
+    chrome.tabs.getSelected null, (tab) ->
+      # Messages sent with a frameId of zero in the options argument (as below) are delivered only to the
+      # tab's main frame.
+      chrome.tabs.sendMessage tab.id, { name: "focusFrame", frameId: 0, highlight: true }, frameId: 0
 
   closeTabsOnLeft: -> removeTabsRelative "before"
   closeTabsOnRight: -> removeTabsRelative "after"
@@ -618,6 +623,7 @@ sendRequestHandlers =
   unregisterFrame: unregisterFrame
   frameFocused: handleFrameFocused
   nextFrame: (request) -> BackgroundCommands.nextFrame 1, request.frameId
+  mainFrame: BackgroundCommands.mainFrame
   updateScrollPosition: handleUpdateScrollPosition
   copyToClipboard: copyToClipboard
   pasteFromClipboard: pasteFromClipboard

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -92,9 +92,9 @@ settings =
     @eventListeners[eventName].push(callback)
 
 #
-# Give this frame a unique id.
+# Give this frame a unique (non-zero) id.
 #
-frameId = Math.floor(Math.random()*999999999)
+frameId = 1 + Math.floor(Math.random()*999999999)
 
 # If an input grabs the focus before the user has interacted with the page, then grab it back (if the
 # grabBackFocus option is set).
@@ -167,7 +167,7 @@ initializePreDomReady = ->
   requestHandlers =
     showHUDforDuration: (request) -> HUD.showForDuration request.text, request.duration
     toggleHelpDialog: (request) -> toggleHelpDialog(request.dialogHtml, request.frameId)
-    focusFrame: (request) -> if (frameId == request.frameId) then focusThisFrame(request.highlight)
+    focusFrame: (request) -> if (request.frameId in [ frameId, 0 ]) then focusThisFrame(request.highlight)
     refreshCompletionKeys: refreshCompletionKeys
     getScrollPosition: -> scrollX: window.scrollX, scrollY: window.scrollY
     setScrollPosition: (request) -> setScrollPosition request.scrollX, request.scrollY
@@ -180,7 +180,7 @@ initializePreDomReady = ->
     # In the options page, we will receive requests from both content and background scripts. ignore those
     # from the former.
     return if sender.tab and not sender.tab.url.startsWith 'chrome-extension://'
-    return unless isEnabledForUrl
+    return unless isEnabledForUrl or (request.frameId == 0 and request.name in [ "focusFrame" ])
     # These requests are delivered to the options page, but there are no handlers there.
     return if request.handler in [ "registerFrame", "frameFocused", "unregisterFrame" ]
     sendResponse requestHandlers[request.name](request, sender)


### PR DESCRIPTION
With hat tip to @mrmr1993, this implements a new `mainFrame` command (default binding `gF`) which focuses the current tab's main frame.

Why is this needed?  Go [here](http://www.thejournal.ie/bus-eireann-transport-unions-days-action-strike-2060286-Apr2015/?utm_source=shortlink), type `gf`.  Now, try to get back to the main frame without using the mouse.

(Notwithstanding @int3's comment in #426, this seems to work well on GMail and Google's Inbox.)

(It would be better if we could achieve this without a new command.)

Fixes #426.