### PR TITLE
History for the vomnibar...

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -45,14 +45,17 @@ class Suggestion
     return @html if @html
     relevancyHtml = if @showRelevancy then "<span class='relevancy'>#{@computeRelevancy()}</span>" else ""
     # NOTE(philc): We're using these vimium-specific class names so we don't collide with the page's CSS.
+    insertTextClass = if @insertText then "vomnibarInsertText" else "vomnibarNoInsertText"
+    insertTextIndicator = "&#xfe62;" # A small plus sign.
+    insertTextIndicator = "&#xfe65;" # A small "greater than" sign.
     @html =
       """
       <div class="vimiumReset vomnibarTopHalf">
-         <span class="vimiumReset vomnibarSource">#{@type}</span>
+         <span class="vimiumReset vomnibarSource #{insertTextClass}">#{insertTextIndicator}</span><span class="vimiumReset vomnibarSource">#{@type}</span>
          <span class="vimiumReset vomnibarTitle">#{@highlightQueryTerms Utils.escapeHtml @title}</span>
        </div>
        <div class="vimiumReset vomnibarBottomHalf">
-        <span class="vimiumReset vomnibarUrl">#{@highlightQueryTerms Utils.escapeHtml @shortenUrl()}</span>
+        <span class="vimiumReset vomnibarSource vomnibarNoInsertText">#{insertTextIndicator}</span><span class="vimiumReset vomnibarUrl">#{@highlightQueryTerms Utils.escapeHtml @shortenUrl()}</span>
         #{relevancyHtml}
       </div>
       """

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -236,10 +236,11 @@ class HistoryCompleter
       onComplete results.map (entry) =>
         # If this history URL starts with the search URL, we reconstruct the original search terms, and insert
         # them into the vomnibar when this suggestion is selected.  We use try/catch because
-        # decodeURIComponent() throw an error.
+        # decodeURIComponent() can throw an error.
         insertText =
           try
             if entry.url.startsWith searchUrl
+              # This maps "https://www.google.ie/search?q=star+wars&..." to "star wars".
               entry.url[searchUrl.length..].split(searchUrlTerminator)[0].split("+").map(decodeURIComponent).join " "
           catch
             null

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -235,13 +235,14 @@ class HistoryCompleter
           []
       onComplete results.map (entry) =>
         # If this history URL starts with the search URL, we reconstruct the original search terms, and insert
-        # them into the vomnibar when this suggestion is selected.
+        # them into the vomnibar when this suggestion is selected.  We use try/catch because
+        # decodeURIComponent() throw an error.
         insertText =
-          if entry.url.startsWith searchUrl
-            try
+          try
+            if entry.url.startsWith searchUrl
               entry.url[searchUrl.length..].split(searchUrlTerminator)[0].split("+").map(decodeURIComponent).join " "
-            catch
-              null
+          catch
+            null
 
         new Suggestion
           queryTerms: queryTerms

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -504,7 +504,6 @@ class SearchEngineCompleter
       title: queryTerms.join " "
       relevancy: 1
       autoSelect: custom
-      forceAutoSelect: custom
       highlightTerms: not haveCompletionEngine
 
     mkSuggestion = (suggestion) ->

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -245,6 +245,10 @@ class HistoryCompleter
           catch
             null
 
+        # If this history item does not have a title and we found its query text above, then use its query
+        # text as its title.
+        entry.title ||= insertText if insertText?
+
         new Suggestion
           queryTerms: queryTerms
           type: "history"

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -227,7 +227,7 @@ class HistoryCompleter
     results = []
     HistoryCache.use (history) =>
       searchUrl = Settings.get "searchUrl"
-      searchUrlTerminator = new RegExp "[&#/]"
+      searchUrlTerminator = new RegExp "[?&#/]"
       results =
         if queryTerms.length > 0
           history.filter (entry) -> RankingUtils.matches(queryTerms, entry.url, entry.title)

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -256,6 +256,14 @@ class HistoryCompleter
     historyEntry = suggestion.relevancyData
     recencyScore = RankingUtils.recencyScore(historyEntry.lastVisitTime)
     wordRelevancy = RankingUtils.wordRelevancy(suggestion.queryTerms, suggestion.url, suggestion.title)
