### PR TITLE
Search engine completion [Version 2]

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -231,8 +231,8 @@ class DomainCompleter
   #     If `referenceCount` goes to zero, the domain entry can and should be deleted.
   domains: null
 
-  filter: ({ queryTerms }, onComplete) ->
-    return onComplete([]) unless queryTerms.length == 1
+  filter: ({ queryTerms, query }, onComplete) ->
+    return onComplete [] unless queryTerms.length == 1 and not /\s$/.test query
     if @domains
       @performSearch(queryTerms, onComplete)
     else

--- a/background_scripts/completion_search.coffee
+++ b/background_scripts/completion_search.coffee
@@ -74,7 +74,7 @@ CompletionSearch =
       reusePreviousSuggestions = do =>
         # Verify that the previous query is a prefix of the current query.
         return false unless 0 == query.indexOf @mostRecentQuery.toLowerCase()
-        # Ensure that every previous suggestion contains the text of the new query.
+        # Verify that every previous suggestion contains the text of the new query.
         for suggestion in (@mostRecentSuggestions.map (s) -> s.toLowerCase())
           return false unless 0 <= suggestion.indexOf query
         # Ok. Re-use the suggestion.

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -135,8 +135,13 @@ class VomnibarUI
     completions = @completions.filter (completion) ->
       completion.selectCommonMatches? and completion.selectCommonMatches
 
+    # Bail on leading whitespace or on redundant whitespace.  This provides users with a way to force this
+    # feature off.
+    value = @input.value
+    return if /^\s/.test(value) or /\s\s/.test value
+
     # Fetch the query and the suggestion texts.
-    query = @input.value.ltrim().split(/\s+/).join(" ").toLowerCase()
+    query = value.ltrim().split(/\s+/).join(" ").toLowerCase()
     suggestions = completions.map (completion) -> completion.title
 
     # Some completion engines add text at the start of the suggestion; for example, Bing takes "they might be"

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -411,8 +411,7 @@ class BackgroundCompleter
 
   filter: (query, @mostRecentCallback) ->
     queryTerms = query.trim().split(/\s+/).filter (s) -> 0 < s.length
-    cacheKey = queryTerms.join " "
-    cacheKey += " " if queryTerms.length == 1 and queryTerms[0] in @keywords and /\s$/.test query
+    cacheKey = query.ltrim().split(/\s+/).join " "
 
     if cacheKey of @cache
       console.log "cache hit:", "-#{cacheKey}-" if @debug

--- a/pages/vomnibar.css
+++ b/pages/vomnibar.css
@@ -139,5 +139,9 @@
   /* background-color: #F1F1F1; */
 
   /* This is the light blue color of the vomnibar selected item. */
-  background-color: #BBCEE9;
+  /* background-color: #BBCEE9; */
+
+  /* This is a considerably lighter blue than Vimium blue, which seems softer
+   * on the eye for this purpose. */
+  background-color: #E6EEFB;
 }


### PR DESCRIPTION
This is a more worked out version of #1632.

Here are some things which are true:

- Completion for Google, Bing, Amazon, DuckDuckGo, Youtube, Wikipedia and Amazon.  Here are a couple of example completion-engine specifications:

```Coffeescript
class Google extends GoogleXMLRegexpEngine
  # Example search URL: http://www.google.com/search?q=%s
  constructor: ->
    super [
      # We match the major English-speaking TLDs.
      new RegExp "^https?://[a-z]+\.google\.(com|ie|co.uk|ca|com.au)/"
      ]

  getUrl: (queryTerms) ->
    "http://suggestqueries.google.com/complete/search?ss_protocol=legace&client=toolbar&q=#{Utils.createSearchQuery queryTerms}"

class Wikipedia extends RegexpEngine
  # Example search URL: http://www.wikipedia.org/w/index.php?title=Special:Search&search=%s
  constructor: ->
    super [ new RegExp "^https?://[a-z]+\.wikipedia\.org/" ]

  getUrl: (queryTerms) ->
    "https://en.wikipedia.org/w/api.php?action=opensearch&format=json&search=#{Utils.createSearchQuery queryTerms}"

  parse: (xhr) ->
    JSON.parse(xhr.responseText)[1]
```

- Users do not and cannot specify completion engines.  Hopefully devs will help out by submitting engines via PRs.  There's almost no cost to adding a new completion engine.

- For custom-search engine searches, we use a completion engine associated with the search engine's URL.  For other queries, we use a completion engine associated with the default search engine.

- There's no explicit mapping from search engine to completer.  Each completer just knows what kind of search URL it can complete, and if it sees such a matching URL, it goes ahead and completes it.  Exactly one completion engine is chosen for each query.

- Tabbing into a completion suggestion populates the vomnibar input.  Tabbing out restores the input's previous contents (unless the user has typed more stuff).

- ~~The top suggestion always appears at the top of the list.  So things like `who directed st<TAB>` completes to `who directed star wars`. `bridges of<TAB>` gives you `bridges of Madison County`.~~ Removed.  This does not work well in practice.

- Completion searches are cached.  We also never launch duplicate identical searches.

- Completion lookups can fail for a variety of reasons.  Fingers crossed, we should fail safe.  Code which could fail due to external factors is protected with `try`/`catch`.

- There's a short delay (currently 200ms) before launching a completion search (in case the user is still typing).  We deliver all of the other completions immediately, then post completion suggestions a couple of hundred milliseconds later.

- I'll not describe the scoring here.  It will probably need tweaking, though.

(The tests fail because there is some hard-wired debugging code still in `settings.coffee`.)