### PR TITLE
Guard against missing sender.

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -385,7 +385,7 @@ setIcon = (request, sender) ->
   chrome.browserAction.setIcon tabId: sender.tab.id, path: path
 
 handleUpdateScrollPosition = (request, sender) ->
-  # See note re. sender.tab at unregisterFrame.
+  # See note regarding sender.tab at unregisterFrame.
   updateScrollPosition sender.tab, request.scrollX, request.scrollY if sender.tab?
 
 updateScrollPosition = (tab, scrollX, scrollY) ->
@@ -678,6 +678,13 @@ chrome.tabs.onRemoved.addListener (tabId) ->
           return if window.incognito
         # There are no remaining incognito-mode tabs, and findModeRawQueryListIncognito is set.
         chrome.storage.local.remove "findModeRawQueryListIncognito"
+
+# Tidy up tab caches when tabs are removed.  We cannot rely on unregisterFrame because Chrome does not always
+# provide sender.tab there.
+# NOTE(smblott) (2015-05-05) This may break restoreTab on legacy Chrome versions, but we'll be moving to
+# chrome.sessions support only soon anyway.
+chrome.tabs.onRemoved.addListener (tabId) ->
+  delete cache[tabId] for cache in [ frameIdsForTab, urlForTab, tabInfoMap ]
 
 # Convenience function for development use.
 window.runTests = -> open(chrome.runtime.getURL('tests/dom_tests/dom_tests.html'))

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -602,7 +602,8 @@ unregisterFrame = (request, sender) ->
   # When a tab is closing, Chrome sometimes passes messages without sender.tab.  Therefore, we guard against
   # this.
   tabId = sender.tab?.id
-  if tabId? and frameIdsForTab[tabId]?
+  return unless tabId?
+  if frameIdsForTab[tabId]?
     if request.tab_is_closing
       updateOpenTabs sender.tab, true
     else

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -599,9 +599,8 @@ registerFrame = (request, sender) ->
   (frameIdsForTab[sender.tab.id] ?= []).push request.frameId
 
 unregisterFrame = (request, sender) ->
-  # When a tab is closing, Chrome sometimes passes on messages without sender.tab.  Therefore, we guard
-  # against this.
-  # FIXME(smblott) Consequently, we have a space leak in frameIdsForTab, tabInfoMap and urlForTab.
+  # When a tab is closing, Chrome sometimes passes messages without sender.tab.  Therefore, we guard against
+  # this.
   tabId = sender.tab?.id
   if tabId? and frameIdsForTab[tabId]?
     if request.tab_is_closing


### PR DESCRIPTION
When a tab is closing, Chrome sometimes doesn't set `sender.tab`.  To reproduce, navigate (by entering the URLs directly) between` www.bing.com` and `www.google.com`.

Fixes #1630.  Partially.  ~~We still have a space leak.~~