### PR TITLE
Add header for Advanced Options.

### DIFF
--- a/pages/options.html
+++ b/pages/options.html
@@ -71,6 +71,9 @@ b: http://b.com/?q=%s description
         </tr>
         <tbody id='advancedOptions'>
           <tr>
+            <td colspan="2"><header>Advanced Options</header></td>
+          </tr>
+          <tr>
             <td class="caption">Scroll step size</td>
             <td>
                 <div class="help">


### PR DESCRIPTION
The options page might look better with a header...

![snapshot](https://cloud.githubusercontent.com/assets/2641335/7580488/f22a8b24-f86d-11e4-94ad-e101e46c9c3b.png)

(This leaves the "show/hide advanced options" link as it is, which isn't great.  But the section headers look better, IMO. Personally, I'd also prefer to get rid of the fold entirely.)

Do you have an opinion on this one, @philc?