### PR TITLE
Do not grab back focus if Vimium is disabled.

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -149,7 +149,6 @@ window.initializeModes = ->
   new NormalMode
   new PassKeysMode
   new InsertMode permanent: true
-  new GrabBackFocus
   Scroller.init settings
 
 #
@@ -159,6 +158,8 @@ initializePreDomReady = ->
   settings.addEventListener("load", LinkHints.init.bind(LinkHints))
   settings.load()
 
+  # Note. checkIfEnabledForUrl() must come after initializeModes(), here, because checkIfEnabledForUrl() may
+  # install an additional mode (GrabBackFocus).
   initializeModes()
   checkIfEnabledForUrl()
   refreshCompletionKeys()
@@ -229,7 +230,9 @@ window.installListeners = ->
       do (type) -> installListener window, type, (event) -> handlerStack.bubbleEvent type, event
     installListener document, "DOMActivate", (event) -> handlerStack.bubbleEvent 'DOMActivate', event
     installedListeners = true
+    # Other one-time initialization operations.
     FindModeHistory.init()
+    new GrabBackFocus if isEnabledForUrl
 
 #
 # Whenever we get the focus:


### PR DESCRIPTION
Thinking about #1588, I realised that we should only be grabbing back the focus on pages where Vimium is enabled.