### PR TITLE
Accept input directly in the HUD iframe for find mode

### DIFF
--- a/content_scripts/mode_find.coffee
+++ b/content_scripts/mode_find.coffee
@@ -61,7 +61,6 @@ class FindMode extends Mode
     hasResults: false
 
   constructor: (options = {}) ->
-    console.log "constructor", @options
     # Save the selection, so findInPlace can restore it.
     @initialRange = getCurrentRange()
     FindMode.query = rawQuery: ""

--- a/content_scripts/mode_visual_edit.coffee
+++ b/content_scripts/mode_visual_edit.coffee
@@ -353,7 +353,7 @@ class Movement extends CountPrefix
       do =>
         doFind = (count, backwards) =>
           initialRange = @selection.getRangeAt(0).cloneRange()
-          for [0...count]
+          for [0...count] by 1
             unless FindMode.execute null, {colorSelection: false, backwards}
               @setSelectionRange initialRange
               HUD.showForDuration("No matches for '#{FindMode.query.rawQuery}'", 1000)

--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -58,7 +58,7 @@ handlers =
 
   showFindMode: (data) ->
     hud = document.getElementById "hud"
-    hud.innerText = "/"
+    hud.innerText = "/\u200A" # \u200A is a "hair space", to leave enough space before the caret/first char.
 
     inputElement = document.createElement "span"
     inputElement.contentEditable = "plaintext-only"


### PR DESCRIPTION
This PR does the bare minimum to get find mode working using a `contentEditable` element in the HUD iframe, instead of using `keydown`/`keypress`. This is a follow-on from #1658.

Issues I'm aware of (and plan to fix in futute PRs):
* no focus checks, so the user can 'escape' the iframe to the parent window and trigger the old code directly
* the current find mode code is nearly unchanged, so there is some code we won't need to keep, and some that will want re-writing
* when the search term gets too long, it overflows the HUD and the caret can be in the overflow

This resolves #556, fixes #1672, and possibly some others too.

@smblott-github sorry I've taken so long to push this, can you take a look over it?