### PR TITLE
Vomnibar query-history mode (a proper one).

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -526,6 +526,19 @@ class SearchEngineCompleter
             console.log "fetched suggestions:", suggestions.length, query if SearchEngineCompleter.debug
             onComplete suggestions.map mkSuggestion
 
+# A completer which provides completions based on the user's query history (that is, those vomnibar queries
+# for which no suggestion was selected).
+class QueryHistoryCompleter
+  filter: (request, onComplete) ->
+    onComplete [
+      new Suggestion
+        queryTerms: request.queryTerms
+        type: "query"
+        url: "https://www.google.ie"
+        title: "Hello"
+        relevancy: 1
+      ]
+
 # A completer which calls filter() on many completers, aggregates the results, ranks them, and returns the top
 # 10. All queries from the vomnibar come through a multi completer.
 class MultiCompleter
@@ -618,6 +631,7 @@ class MultiCompleter
     suggestions
 
 # A completer which can toggle between two or more sub-completers (which must themselves be MultiCompleters).
+# The active completer is determined based on request.tabToggleCount, which is provided by the vomnibar.
 class ToggleCompleter
   constructor: (@completers) ->
 
@@ -835,6 +849,7 @@ root = exports ? window
 root.Suggestion = Suggestion
 root.BookmarkCompleter = BookmarkCompleter
 root.MultiCompleter = MultiCompleter
+root.ToggleCompleter = ToggleCompleter
 root.HistoryCompleter = HistoryCompleter
 root.DomainCompleter = DomainCompleter
 root.TabCompleter = TabCompleter
@@ -843,3 +858,4 @@ root.HistoryCache = HistoryCache
 root.RankingUtils = RankingUtils
 root.RegexpCache = RegexpCache
 root.TabRecency = TabRecency
+root.QueryHistoryCompleter = QueryHistoryCompleter

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -617,6 +617,16 @@ class MultiCompleter
     suggestion.generateHtml() for suggestion in suggestions
     suggestions
 
+# A completer which can toggle between two or more sub-completers (which must themselves be MultiCompleters).
+class ToggleCompleter
+  constructor: (@completers) ->
+
+  refresh: (port) -> completer.refresh? port for completer in @completers
+  cancel: (port) -> completer.cancel? port for completer in @completers
+
+  filter: (request, onComplete) ->
+    @completers[request.tabToggleCount % @completers.length].filter request, onComplete
+
 # Utilities which help us compute a relevancy score for a given item.
 RankingUtils =
   # Whether the given things (usually URLs or titles) match any one of the query terms.

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -616,13 +616,8 @@ class QueryHistoryCompleter
           queryHistory =
             for entry in history
               [ url, timestamp ] = [ entry.url, entry.lastVisitTime ]
