### PR TITLE
Vomnibar filter duplicates

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -41,6 +41,7 @@ class Suggestion
     # or @relevancyFunction.
     @relevancy ?= @relevancyFunction this
 
+  # Note. This always returns a truthy value.
   generateHtml: ->
     return @html if @html
     relevancyHtml = if @showRelevancy then "<span class='relevancy'>#{@computeRelevancy()}</span>" else ""
@@ -52,7 +53,7 @@ class Suggestion
          <span class="vimiumReset vomnibarTitle">#{@highlightQueryTerms Utils.escapeHtml @title}</span>
        </div>
        <div class="vimiumReset vomnibarBottomHalf">
-        <span class="vimiumReset vomnibarUrl">#{@shortenUrl @highlightQueryTerms Utils.escapeHtml @url}</span>
+        <span class="vimiumReset vomnibarUrl">#{@highlightQueryTerms Utils.escapeHtml @shortenUrl()}</span>
         #{relevancyHtml}
       </div>
       """
@@ -67,8 +68,6 @@ class Suggestion
     a = document.createElement 'a'
     a.href = url
     a.hostname
-
-  shortenUrl: (url) -> @stripTrailingSlash(url).replace(/^https?:\/\//, "")
 
   stripTrailingSlash: (url) ->
     url = url.substring(url, url.length - 1) if url[url.length - 1] == "/"
@@ -129,6 +128,28 @@ class Suggestion
         previous = range
     mergedRanges
 
+  # Simplify a suggestion's URL (by removing those parts which aren't useful for either display or comparison).
+  shortenUrl: () ->
+    return @shortUrl if @shortUrl?
+    url = @url
+    for [ filter, replacements ] in @stripPatterns
+      if new RegExp(filter).test url
+        for replace in replacements
+          url = url.replace replace, ""
+    @shortUrl = url
+
+  # Patterns to strip from URLs; of the form [ [ filter, replacements ], [ filter, replacements ], ... ]
+  #   - filter is a regexp; a URL must match this regexp first.
+  #   - replacements (itself a list) is a list of regexps, each of which is removed from matching URLs.
+  #
+  stripPatterns: [
+    # Google search specific replacements; replaces query parameters which are known to not be helpful.
+    [ '^https?://www\.google\.(com|ca|com\.au|co\.uk|ie)/.*[&?]q=',
+      "ei gws_rd url ved usg sa usg sig2".split(/\s+/).map (param) -> new RegExp "\&#{param}=[^&]+" ]
+
+    # General replacements; replaces leading and trailing fluff.
+    [ '.', [ "^https?://", "\\W+$" ].map (re) -> new RegExp re ]
+  ]
 
 class BookmarkCompleter
   folderSeparator: "/"
@@ -575,11 +596,23 @@ class MultiCompleter
         @filter @mostRecentQuery...
 
   prepareSuggestions: (queryTerms, suggestions) ->
+    # Compute suggestion relevancies and sort.
     suggestion.computeRelevancy queryTerms for suggestion in suggestions
     suggestions.sort (a, b) -> b.relevancy - a.relevancy
-    for suggestion in suggestions[0...@maxResults]
-      suggestion.generateHtml()
-      suggestion
+
+    # Simplify URLs and remove duplicates (duplicate simplified URLs, that is).
+    count = 0
+    seenUrls = {}
+    suggestions =
+      for suggestion in suggestions
+        url = suggestion.shortenUrl()
+        continue if seenUrls[url]
+        break if ++count == @maxResults
+        seenUrls[url] = suggestion
+
+    # Generate HTML for the remaining suggestions and return them.
+    suggestion.generateHtml() for suggestion in suggestions
+    suggestions
 
 # Utilities which help us compute a relevancy score for a given item.
 RankingUtils =

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -127,7 +127,7 @@ class Suggestion
         previous = range
     mergedRanges
 
-  # Simplify a suggestion's URL (by removing those parts which aren't useful for either display or comparison).
+  # Simplify a suggestion's URL (by removing those parts which aren't useful for display or comparison).
   shortenUrl: () ->
     return @shortUrl if @shortUrl?
     url = @url
@@ -138,14 +138,15 @@ class Suggestion
     @shortUrl = url
 
   # Patterns to strip from URLs; of the form [ [ filter, replacements ], [ filter, replacements ], ... ]
-  #   - filter is a regexp; a URL must match this regexp first.
-  #   - replacements (itself a list) is a list of regexps, each of which is removed from matching URLs.
+  #   - filter is a regexp string; a URL must match this regexp first.
+  #   - replacements (itself a list) is a list of regexp objects, each of which is removed from URLs matching
+  #     the filter.
   #
-  # This includes some site-specific patterns for very-popular sites with URLs which don't work well in the
+  # Note. This includes site-specific patterns for very-popular sites with URLs which don't work well in the
   # vomnibar.
   #
   stripPatterns: [
-    # Google search specific replacements; replaces query parameters which are known to not be helpful.
+    # Google search specific replacements; this replaces query parameters which are known to not be helpful.
     [ "^https?://www\.google\.(com|ca|com\.au|co\.uk|ie)/.*[&?]q="
       "ei gws_rd url ved usg sa usg sig2".split(/\s+/).map (param) -> new RegExp "\&#{param}=[^&]+" ]
 

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -41,7 +41,6 @@ class Suggestion
     # or @relevancyFunction.
     @relevancy ?= @relevancyFunction this
 
-  # Note. This always returns a truthy value.
   generateHtml: ->
     return @html if @html
     relevancyHtml = if @showRelevancy then "<span class='relevancy'>#{@computeRelevancy()}</span>" else ""
@@ -142,9 +141,12 @@ class Suggestion
   #   - filter is a regexp; a URL must match this regexp first.
   #   - replacements (itself a list) is a list of regexps, each of which is removed from matching URLs.
   #
+  # This includes some site-specific patterns for very-popular sites with URLs which don't work well in the
+  # vomnibar.
+  #
   stripPatterns: [
     # Google search specific replacements; replaces query parameters which are known to not be helpful.
-    [ '^https?://www\.google\.(com|ca|com\.au|co\.uk|ie)/.*[&?]q=',
+    [ "^https?://www\.google\.(com|ca|com\.au|co\.uk|ie)/.*[&?]q="
       "ei gws_rd url ved usg sa usg sig2".split(/\s+/).map (param) -> new RegExp "\&#{param}=[^&]+" ]
 
     # General replacements; replaces leading and trailing fluff.


### PR DESCRIPTION
This does two things.

1. It filters vomnibar suggestions to exclude items with the same URL.  This is pretty common.  Typing  `fac` into the vomnibar, the first three suggestions are identical (Facebook: domain, bookmark, history). Bookmarked items usually generate two entries (history and bookmark).

2. Before filtering, this shortens the URL: remove leading and trailing fluff.  This increases the chances of finding a duplicate.

**Important note**... The URL shortening includes some custom rules for Google search (Google adds unique ids to every query, thereby polluting the vomnibar with, effectively, duplicates).