### PR TITLE
Disable UIComponent for XML documents

### DIFF
--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -6,6 +6,14 @@ class UIComponent
 
   constructor: (iframeUrl, className, @handleMessage) ->
     styleSheet = document.createElement "style"
+
+    # If this is an XML document, nothing we do here works:
+    # * <style> elements show their contents inline,
+    # * <iframe> elements don't load any content,
+    # * document.createElement generates elements that have style == null and ignore CSS.
+    # We bail here if this is the case so we're polluting the DOM to no or negative effect.
+    return unless styleSheet.style
+
     styleSheet.type = "text/css"
     # Default to everything hidden while the stylesheet loads.
     styleSheet.innerHTML = "* {display: none !important;}"


### PR DESCRIPTION
If the page is an XML document, nothing we do works:
* `<style>` elements show their contents inline,
* `<iframe>` elements don't load any content,
* `document.createElement` generates elements that
  - have `element.style == null`, and
  - ignore CSS.

This PR stops us from injecting anything into the DOM from `UIComponent`, fixing #1640.