### PR TITLE
Vomnibar action on enter

### DIFF
--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -191,19 +191,20 @@ class VomnibarUI
       @updateSelection()
     else if (action == "enter")
       if @selection == -1
+        # <Alt>/<Meta> includes prompted text in the query (normally it is not included).
+        #
+        # FIXME(smblott).  This is a terrible binding. <Ctrl-Enter> would be better, but that's already being
+        # used.  We need a better UX around how to include the prompted text in the query. <Right> then
+        # <Enter> works, but that's ugly too.
+        window.getSelection().collapseToEnd() if event.altKey or event.metaKey
         # The user has not selected a suggestion.
-        query = @input.value.trim()
+        query = @getInputWithoutPromptedText().trim()
         # <Enter> on an empty vomnibar is a no-op.
         return unless 0 < query.length
         if @suppressedLeadingKeyword?
-          # This is a custom search engine completion.  Because of the way we add prompted text to the input
-          # (addPromptedText), the text in the input might not correspond to any of the completions.  So we
-          # fire off the query to the background page and use the completion at the top of the list (which
-          # will be the right one).
-          #
-          # <Enter> on its own selects only the text that the user has typed. <Control-Enter> also includes
-          # any prompted text.
-          window.getSelection()?.collapseToEnd() if @inputContainsASelectionRange() and event.ctrlKey
+          # This is a custom search engine completion.  The text in the input might not correspond to any of
+          # the completions.  So we fire off the query to the background page and use the completion at the
+          # top of the list (which will be the right one).
           @update true, =>
             if @completions[0]
               completion = @completions[0]

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -200,7 +200,10 @@ class VomnibarUI
           # (addPromptedText), the text in the input might not correspond to any of the completions.  So we
           # fire off the query to the background page and use the completion at the top of the list (which
           # will be the right one).
-          window.getSelection()?.collapseToEnd() if @inputContainsASelectionRange()
+          #
+          # <Enter> on its own selects only the text that the user has typed. <Control-Enter> also includes
+          # any prompted text.
+          window.getSelection()?.collapseToEnd() if @inputContainsASelectionRange() and event.ctrlKey
           @update true, =>
             if @completions[0]
               completion = @completions[0]


### PR DESCRIPTION
There was a very bad UX around search completion and prompted text and the behaviour of `Enter`.

Type `They might`, be prompted with `They might be giants`, hit `Enter`, and you were getting the latter.  This makes it hard to search for just `They might`, on its own.

With this PR:
- The prompted text is excluded when the user types `Enter`.
- `<Alt-Enter>` includes the prompted text.  This is a bad binding, but I think it's temporary until we figure out the right UX around this.

(Immediate merge because the existing UX is just so poor.)