### PR TITLE
Use classes for border flashes

### DIFF
--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -109,6 +109,20 @@ div.internalVimiumSelectedInputHint span {
   color: white !important;
 }
 
+/* Frame Highlight Marker CSS*/
+div.vimiumHighlightedFrame {
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  width: 100%;
+  height: 100%;
+  padding: 0px;
+  margin: 0px;
+  border: 5px solid yellow;
+  box-sizing: border-box;
+  pointer-events: none;
+}
+
 /* Help Dialog CSS */
 
 div#vimiumHelpDialog {

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -327,20 +327,39 @@ setScrollPosition = (scrollX, scrollY) ->
 #
 # Called from the backend in order to change frame focus.
 #
-window.focusThisFrame = (request) ->
-  if window.innerWidth < 3 or window.innerHeight < 3
-    # This frame is too small to focus. Cancel and tell the background frame to focus the next one instead.
-    # This affects sites like Google Inbox, which have many tiny iframes. See #1317.
-    # Here we're assuming that there is at least one frame large enough to focus.
-    chrome.runtime.sendMessage({ handler: "nextFrame", frameId: frameId })
-    return
-  window.focus()
-  shouldHighlight = request.highlight
-  shouldHighlight ||= request.highlightOnlyIfNotTop and not DomUtils.isTopFrame()
-  if document.body and shouldHighlight
-    borderWas = document.body.style.border
-    document.body.style.border = '5px solid yellow'
-    setTimeout((-> document.body.style.border = borderWas), 200)
+window.focusThisFrame = do ->
+  # Create a shadow DOM wrapping the frame so the page's styles don't interfere with ours.
+  highlightedFrameElement = document.createElement "div"
+  _shadowDOM = highlightedFrameElement.createShadowRoot()
+
+  # Inject stylesheet.
+  _styleSheet = document.createElement "style"
+  if _styleSheet.style?
+    _styleSheet.innerHTML = ""
+    _shadowDOM.appendChild _styleSheet
+    # Load stylesheet.
+    xhr = new XMLHttpRequest()
+    xhr.onload = (e) -> _styleSheet.innerHTML = xhr.responseText
+    xhr.open "GET", chrome.runtime.getURL("content_scripts/vimium.css"), true
+    xhr.send()
+
+  _frameEl = document.createElement "div"
+  _frameEl.className = "vimiumReset vimiumHighlightedFrame"
+  _shadowDOM.appendChild _frameEl
+
+  (request) ->
+    if window.innerWidth < 3 or window.innerHeight < 3
+      # This frame is too small to focus. Cancel and tell the background frame to focus the next one instead.
+      # This affects sites like Google Inbox, which have many tiny iframes. See #1317.
+      # Here we're assuming that there is at least one frame large enough to focus.
+      chrome.runtime.sendMessage({ handler: "nextFrame", frameId: frameId })
+      return
+    window.focus()
+    shouldHighlight = request.highlight
+    shouldHighlight ||= request.highlightOnlyIfNotTop and not DomUtils.isTopFrame()
+    if shouldHighlight
+      document.documentElement.appendChild highlightedFrameElement
+      setTimeout (-> highlightedFrameElement.remove()), 200
 
 extend window,
   scrollToBottom: -> Scroller.scrollTo "y", "max"

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -330,7 +330,8 @@ setScrollPosition = (scrollX, scrollY) ->
 window.focusThisFrame = do ->
   # Create a shadow DOM wrapping the frame so the page's styles don't interfere with ours.
   highlightedFrameElement = document.createElement "div"
-  _shadowDOM = highlightedFrameElement.createShadowRoot()
+  # PhantomJS doesn't support createShadowRoot, so guard against its non-existance.
+  _shadowDOM = highlightedFrameElement.createShadowRoot?() ? highlightedFrameElement
 
   # Inject stylesheet.
   _styleSheet = document.createElement "style"


### PR DESCRIPTION
This fixes #1634 and ensures that the border flash for `gf` and `gF` is always visible by adding/removing a dedicated element.

Note: since the flash is no longer on the body, the characteristic 'jump' as the page content is redrawn no longer occurs. It's easy to add back in if it's missed.