### PR TITLE
Fix matching text for text link hints

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -64,8 +64,8 @@ LinkHints =
       # When using text filtering, we sort the elements such that we visit descendants before their ancestors.
       # This allows us to exclude the text used for matching descendants from that used for matching their
       # ancestors.
-      textLength = (el) -> el.element.textContent?.length ? 0
-      elements.sort (a,b) -> textLength(a) - textLength b
+      length = (el) -> el.element.innerHTML?.length ? 0
+      elements.sort (a,b) -> length(a) - length b
     hintMarkers = (@createMarkerFor(el) for el in elements)
     @getMarkerMatcher().fillInMarkers(hintMarkers)
 

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -65,7 +65,7 @@ LinkHints =
       # This allows us to exclude the text used for matching descendants from that used for matching their
       # ancestors.
       textLength = (el) -> el.element.textContent?.length ? 0
-      elements = elements.sort (a,b) -> textLength(a) - textLength b
+      elements.sort (a,b) -> textLength(a) - textLength b
     hintMarkers = (@createMarkerFor(el) for el in elements)
     @getMarkerMatcher().fillInMarkers(hintMarkers)
 

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -60,6 +60,12 @@ LinkHints =
     # For these modes, we filter out those elements which don't have an HREF (since there's nothing we can do
     # with them).
     elements = (el for el in elements when el.element.href?) if mode in [ COPY_LINK_URL, OPEN_INCOGNITO ]
+    if settings.get "filterLinkHints"
+      # When using text filtering, we sort the elements such that we visit descendants before their ancestors.
+      # This allows us to exclude the text used for matching descendants from that used for matching their
+      # ancestors.
+      textLength = (el) -> el.element.textContent?.length ? 0
+      elements = elements.sort (a,b) -> textLength(a) - textLength b
     hintMarkers = (@createMarkerFor(el) for el in elements)
     @getMarkerMatcher().fillInMarkers(hintMarkers)
 
@@ -238,8 +244,6 @@ LinkHints =
     # Remove rects from elements where another clickable element lies above it.
     nonOverlappingElements = []
     # Traverse the DOM from first to last, since later elements show above earlier elements.
-    # NOTE(smblott). filterHints.generateLinkText also assumes this order when generating the content text for
-    # each hint.  Specifically, we consider descendents before we consider their ancestors.
     visibleElements = visibleElements.reverse()
     while visibleElement = visibleElements.pop()
       rects = [visibleElement.rect]

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -228,9 +228,9 @@ context "Filtered link hints",
       hintMarkers = getHintMarkers()
       assert.equal "1", hintMarkers[0].textContent.toLowerCase()
       assert.equal "2", hintMarkers[1].textContent.toLowerCase()
-      assert.equal "3", hintMarkers[2].textContent.toLowerCase()
+      assert.equal "3: a label", hintMarkers[2].textContent.toLowerCase()
       assert.equal "4: a label", hintMarkers[3].textContent.toLowerCase()
-      assert.equal "5: a label", hintMarkers[4].textContent.toLowerCase()
+      assert.equal "5", hintMarkers[4].textContent.toLowerCase()
 
 context "Input focus",
 

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -156,6 +156,9 @@ context "Alphabetical link hints",
     assert.equal "", hintMarkers[0].style.display
 
 context "Filtered link hints",
+  # Note.  In all of these tests, the order of the elements returned by getHintMarkers() may be different from
+  # the order they are listed in the test HTML content.  This is because LinkHints.activateMode() sorts the
+  # elements.
 
   setup ->
     stub settings.values, "filterLinkHints", true
@@ -205,8 +208,8 @@ context "Filtered link hints",
     should "label the images", ->
       hintMarkers = getHintMarkers()
       assert.equal "1: alt text", hintMarkers[0].textContent.toLowerCase()
-      assert.equal "2: alt text", hintMarkers[1].textContent.toLowerCase()
-      assert.equal "3: some title", hintMarkers[2].textContent.toLowerCase()
+      assert.equal "2: some title", hintMarkers[1].textContent.toLowerCase()
+      assert.equal "3: alt text", hintMarkers[2].textContent.toLowerCase()
       assert.equal "4", hintMarkers[3].textContent.toLowerCase()
 
   context "Input hints",


### PR DESCRIPTION
This ensures that the texts used for filtering link hints are generated by visiting descendants before their ancestors.  There's an explanation of what's intended in this commit: b7535a604954b5873d825eb66bfecd08f1f2c99b.  However, it turns out we actually need to sort the nodes into the intended order.  That's this PR.

To see what's going on:
- enable `￼ Use the link's name and numbers for link-hint filtering`
- visit [this page](http://www.reddit.com/r/peloton/comments/348rxh/race_thread_2015_tour_of_romandie_stage_2/)
- try to select `Profile Map` by typing the text.

In `master` currently, we can't -- because we're visiting the elements in the wrong order.  We end up instead picking some (pretty useless) ancestor.