+    if suggestion.insertText?
+      # If this suggestion matches a previous search with the default search engine, then we also score the
+      # previous query terms themselves (suggestion.insertText) and, if that score is higher, then we use it
+      # in place of the wordRelevancy score.  Because the query terms are shorter than the original URL, this
+      # has the side effect of boosting the wordRelevancy score for previous searches with the default search
+      # engine.
+      wordRelevancy = Math.max wordRelevancy,
+        RankingUtils.wordRelevancy suggestion.queryTerms, suggestion.insertText, suggestion.title
     # Average out the word score and the recency. Recency has the ability to pull the score up, but not down.
     (wordRelevancy + Math.max recencyScore, wordRelevancy) / 2
 

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -114,6 +114,21 @@ Utils =
     searchUrl += "%s" unless 0 <= searchUrl.indexOf "%s"
     searchUrl.replace /%s/g, @createSearchQuery query
 
+  # Extract a query from url if it appears to be a URL created by createSearchQuery.
+  # For example, map "https://www.google.ie/search?q=star+wars&foo&bar" to "star wars".
+  extractQuery: do =>
+    queryTerminator = new RegExp "[?&#/]"
+    httpProtocolRegexp = new RegExp "^https?://"
+    (searchUrl, url) ->
+      url = url.replace httpProtocolRegexp
+      searchUrl = searchUrl.split("%s")[0].replace httpProtocolRegexp
+      # We use try/catch because decodeURIComponent can throw an exception.
+      try
+        if url.startsWith searchUrl
+          url[searchUrl.length..].split(queryTerminator)[0].split("+").map(decodeURIComponent).join " "
+      catch
+        null
+
   # Converts :string into a Google search if it's not already a URL. We don't bother with escaping characters
   # as Chrome will do that for us.
   convertToUrl: (string) ->

--- a/pages/vomnibar.css
+++ b/pages/vomnibar.css
@@ -145,3 +145,10 @@
    * on the eye for this purpose. */
   background-color: #E6EEFB;
 }
+
+.vomnibarInsertText {
+}
+
+.vomnibarNoInsertText {
+  visibility: hidden;
+}


### PR DESCRIPTION
Type `star wars` into the vomnibar.  Then, realise you really meant `star wars director`.  You need to retype the whole query.  Some mechanism for a vomnibar history would be helpful.

Here's one (kind of cute) idea. (A couple of other possibilities are mentioned below).

Start retyping the query...

![snapshot](https://cloud.githubusercontent.com/assets/2641335/7649945/997d510e-fae9-11e4-993b-f066cbe23ffc.png)

Ah!  There's the history item, in top spot, no less.  Hit `Tab`, and we get this...

![snapshot](https://cloud.githubusercontent.com/assets/2641335/7649964/cafcc58e-fae9-11e4-9d9f-ec8f0ab1ae27.png)

That is:
- We recognise that this history item has the default search URL as a prefix.
- We strip off the prefix (and any extra suffix) and decode the original query (`star wars`, here).
- And, we insert that text into the vomnibar, so the user can continue typing `director`.

(This comes almost for free as a result of some of the search-completion infrastructure.)

Relevancy:
- Additionally, we rescore matching history suggestions for word relevancy, this time considering only the query terms. Then we choose the maximum of the original word relevancy and this new word relevancy.  This has the side effect (usually) of bumping up the history item's score and pushing it up the list.

Caveat:
- This doesn't play well with the way the vomnibar leaves `@selection` unchanged when the vomnibar updates.  It means, in effect, that the text in the vomnibar input could be replaced with whatever text happens to end up as the selected suggestion.
- This PR changes that behaviour.  Every time the vomnibar updates, `@selection` is reset.
- This is not such a big loss.  The existing behaviour is actually pretty weird.  When a suggestion is selected and the user types (or deletes characters from the query), there is practically no way that the user can predict what suggestion is going to end up selected.

This idea is pretty cheap and easy to understand.

Here are two alternative (or possibly additional) ideas.

1. Add a new *query history* vomnibar mode.  This would require a new command.

2. When the vomnibar is empty, `Tab`, `Up` or `Down` toggle into a *query history* mode, whereby the completion list consists only of URLs the user has selected and the default searches they've launched (possibly with scoring weighted heavily for recency).  Add a similar toggle to get back to the original mode.

(For me, 1. is a non-starter, but 2. might have legs.  However, both are actually orthogonal to the idea here.  We could do this PR on its own, or this PR plus 2., if there's any interest.)