-              continue unless url.startsWith searchUrl
-              # We use try/catch because decodeURIComponent can raise an exception.
-              try
-                text = url[searchUrl.length..].split(/[/&?#]/)[0].split("+").map(decodeURIComponent).join " "
-              catch
-                continue
-              continue unless text? and 0 < text.length
+              text = Utils.extractQuery searchUrl, url
+              continue unless text
               { text, timestamp }
 
           # Sort into decreasing order (by timestamp) and remove duplicates.

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -486,6 +486,7 @@ class SearchEngineCompleter
       autoSelect: custom
       forceAutoSelect: custom
       highlightTerms: not haveCompletionEngine
+      isCustomSearch: custom
 
     mkSuggestion = (suggestion) ->
       new Suggestion
@@ -496,6 +497,7 @@ class SearchEngineCompleter
         relevancy: relevancy *= 0.9
         insertText: suggestion
         highlightTerms: false
+        isCustomSearch: custom
 
     cachedSuggestions =
       if haveCompletionEngine then CompletionSearch.complete searchUrl, queryTerms else null

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -384,8 +384,8 @@ class SearchEngineCompleter
   @debug: false
   searchEngines: null
 
-  cancel: ->
-    CompletionSearch.cancel()
+  constructor: (@defaultSearchOnly = false) ->
+  cancel: -> CompletionSearch.cancel()
 
   # This looks up the custom search engine and, if one is found, notes it and removes its keyword from the
   # query terms.
@@ -402,7 +402,8 @@ class SearchEngineCompleter
 
   refresh: (port) ->
     # Parse the search-engine configuration.
-    @searchEngines = new AsyncDataFetcher (callback) ->
+    @searchEngines = new AsyncDataFetcher (callback) =>
+      return callback {} if @defaultSearchOnly
       engines = {}
       for line in Settings.get("searchEngines").split "\n"
         line = line.trim()

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -384,7 +384,7 @@ class SearchEngineCompleter
   @debug: false
   searchEngines: null
 
-  constructor: (@defaultSearchOnly = false) ->
+  constructor: (@defaultSearchOnly = false, @initializationRelevancyFactor = 1.0) ->
   cancel: -> CompletionSearch.cancel()
 
   # This looks up the custom search engine and, if one is found, notes it and removes its keyword from the
@@ -446,7 +446,7 @@ class SearchEngineCompleter
 
     return onComplete [] unless custom or 0 < queryTerms.length
 
-    factor = Math.max 0.0, Math.min 1.0, Settings.get "omniSearchWeight"
+    factor = @initializationRelevancyFactor * Math.max 0.0, Math.min 1.0, Settings.get "omniSearchWeight"
     haveCompletionEngine = (0.0 < factor or custom) and CompletionSearch.haveCompletionEngine searchUrl
 
     # Relevancy:

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -488,6 +488,7 @@ class SearchEngineCompleter
       forceAutoSelect: custom
       highlightTerms: not haveCompletionEngine
       isCustomSearch: custom
+      searchUrl: searchUrl
 
     mkSuggestion = (suggestion) ->
       new Suggestion
@@ -499,6 +500,7 @@ class SearchEngineCompleter
         insertText: suggestion
         highlightTerms: false
         isCustomSearch: custom
+        searchUrl: searchUrl
 
     cachedSuggestions =
       if haveCompletionEngine then CompletionSearch.complete searchUrl, queryTerms else null

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -528,10 +528,9 @@ class SearchEngineCompleter
             console.log "fetched suggestions:", suggestions.length, query if SearchEngineCompleter.debug
             onComplete suggestions.map mkSuggestion
 
-# A completer which provides completions based on the user's query history (that is, those vomnibar queries
-# for which no suggestion was selected).
+# A completer which provides completions based on the user's query history using this default search URL.
 #
-# QueryHistory entries area stored in chrome.storage.local under the key "vomnibarQueryHistory" in the form:
+# QueryHistory entries are stored in chrome.storage.local under the key "vomnibarQueryHistory" in the form:
 #   [ { text: ..., timestamp: ...}, ... ]
 #
 # Insertions only happen in vomnibar.coffee(), and new entries are only ever appended.  Therefore, the list is

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -539,7 +539,6 @@ class SearchEngineCompleter
 #
 class QueryHistoryCompleter
   maxHistory: 1000
-  filtersSinceRefresh: 0
 
   constructor: ->
     chrome.storage.onChanged.addListener (changes, area) =>
@@ -556,7 +555,6 @@ class QueryHistoryCompleter
         chrome.storage.local.set vomnibarQueryHistory: queryHistory[0...@maxHistory].reverse()
 
   filter: ({ queryTerms }, onComplete) ->
-    autoSelect = @filtersSinceRefresh++ == 0
     chrome.storage.local.get "vomnibarQueryHistory", (items) =>
       if chrome.runtime.lastError
         onComplete []
@@ -572,9 +570,6 @@ class QueryHistoryCompleter
             relevancyFunction: @computeRelevancy
             timestamp: timestamp
             insertText: text
-
-  refresh: ->
-    @filtersSinceRefresh = 0
 
   computeRelevancy: ({ queryTerms, url, title, timestamp }) ->
     wordRelevancy = if queryTerms.length == 0 then 0.0 else RankingUtils.wordRelevancy queryTerms, url, title

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -60,8 +60,13 @@ completers =
       ]
     completionSources.queryHistory
     ]
-  bookmarks: new ToggleCompleter [ new MultiCompleter([completionSources.bookmarks]), completionSources.queryHistory ]
-  tabs: new ToggleCompleter [ new MultiCompleter([completionSources.tabs]), completionSources.queryHistory ]
+
+  bookmarks: new ToggleCompleter [
+    new MultiCompleter [completionSources.bookmarks]
+    completionSources.queryHistory
+    ]
+
+  tabs: new MultiCompleter [completionSources.tabs]
 
 completionHandlers =
   filter: (completer, request, port) ->

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -48,7 +48,8 @@ completionSources =
   domains: new DomainCompleter
   tabs: new TabCompleter
   searchEngines: new SearchEngineCompleter
-  queryHistory: new MultiCompleter [ new QueryHistoryCompleter ]
+  searchEnginesDefaultOnly: new SearchEngineCompleter true
+  queryHistory: new QueryHistoryCompleter
 
 completers =
   omni: new ToggleCompleter [
@@ -58,7 +59,10 @@ completers =
       completionSources.domains
       completionSources.searchEngines
       ]
