### PR TITLE
Always cancel scrolling after additional (non-repeat) keydowns

### DIFF
--- a/content_scripts/scroller.coffee
+++ b/content_scripts/scroller.coffee
@@ -132,6 +132,7 @@ CoreScroller =
         handlerStack.alwaysContinueBubbling =>
           @keyIsDown = true
           @lastEvent = event
+          @time += 1 unless event.repeat
       keyup: =>
         handlerStack.alwaysContinueBubbling =>
           @keyIsDown = false


### PR DESCRIPTION
This fixes #1596.