### PR TITLE
Do not ignore recency in history scores.

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -252,8 +252,8 @@ class HistoryCompleter
     historyEntry = suggestion.relevancyData
     recencyScore = RankingUtils.recencyScore(historyEntry.lastVisitTime)
     wordRelevancy = RankingUtils.wordRelevancy(suggestion.queryTerms, suggestion.url, suggestion.title)
-    # Average out the word score and the recency. Recency has the ability to pull the score up, but not down.
-    (wordRelevancy + Math.max recencyScore, wordRelevancy) / 2
+    # Average out the word relevancy and the recency.
+    (wordRelevancy + recencyScore) / 2
 
 # The domain completer is designed to match a single-word query which looks like it is a domain. This supports
 # the user experience where they quickly type a partial domain, hit tab -> enter, and expect to arrive there.


### PR DESCRIPTION
See [this line](https://github.com/philc/vimium/commit/51f197952208701542eef60b353f248e5b9c6054#diff-d25503b9a051bcc246a7773e67af13f3R95):

```Coffeescript
# Average out the word score and the recency. Recency has the ability to pull the score up, but not down.
score = (wordRelevancy + Math.max(recencyScore, wordRelevancy)) / 2
```

This is the relevancy calculation for the history completer.

I'm suspicious.  This might actually be making matters worse.  In particular, it has the effect of (unduly?) promoting very-old suggestions which just happen to have short titles (or URLs).  Therefore they have a higher word relevancy and their recency is ignored.  So a page I visited five minutes ago is displaced by one I visited in the dim an distant past.