### PR TITLE
Retain previous matching completion suggestions.

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -52,7 +52,7 @@ class Suggestion
          <span class="vimiumReset vomnibarTitle">#{@highlightQueryTerms Utils.escapeHtml @title}</span>
        </div>
        <div class="vimiumReset vomnibarBottomHalf">
-        <span class="vimiumReset vomnibarUrl">#{@highlightQueryTerms Utils.escapeHtml @shortenUrl()}</span>
+        <span class="vimiumReset vomnibarUrl">#{@highlightUrlTerms Utils.escapeHtml @shortenUrl()}</span>
         #{relevancyHtml}
       </div>
       """
@@ -113,6 +113,9 @@ class Suggestion
         "<span class='vomnibarMatch'>#{string.substring(start, end)}</span>" +
         string.substring(end)
     string
+
+  highlightUrlTerms: (string) ->
+    if @highlightTermsExcludeUrl then string else @highlightQueryTerms string
 
   # Merges the given list of ranges such that any overlapping regions are combined. E.g.
   #   mergeRanges([0, 4], [3, 6]) => [0, 6].  A range is [startIndex, endIndex].
@@ -486,8 +489,8 @@ class SearchEngineCompleter
     previousSuggestions =
       for url, suggestion of @previousSuggestions
         continue unless RankingUtils.matches queryTerms, suggestion.title
-        # Reset the previous relevancy and HTML, they may not be correct wrt. the current query.
-        extend suggestion, relevancy: null, html: null
+        # Reset various fields, they may not be correct wrt. the current query.
+        extend suggestion, relevancy: null, html: null, highlightTerms: true, queryTerms: queryTerms
         suggestion.relevancy = null
         suggestion
 
@@ -512,6 +515,7 @@ class SearchEngineCompleter
           title: suggestion
           insertText: suggestion
           highlightTerms: false
+          highlightTermsExcludeUrl: true
           isCustomSearch: custom
           # The first (top) suggestion gets a score of 1.  This puts it two <Tab>s away if a domain completion
           # is present (which has a score of 2), and one <Tab> away otherwise.

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -480,9 +480,14 @@ class SearchEngineCompleter
             # And the URL suffix (which must contain the query part) matches the current query.
             RankingUtils.matches queryTerms, suggestion.url[engine.searchUrlPrefix.length..])
 
+    # If a previous suggestion still matches the query, then we keep it (even if the completion engine may not
+    # return it for the current query).  This allows the user to pick suggestions by typing fragments of their
+    # text, without regard to whether the completion engine can complete the actual text of the query.
     previousSuggestions =
       for url, suggestion of @previousSuggestions
         continue unless RankingUtils.matches queryTerms, suggestion.title
+        # Reset the previous relevancy and HTML, they may not be correct wrt. the current query.
+        extend suggestion, relevancy: null, html: null
         suggestion.relevancy = null
         suggestion
 


### PR DESCRIPTION
This melds search completions with the vomnibar's existing matching rules and seems to be a big UX win.  Here are a couple of walk throughs.

Query: Search for the song "Istanbul" by "They might be Giants".
Getting started...

First, search completion pulls up the right search in position eight:

![snapshot](https://cloud.githubusercontent.com/assets/2641335/7677560/f2753800-fd44-11e4-9009-06f7a740281d.png)

I could `Tab` down to there.  But the Vimium way is to just add some more text to pull that suggestion to the top.  So, I continue "they mig **is**"...

![snapshot](https://cloud.githubusercontent.com/assets/2641335/7677575/17fe2c26-fd45-11e4-9a7d-161864021555.png)

And that pulls the query I'm looking for right to the top (despite the fact that the query "they mig is" does not itself pull any suggestions from Google).

What's happening is that we're  retaining previous suggestions which continue to match the query (even if the completion engine no longer returns them).  This allows us to continue with Vimium-style matching.

Another example.
Query Wikipedia for "Lake Victoria Perch" (a kind of fish).

First, "lake vict"...
And we have what we're looking for in slot six.

![snapshot](https://cloud.githubusercontent.com/assets/2641335/7677438/f6a338c4-fd43-11e4-8b7e-d9298e9230da.png)

Continuing "lake vict **pe**"...

![snapshot](https://cloud.githubusercontent.com/assets/2641335/7677448/13379e3a-fd44-11e4-933b-54df8c883f83.png)

... and the search we're looking for is just a `Tab` away.

This addresses "UX Issue 2" from #1651.