### PR TITLE
Search completion ux tweaks.

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -485,7 +485,6 @@ class SearchEngineCompleter
     mkSuggestion = do =>
       count = 0
       (suggestion) =>
-        console.log count
         new Suggestion
           queryTerms: queryTerms
           type: description

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -10,7 +10,7 @@
 #  - refresh(): (optional) refreshes the completer's data source (e.g. refetches the list of bookmarks).
 #  - cancel(): (optional) cancels any pending, cancelable action.
 class Suggestion
-  showRelevancy: true # Set this to true to render relevancy when debugging the ranking scores.
+  showRelevancy: false # Set this to true to render relevancy when debugging the ranking scores.
 
   constructor: (@options) ->
     # Required options.
@@ -281,7 +281,7 @@ class DomainCompleter
         queryTerms: queryTerms
         type: "domain"
         url: domains[0]?[0] ? "" # This is the URL or an empty string, but not null.
-        relevancy: 1
+        relevancy: 2
       ].filter (s) -> 0 < s.url.length
 
   # Returns a list of domains of the form: [ [domain, relevancy], ... ]
@@ -477,22 +477,28 @@ class SearchEngineCompleter
       type: description
       url: Utils.createSearchUrl queryTerms, searchUrl
       title: queryTerms.join " "
-      relevancy: 1
+      relevancy: 2
       autoSelect: custom
       forceAutoSelect: custom
       highlightTerms: not haveCompletionEngine
 
-    mkSuggestion = (suggestion) =>
-      new Suggestion
-        queryTerms: queryTerms
-        type: description
-        url: Utils.createSearchUrl suggestion, searchUrl
-        title: suggestion
-        insertText: suggestion
-        highlightTerms: false
-        isCustomSearch: custom
-        relevancyFunction: @computeRelevancy
-        relevancyData: factor
+    mkSuggestion = do =>
+      count = 0
+      (suggestion) =>
+        console.log count
+        new Suggestion
+          queryTerms: queryTerms
+          type: description
+          url: Utils.createSearchUrl suggestion, searchUrl
+          title: suggestion
+          insertText: suggestion
+          highlightTerms: false
+          isCustomSearch: custom
+          # The first (top) suggestion gets a score of 1.  This puts it two <Tab>s away if a domain completion
+          # is present (which has a score of 2), and one <Tab> away otherwise.
+          relevancy: if 0 < count++ then null else 1
+          relevancyFunction: @computeRelevancy
+          relevancyData: factor
 
     cachedSuggestions =
       if haveCompletionEngine then CompletionSearch.complete searchUrl, queryTerms else null

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -456,10 +456,6 @@ class SearchEngineCompleter
     factor = Math.max 0.0, Math.min 1.0, Settings.get "omniSearchWeight"
     haveCompletionEngine = (0.0 < factor or custom) and CompletionSearch.haveCompletionEngine searchUrl
 
-    # We weight the relevancy factor by the length of the query (exponentially).  The idea is that, the
-    # more the user has typed, the less likely it is that another completer has proven fruitful.
-    factor *= 1 - Math.pow 0.8, query.length
-
     # This filter is applied to all of the suggestions from all of the completers, after they have been
     # aggregated by the MultiCompleter.
     filter = (suggestions) ->
@@ -496,9 +492,7 @@ class SearchEngineCompleter
         highlightTerms: false
         isCustomSearch: custom
         relevancyFunction: @computeRelevancy
-        # We reduce the relevancy factor as suggestions are added. This respects, to some extent, the
-        # order provided by the completion engine.
-        relevancyData: factor *= 0.95
+        relevancyData: factor
 
     cachedSuggestions =
       if haveCompletionEngine then CompletionSearch.complete searchUrl, queryTerms else null


### PR DESCRIPTION
This implements two tweaks to the search-completion UX.

1. b50c1fe710f1c33d76410dedcf8551c1a1772cba "fixes" "UX Issue 1" from #1651.  It prevents search-engine suggestions from jumping around in the completion list.

2. 4309dcd3030687f3ed02b86bbdf7c485baaee4a5 promotes the score of the top search-engine completion to top spot.  This makes it (and its `<Tab>` completion text) always either one or two `<Tab>`s away (depending upon whether a domain-completer suggestion is present or not).

(Note.  The whole search-engine completion UX is difficult to get right, and a bit of a moving target at the moment.)