### PR TITLE
Use a shadowDom for the Vomnibar (and all UIComponents)

### DIFF
--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -5,11 +5,16 @@ class UIComponent
   options: null
 
   constructor: (iframeUrl, className, @handleMessage) ->
-    styleSheet = document.createElement "link"
-    extend styleSheet,
-      rel: "stylesheet"
-      type: "text/css"
-      href: chrome.runtime.getURL "content_scripts/vimium.css"
+    styleSheet = document.createElement "style"
+    styleSheet.type = "text/css"
+    # Default to everything hidden while the stylesheet loads.
+    styleSheet.innerHTML = "* {display: none !important;}"
+    # Load stylesheet.
+    xhr = new XMLHttpRequest()
+    xhr.onload = (e) -> styleSheet.innerHTML = xhr.responseText
+    xhr.open "GET", chrome.runtime.getURL("content_scripts/vimium.css"), true
+    xhr.send()
+
     @iframeElement = document.createElement "iframe"
     extend @iframeElement,
       className: className

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -5,12 +5,24 @@ class UIComponent
   options: null
 
   constructor: (iframeUrl, className, @handleMessage) ->
+    styleSheet = document.createElement "link"
+    extend styleSheet,
+      rel: "stylesheet"
+      type: "text/css"
+      href: chrome.runtime.getURL "content_scripts/vimium.css"
     @iframeElement = document.createElement "iframe"
-    @iframeElement.className = className
-    @iframeElement.seamless = "seamless"
-    @iframeElement.src = chrome.runtime.getURL iframeUrl
+    extend @iframeElement,
+      className: className
+      seamless: "seamless"
+      src: chrome.runtime.getURL iframeUrl
     @iframeElement.addEventListener "load", => @openPort()
-    document.documentElement.appendChild @iframeElement
+    shadowWrapper = document.createElement "div"
+    # PhantomJS doesn't support createShadowRoot, so guard against its non-existance.
+    shadowDOM = shadowWrapper.createShadowRoot?() ? shadowWrapper
+    shadowDOM.appendChild styleSheet
+    shadowDOM.appendChild @iframeElement
+    document.documentElement.appendChild shadowWrapper
+
     @showing = true # The iframe is visible now.
     # Hide the iframe, but don't interfere with the focus.
     @hide false

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -279,6 +279,7 @@ iframe.vomnibarFrame {
   padding: 0px;
   overflow: hidden;
 
+  display: block;
   position: fixed;
   width: calc(80% + 20px); /* same adjustment as in pages/vomnibar.coffee */
   min-width: 400px;
@@ -303,11 +304,11 @@ div#vimiumFlash {
 
 /* UIComponent CSS */
 iframe.vimiumUIComponentHidden {
-  display: none !important;
+  display: none;
 }
 
 iframe.vimiumUIComponentVisible {
-  display: block !important;
+  display: block;
 }
 
 iframe.vimiumUIComponentReactivated {

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -275,7 +275,7 @@ body.vimiumFindMode ::selection {
 /* Vomnibar Frame CSS */
 
 iframe.vomnibarFrame {
-  background-color: transparent !important;
+  background-color: transparent;
   padding: 0px;
   overflow: hidden;
 

--- a/manifest.json
+++ b/manifest.json
@@ -68,6 +68,7 @@
     "default_popup": "pages/popup.html"
   },
   "web_accessible_resources": [
-    "pages/vomnibar.html"
+    "pages/vomnibar.html",
+    "content_scripts/vimium.css"
   ]
 }


### PR DESCRIPTION
This wraps `UIComponent.iframeElement` in a shadow DOM, so that page CSS doesn't override our own.

@smblott-github suggest this instead of #1613?