### PR TITLE
Stop caching Vomnibar completers so we don't handle stale responses

### DIFF
--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -6,12 +6,8 @@
 Vomnibar =
   vomnibarUI: null # the dialog instance for this window
   getUI: -> @vomnibarUI
-  completers: {}
 
-  getCompleter: (name) ->
-    if (!(name of @completers))
-      @completers[name] = new BackgroundCompleter(name)
-    @completers[name]
+  getCompleter: (name) -> new BackgroundCompleter(name)
 
   #
   # Activate the Vomnibox.


### PR DESCRIPTION
With cached completers, Vomnibar completions from the background page for an old instance of the Vomnibar can still be received by a new instance. For example, typing `bkeyword<enter>b`quickly can bring up completions for `keyword` in the new instance. This is easy to reproduce on slower computers.

This PR removes the cache of completers from the Vomnibar, so every Vomnibar instance opens a new port, fixing the issue.