### PR TITLE
Use css @import rather than XMLHttpRequest for shadow DOM external style

### DIFF
--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -8,12 +8,7 @@ class UIComponent
     styleSheet = document.createElement "style"
     styleSheet.type = "text/css"
     # Default to everything hidden while the stylesheet loads.
-    styleSheet.innerHTML = "* {display: none !important;}"
-    # Load stylesheet.
-    xhr = new XMLHttpRequest()
-    xhr.onload = (e) -> styleSheet.innerHTML = xhr.responseText
-    xhr.open "GET", chrome.runtime.getURL("content_scripts/vimium.css"), true
-    xhr.send()
+    styleSheet.innerHTML = "@import url(\"#{chrome.runtime.getURL("content_scripts/vimium.css")}\");"
 
     @iframeElement = document.createElement "iframe"
     extend @iframeElement,

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -336,13 +336,8 @@ window.focusThisFrame = do ->
   # Inject stylesheet.
   _styleSheet = document.createElement "style"
   if _styleSheet.style?
-    _styleSheet.innerHTML = ""
+    _styleSheet.innerHTML = "@import url(\"#{chrome.runtime.getURL("content_scripts/vimium.css")}\");"
     _shadowDOM.appendChild _styleSheet
-    # Load stylesheet.
-    xhr = new XMLHttpRequest()
-    xhr.onload = (e) -> _styleSheet.innerHTML = xhr.responseText
-    xhr.open "GET", chrome.runtime.getURL("content_scripts/vimium.css"), true
-    xhr.send()
 
   _frameEl = document.createElement "div"
   _frameEl.className = "vimiumReset vimiumHighlightedFrame"


### PR DESCRIPTION
Since moving to using shadow DOMs for some of the UI, we've been manually loading our stylesheet via `XMLHttpRequest` and injecting it into a style element in the shadow DOM. CSS supports `@import` for doing this automatically, so we should use that instead.