### PR TITLE
Simplify front-end settings logic.

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -204,12 +204,16 @@ selectSpecificTab = (request) ->
 #
 # Used by the content scripts to get settings from the local storage.
 #
-handleSettings = (args, port) ->
-  if (args.operation == "get")
-    value = Settings.get(args.key)
-    port.postMessage({ key: args.key, value: value })
-  else # operation == "set"
-    Settings.set(args.key, args.value)
+handleSettings = (request, port) ->
+  switch request.operation
+    when "get" # Get a single settings value.
+      port.postMessage key: request.key, value: Settings.get request.key
+    when "set" # Set a single settings value.
+      Settings.set request.key, request.value
+    when "fetch" # Fetch multiple settings values.
+      values = request.values
+      values[key] = Settings.get key for own key of values
+      port.postMessage { values }
 
 refreshCompleter = (request) -> completers[request.name].refresh()
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -91,7 +91,7 @@ settings =
     @values = response.values if response.values?
     @values[response.key] = response.value if response.key? and response.value?
     @isLoaded = true
-    listener() while listener = @eventListeners["load"].pop()
+    listener() while listener = @eventListeners.load?.pop()
 
   addEventListener: (eventName, callback) ->
     (@eventListeners[eventName] ||= []).push callback

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -94,7 +94,7 @@ settings =
     listener() while listener = @eventListeners["load"].pop()
 
   addEventListener: (eventName, callback) ->
-    (@eventListeners[eventName] ||= []).push(callback)
+    (@eventListeners[eventName] ||= []).push callback
 
 #
 # Give this frame a unique (non-zero) id.


### PR DESCRIPTION
A couple of front-end settings-logic changes...

- Simplify the logic.
- Send a single request for all required settings.
- Eliminate the need to count messages (which feels fragile).

(This probably isn't the last word in how settings are handled, but it's better than the status quo.  We replace 24 messages *every time a frame receives the focus* with just two.)