### PR TITLE
Fix for #1554.

### DIFF
--- a/tests/dom_tests/dom_utils_test.coffee
+++ b/tests/dom_tests/dom_utils_test.coffee
@@ -73,6 +73,15 @@ context "Check visibility",
     """
     assert.equal null, (DomUtils.getVisibleClientRect (document.getElementById 'foo'), true)
 
+  should "detect font-size: 0; and display: inline; links when their children are display: inline", ->
+    # This test represents the minimal test case covering issue #1554.
+    document.getElementById("test-div").innerHTML = """
+    <a id='foo' style='display: inline; font-size: 0px;'>
+      <div style='display: inline; font-size: 16px;'>test</div>
+    </a>
+    """
+    assert.isTrue (DomUtils.getVisibleClientRect (document.getElementById 'foo'), true) != null
+
   should "detect links inside opacity:0 elements as visible", ->
     # XXX This is an expected failure. See issue #16.
     document.getElementById("test-div").innerHTML = """


### PR DESCRIPTION
Elements with `font-size: 0px; display: inline;` will declare a height of zero, even if a child with `display: inline;` and non-zero `font-size` contains text. This PR adds a work-around to deal with this case, fixing #1554.