### PR TITLE
Make GrabBackFocus work for javascript page transitions from links

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -135,8 +135,9 @@ class GrabBackFocus extends Mode
 
 # Pages can load new content dynamically and change the displayed URL using history.pushState. Since this can
 # often be indistinguishable from an actual new page load for the user, we should also re-start GrabBackFocus
-# for these as well.
+# for these as well. This fixes issue #1622.
 handlerStack.push
+  _name: "GrabBackFocus-pushState-monitor"
   click: (event) ->
     target = event.target
     while target

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -139,6 +139,9 @@ class GrabBackFocus extends Mode
 handlerStack.push
   _name: "GrabBackFocus-pushState-monitor"
   click: (event) ->
+    # If a focusable element is focused, the user must have clicked on it. Retain focus and bail.
+    return true if DomUtils.isFocusable document.activeElement
+
     target = event.target
     while target
       # Often, a link which triggers a content load and url change with javascript will also have the new


### PR DESCRIPTION
Pages can load new content dynamically and change the displayed URL using `history.pushState`. Since this can often be indistinguishable from an actual new page load for the user, we should also re-start `GrabBackFocus` for these as well.

This PR does this, by restarting `GrabBackFocus` mode whenever a link is clicked which points to a URL that could be moved to via a `history.pushState`. The expectation is that such a link will either navigate to the URL as normal, or the navigation will br simulated in Javascript.

This fixes #1588.