### PR TITLE
Change vomnibar insert-text indicator.

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -44,10 +44,9 @@ class Suggestion
   generateHtml: ->
     return @html if @html
     relevancyHtml = if @showRelevancy then "<span class='relevancy'>#{@computeRelevancy()}</span>" else ""
-    # NOTE(philc): We're using these vimium-specific class names so we don't collide with the page's CSS.
     insertTextClass = if @insertText then "vomnibarInsertText" else "vomnibarNoInsertText"
-    insertTextIndicator = "&#xfe62;" # A small plus sign.
-    insertTextIndicator = "&#xfe65;" # A small "greater than" sign.
+    insertTextIndicator = "&#8618;" # A right hooked arrow.
+    # NOTE(philc): We're using these vimium-specific class names so we don't collide with the page's CSS.
     @html =
       """
       <div class="vimiumReset vomnibarTopHalf">


### PR DESCRIPTION
Use a rightwards hooked arrow instead of a small greater-than sign, which according to @philc, renders as a large (and ugly) greater-than sign on Macs.  See #1651.

Now looks like this...

![snapshot](https://cloud.githubusercontent.com/assets/2641335/7806946/b23d9d00-037e-11e5-83ab-230c7336b1a9.png)

(I'd prefer a smaller symbol, but this is better than the ugly greater-than which @philc reports in #1651.)