-    completionSources.queryHistory
+    new MultiCompleter [
+      completionSources.queryHistory
+      completionSources.searchEnginesDefaultOnly
+      ]
     ]
 
   bookmarks: new MultiCompleter [completionSources.bookmarks]

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -48,16 +48,20 @@ completionSources =
   domains: new DomainCompleter
   tabs: new TabCompleter
   searchEngines: new SearchEngineCompleter
+  queryHistory: new MultiCompleter [ new QueryHistoryCompleter ]
 
 completers =
-  omni: new MultiCompleter [
-    completionSources.bookmarks
-    completionSources.history
-    completionSources.domains
-    completionSources.searchEngines
+  omni: new ToggleCompleter [
+    new MultiCompleter [
+      completionSources.bookmarks
+      completionSources.history
+      completionSources.domains
+      completionSources.searchEngines
+      ]
+    completionSources.queryHistory
     ]
-  bookmarks: new MultiCompleter [completionSources.bookmarks]
-  tabs: new MultiCompleter [completionSources.tabs]
+  bookmarks: new ToggleCompleter [ new MultiCompleter([completionSources.bookmarks]), completionSources.queryHistory ]
+  tabs: new ToggleCompleter [ new MultiCompleter([completionSources.tabs]), completionSources.queryHistory ]
 
 completionHandlers =
   filter: (completer, request, port) ->

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -48,7 +48,7 @@ completionSources =
   domains: new DomainCompleter
   tabs: new TabCompleter
   searchEngines: new SearchEngineCompleter
-  searchEnginesDefaultOnly: new SearchEngineCompleter true
+  searchEnginesDefaultOnly: new SearchEngineCompleter true, 0.5
   queryHistory: new QueryHistoryCompleter
 
 completers =

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -61,11 +61,7 @@ completers =
     completionSources.queryHistory
     ]
 
-  bookmarks: new ToggleCompleter [
-    new MultiCompleter [completionSources.bookmarks]
-    completionSources.queryHistory
-    ]
-
+  bookmarks: new MultiCompleter [completionSources.bookmarks]
   tabs: new MultiCompleter [completionSources.tabs]
 
 completionHandlers =

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -114,6 +114,21 @@ Utils =
     searchUrl += "%s" unless 0 <= searchUrl.indexOf "%s"
     searchUrl.replace /%s/g, @createSearchQuery query
 
+  # Extract a query from url if it appears to be a URL created by createSearchQuery.
+  # For example, map "https://www.google.ie/search?q=star+wars&foo&bar" to "star wars".
+  extractQuery: do =>
+    queryTerminator = new RegExp "[?&#/]"
+    httpProtocolRegexp = new RegExp "^https?://"
+    (searchUrl, url) ->
+      url = url.replace httpProtocolRegexp
+      searchUrl = searchUrl.split("%s")[0].replace httpProtocolRegexp
+      # We use try/catch because decodeURIComponent can throw an exception.
+      try
+        if url.startsWith searchUrl
+          url[searchUrl.length..].split(queryTerminator)[0].split("+").map(decodeURIComponent).join " "
+      catch
+        null
+
   # Converts :string into a Google search if it's not already a URL. We don't bother with escaping characters
   # as Chrome will do that for us.
   convertToUrl: (string) ->

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -151,12 +151,8 @@ class VomnibarUI
     else if (action == "enter")
       if @selection == -1
         query = text = @input.value.trim()
-        unless 0 < query.length
-          # Allow the background completer to toggle the vomnibar mode, if required.
-          # NOTE(smblott) Experimental binding.
-          @tabToggleCount += 1
-          @update true
-          return
+        # <Enter> on an empty vomnibar is a no-op.
+        return unless 0 < query.length
         # If the user types something and hits enter without selecting a completion from the list, then:
         #   - If a search URL has been provided, then use it.  This is custom search engine request.
         #   - Otherwise, send the query to the background page, which will open it as a URL or create a
@@ -178,10 +174,9 @@ class VomnibarUI
         @input.value = @customSearchMode
         @customSearchMode = null
         @updateCompletions()
-      else if @input.value.length == 0
-        # Allow the background completer to toggle the vomnibar mode, if required.
-        # NOTE(smblott) Experimental binding.
-        @tabToggleCount += 1
+      else if @input.value.length == 0 and 0 < @tabToggleCount
+        # Reverse completer toggle via <Tab>.
+        @tabToggleCount -= 1
         @update true
       else
         return true # Do not suppress event.

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -191,9 +191,9 @@ class VomnibarUI
       if chrome.extension.inIncognitoContext
         # We don't record queries in incognito mode at all.
         null
