### PR TITLE
Remove background page logging.

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -506,12 +506,9 @@ splitKeyQueue = (queue) ->
 handleKeyDown = (request, port) ->
   key = request.keyChar
   if (key == "<ESC>")
-    console.log("clearing keyQueue")
     keyQueue = ""
   else
-    console.log("checking keyQueue: [", keyQueue + key, "]")
     keyQueue = checkKeyQueue(keyQueue + key, port.sender.tab.id, request.frameId)
-    console.log("new KeyQueue: " + keyQueue)
   # Tell the content script whether there are keys in the queue.
   # FIXME: There is a race condition here.  The behaviour in the content script depends upon whether this message gets
   # back there before or after the next keystroke.


### PR DESCRIPTION
Why do we still have this background page logging?  We should remove it.

![snapshot](https://cloud.githubusercontent.com/assets/2641335/7430046/f265960e-f004-11e4-80a3-e579444d76c9.png)

It rarely serves a purpose.