### PR TITLE
Update exclusion rules when the URL is changed by history.pushState/popState or its hash changes

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -89,12 +89,11 @@ getCurrentTabUrl = (request, sender) -> sender.tab.url
 # Checks the user's preferences in local storage to determine if Vimium is enabled for the given URL, and
 # whether any keys should be passed through to the underlying page.
 #
-root.isEnabledForUrl = isEnabledForUrl = (request, sender) ->
+root.isEnabledForUrl = isEnabledForUrl = (request) ->
   rule = Exclusions.getRule(request.url)
   {
     isEnabledForUrl: not rule or rule.passKeys
     passKeys: rule?.passKeys or ""
-    incognito: sender.tab.incognito
   }
 
 # Retrieves the help dialog HTML template from a file, and populates it with the latest keybindings.

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -96,6 +96,15 @@ root.isEnabledForUrl = isEnabledForUrl = (request) ->
     passKeys: rule?.passKeys or ""
   }
 
+isEnabledForUpdatedUrl = (details) ->
+  message = isEnabledForUrl details
+  message.name = "updateEnabledForUrlState"
+  chrome.tabs.sendMessage details.tabId, message, {frameId: details.frameId}
+
+# Re-check whether Vimium is enabled for a frame when the url changes without a reload.
+chrome.webNavigation.onHistoryStateUpdated.addListener isEnabledForUpdatedUrl # history.pushState.
+chrome.webNavigation.onReferenceFragmentUpdated.addListener isEnabledForUpdatedUrl # Hash changed.
+
 # Retrieves the help dialog HTML template from a file, and populates it with the latest keybindings.
 # This is called by options.coffee.
 root.helpDialogHtml = (showUnboundCommands, showCommandNames, customTitle) ->

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -12,7 +12,7 @@ findModeInitialRange = null
 isShowingHelpDialog = false
 keyPort = null
 isEnabledForUrl = true
-isIncognitoMode = false
+isIncognitoMode = chrome.extension.inIncognitoContext
 passKeys = null
 keyQueue = null
 # The user's operating system.
@@ -551,9 +551,7 @@ checkIfEnabledForUrl = ->
   url = window.location.toString()
 
   chrome.runtime.sendMessage { handler: "isEnabledForUrl", url: url }, (response) ->
-    isEnabledForUrl = response.isEnabledForUrl
-    passKeys = response.passKeys
-    isIncognitoMode = response.incognito
+    {isEnabledForUrl, passKeys} = response
     if isEnabledForUrl
       initializeWhenEnabled()
     else if HUD.isReady()

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -200,7 +200,7 @@ installListener = (element, event, callback) ->
 # Run this as early as possible, so the page can't register any event handlers before us.
 #
 installedListeners = false
-window.initializeWhenEnabled = ->
+window.initializeWithState = ->
   unless installedListeners
     # Key event handlers fire on window before they do on document. Prefer window for key events so the page
     # can't set handlers to grab the keys before us.
@@ -555,9 +555,8 @@ checkIfEnabledForUrl = ->
 
 updateEnabledForUrlState = (response) ->
   {isEnabledForUrl, passKeys} = response
-  if isEnabledForUrl
-    initializeWhenEnabled()
-  else if HUD.isReady()
+  initializeWithState()
+  if HUD.isReady() and not isEnabledForUrl
     # Quickly hide any HUD we might already be showing, e.g. if we entered insert mode on page load.
     HUD.hide()
   handlerStack.bubbleEvent "registerStateChange",

--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": 2,
   "name": "Vimium",
   "version": "1.49",
+  "minimum_chrome_version": "41",
   "description": "The Hacker's Browser. Vimium provides keyboard shortcuts for navigation and control in the spirit of Vim.",
   "icons": {  "16": "icons/icon16.png",
               "48": "icons/icon48.png",

--- a/manifest.json
+++ b/manifest.json
@@ -28,6 +28,7 @@
     "storage",
     "sessions",
     "notifications",
+    "webNavigation",
     "<all_urls>"
   ],
   "content_scripts": [

--- a/tests/dom_tests/chrome.coffee
+++ b/tests/dom_tests/chrome.coffee
@@ -29,3 +29,5 @@ root.chrome =
       set: ->
     onChanged:
       addListener: ->
+  extension:
+    inIncognitoContext: false

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -1,6 +1,6 @@
 
 # Install frontend event handlers.
-initializeWhenEnabled()
+initializeWithState()
 
 installListener = (element, event, callback) ->
   element.addEventListener event, (-> callback.apply(this, arguments)), true

--- a/tests/unit_tests/exclusion_test.coffee
+++ b/tests/unit_tests/exclusion_test.coffee
@@ -21,10 +21,6 @@ extend(global, require "../../background_scripts/exclusions.js")
 extend(global, require "../../background_scripts/commands.js")
 extend(global, require "../../background_scripts/main.js")
 
-dummyTab =
-  tab:
-    incognito: false
-
 # These tests cover only the most basic aspects of excluded URLs and passKeys.
 #
 context "Excluded URLs and pass keys",
@@ -40,22 +36,22 @@ context "Excluded URLs and pass keys",
       ])
 
   should "be disabled for excluded sites", ->
-    rule = isEnabledForUrl({ url: 'http://mail.google.com/calendar/page' }, dummyTab)
+    rule = isEnabledForUrl({ url: 'http://mail.google.com/calendar/page' })
     assert.isFalse rule.isEnabledForUrl
     assert.isFalse rule.passKeys
 
   should "be disabled for excluded sites, one exclusion", ->
-    rule = isEnabledForUrl({ url: 'http://www.bbc.com/calendar/page' }, dummyTab)
+    rule = isEnabledForUrl({ url: 'http://www.bbc.com/calendar/page' })
     assert.isFalse rule.isEnabledForUrl
     assert.isFalse rule.passKeys
 
   should "be enabled, but with pass keys", ->
-    rule = isEnabledForUrl({ url: 'https://www.facebook.com/something' }, dummyTab)
+    rule = isEnabledForUrl({ url: 'https://www.facebook.com/something' })
     assert.isTrue rule.isEnabledForUrl
     assert.equal rule.passKeys, 'abcd'
 
   should "be enabled", ->
-    rule = isEnabledForUrl({ url: 'http://www.twitter.com/pages' }, dummyTab)
+    rule = isEnabledForUrl({ url: 'http://www.twitter.com/pages' })
     assert.isTrue rule.isEnabledForUrl
     assert.isFalse rule.passKeys
 

--- a/tests/unit_tests/test_chrome_stubs.coffee
+++ b/tests/unit_tests/test_chrome_stubs.coffee
@@ -38,6 +38,12 @@ exports.chrome =
       addListener: () -> true
     query: () -> true
 
+  webNavigation:
+    onHistoryStateUpdated:
+      addListener: () ->
+    onReferenceFragmentUpdated:
+      addListener: () ->
+
   windows:
     onRemoved:
       addListener: () -> true


### PR DESCRIPTION
This PR fixes #1578, using `chrome.webRequest` to check exclusion rules for frames that changed URL without a page load.

Side effects:
* we need the `webRequest` permission
* introduced `minimum_chrome_version: 41` so we know we can message frames individually
  - current version is 42
* event listeners are always registered, even when Vimium is disabled
  - justification in 6446cf0, the relevant commit