### PR TITLE
Go directly to next/previous tab.

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -321,8 +321,8 @@ commandDescriptions =
   goToRoot: ["Go to root of current URL hierarchy", { passCountToFunction: true }]
 
   # Manipulating tabs
-  nextTab: ["Go one tab right", { background: true }]
-  previousTab: ["Go one tab left", { background: true }]
+  nextTab: ["Go one tab right", { background: true, passCountToFunction: true }]
+  previousTab: ["Go one tab left", { background: true, passCountToFunction: true }]
   firstTab: ["Go to the first tab", { background: true }]
   lastTab: ["Go to the last tab", { background: true }]
 

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -360,8 +360,7 @@ selectTab = (direction, count = 1) ->
           when "last"
             tabs.length - 1
       # Bring toSelect into the range [0,tabs.length).
-      toSelect += tabs.length while toSelect < 0
-      toSelect %= tabs.length
+      toSelect = (toSelect + tabs.length * Math.abs count) % tabs.length
       chrome.tabs.update tabs[toSelect].id, selected: true
 
 updateOpenTabs = (tab, deleteFrames = false) ->


### PR DESCRIPTION
This makes `nextTab` and `previousTab` go directly to the relevant tab, without visiting intervening tabs -- all of which avoids a nasty flicker for 5J or 5K.