### PR TITLE
Two errors fixed...

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -29,6 +29,8 @@ class Suggestion
     @highlightTerms = true
     # @insertText is text to insert into the vomnibar input when the suggestion is selected.
     @insertText = null
+    # @deDuplicate controls whether this suggestion is a candidate for deduplication.
+    @deDuplication = true
 
     # Other options set by individual completers include:
     # - tabId (TabCompleter)
@@ -390,6 +392,7 @@ class TabCompleter
           title: tab.title
           relevancyFunction: @computeRelevancy
           tabId: tab.id
+          deDuplicate: false
       onComplete suggestions
 
   computeRelevancy: (suggestion) ->
@@ -665,7 +668,7 @@ class MultiCompleter
     suggestions =
       for suggestion in suggestions
         url = suggestion.shortenUrl()
-        continue if seenUrls[url]
+        continue if suggestion.deDuplicate and seenUrls[url]
         break if count++ == @maxResults
         seenUrls[url] = suggestion
 

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -126,9 +126,12 @@ class VomnibarUI
     if (action == "dismiss")
       @hide()
     else if action in [ "tab", "down" ]
-      if @input.value.trim().length == 0 and action == "tab" and not @seenTabToOpenCompletionList
-        @seenTabToOpenCompletionList = true
-        @update true
+      if action == "tab" and
+        @completer.name == "omni" and
+        not @seenTabToOpenCompletionList and
+        @input.value.trim().length == 0
+          @seenTabToOpenCompletionList = true
+          @update true
       else
         @selection += 1
         @selection = @initialSelectionValue if @selection == @completions.length


### PR DESCRIPTION
764d70312f292882abe4940adf9fee3d6e834327:
- Recently, we began removing duplicate URLs from the suggestion list offered in the vomnibar.  I overlooked the that fact that this makes no sense for the vomnibar in tabs mode (where the user can have several tabs open on the same URL).

402004f3567042a9fa940c3fd66ece1f60c10f88:
- `Tab` on an empty vomnibar opens the history sorted by recency.  That too makes no sense for the tabs-mode vomnibar.  What's more, as a result, it was taking *two* TABs to initially advance the selection.

Both errors fixed here.