-      else if obj.insertText and not obj.isCustomSearch
-        # Pick up the text from (non-custom) searches.
-        obj.insertText
+      else if (obj.queryText or obj.insertText) and not obj.isCustomSearch
+        # Pick up the text from (non-custom) searches; queryText takes precedence over insertText.
+        obj.queryText or obj.insertText
       else if "string" == typeof obj
         # Pick up the text from regular searches.
         obj

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -184,17 +184,20 @@ class VomnibarUI
 
   recordQueryHistoryAndPerformAction: (obj, callback) ->
     query =
-      # Pick up the text from (non-custom) searches.
-      if obj.insertText and not obj.isCustomSearch
-        obj.insertText
-      # Pick up the text from regular searches.
+      if chrome.extension.inIncognitoContext
+        # We don't record queries in incognito mode at all.
+        null
+      else if obj.insertText and not obj.isCustomSearch
+        # Pick up the text from (non-custom) searches.
+          obj.insertText
       else if "string" == typeof obj
+        # Pick up the text from regular searches.
         obj
       else
         # We ignore everything else.
         null
 
-    if not query
+    if chrome.extension.inIncognitoContext or not query
       callback()
     else
       # We record the query in chrome.storage.local *before* calling callback() to ensure that this tab stays

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -189,7 +189,7 @@ class VomnibarUI
         null
       else if obj.insertText and not obj.isCustomSearch
         # Pick up the text from (non-custom) searches.
-          obj.insertText
+        obj.insertText
       else if "string" == typeof obj
         # Pick up the text from regular searches.
         obj
@@ -197,7 +197,7 @@ class VomnibarUI
         # We ignore everything else.
         null
 
-    if chrome.extension.inIncognitoContext or not query
+    if not query
       callback()
     else
       # We record the query in chrome.storage.local *before* calling callback() to ensure that this tab stays

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -151,8 +151,12 @@ class VomnibarUI
     else if (action == "enter")
       if @selection == -1
         query = text = @input.value.trim()
-        # <Enter> on an empty query is a no-op.
-        return unless 0 < query.length
+        unless 0 < query.length
+          # Allow the background completer to toggle the vomnibar mode, if required.
+          # NOTE(smblott) Experimental binding.
+          @tabToggleCount += 1
+          @update true
+          return
         # If the user types something and hits enter without selecting a completion from the list, then:
         #   - If a search URL has been provided, then use it.  This is custom search engine request.
         #   - Otherwise, send the query to the background page, which will open it as a URL or create a

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -136,7 +136,7 @@ class VomnibarUI
     if (action == "dismiss")
       @hide()
     else if action in [ "tab", "down" ]
-      if action == "tab" and @input.value.trim().length == 0
+      if action == "tab" and @input.value.trim().length == 0 and @completions.length == 0
         # Allow the background completer to toggle the vomnibar mode, if required.
         @tabToggleCount += 1
         @update true

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -178,6 +178,11 @@ class VomnibarUI
         @input.value = @customSearchMode
         @customSearchMode = null
         @updateCompletions()
+      else if @input.value.length == 0
+        # Allow the background completer to toggle the vomnibar mode, if required.
+        # NOTE(smblott) Experimental binding.
+        @tabToggleCount += 1
+        @update true
       else
         return true # Do not suppress event.
 

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -192,7 +192,6 @@ class VomnibarUI
         obj
       else
         # We ignore everything else.
-        console.log "skip", obj.url
         null
 
     if not query


### PR DESCRIPTION
This implements a query history for vomnibar queries (default search engine only).

It looks like this...

![snapshot](https://cloud.githubusercontent.com/assets/2641335/7656463/8b4ff652-fb22-11e4-913f-f7590941e886.png)

These are the default-search-engine queries run either:
- directly from the vomnibar input
- from a default search-engine completion, or
- (with #1661) from a history entry which matches the default search URL.

The *big* outstanding issue is how to activate this vomnibar mode.  The way it works here, query history mode is activated whenever the user hits `Tab` in a *completely* empty vomnibar (that is, the vomnibar input is empty, and there are no completions).  This is the start state for "omni" and "bookmarks" modes.  So, `o` then `Tab` then `Tab` brings up the most recent search query, like this...

![snapshot](https://cloud.githubusercontent.com/assets/2641335/7656599/570ca4de-fb23-11e4-825e-44b90b4dedc0.png)

... where the user can then either resubmit the query or edit it.

That's a very nice binding... if you know about it.  It's somewhat hidden away if you do not.  If we go with this, then this would be important enough to get a mention in the main README.

(Apart from adding two new commands, I don't really have any other good ideas as to how such a query history mode could be activated.)