### PR TITLE
Ensure that the Vomnibar iframe background is transparent

### DIFF
--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -275,7 +275,7 @@ body.vimiumFindMode ::selection {
 /* Vomnibar Frame CSS */
 
 iframe.vomnibarFrame {
-  background-color: transparent;
+  background-color: transparent !important;
   padding: 0px;
   overflow: hidden;
 


### PR DESCRIPTION
Some extensions (eg. Hacker Vision) override the background colour of iframes to make the screen dark, even when the frame is already set to transparent. This PR gives our rule higher priority, so that the frame is still rendered as transparent, and doesn't obscure the content beneath.

This fixes #1583.