### PR TITLE
Disable UIComponent for XML (merge).

### DIFF
--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -56,6 +56,11 @@ class Tween
   styleElement: null
 
   constructor: (@cssSelector, insertionPoint = document.documentElement) ->
+    # Disable on XML pages.  See comment in UIComponent constructor.
+    unless styleSheet.style
+      @fade = @stop = @updateStyle = ->
+      return
+
     @styleElement = document.createElement "style"
     @styleElement.type = "text/css"
     @styleElement.innerHTML = ""

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -7,6 +7,18 @@ class UIComponent
 
   constructor: (iframeUrl, className, @handleMessage) ->
     styleSheet = document.createElement "style"
+
+    unless styleSheet.style
+      # If this is an XML document, nothing we do here works:
+      # * <style> elements show their contents inline,
+      # * <iframe> elements don't load any content,
+      # * document.createElement generates elements that have style == null and ignore CSS.
+      # If this is the case we don't want to pollute the DOM to no or negative effect.  So we bail
+      # immediately, and disable all externally-called methods.
+      @postMessage = @activate = @show = @hide = ->
+        console.log "This vimium feature is disabled because it is incompatible with this page."
+      return
+
     styleSheet.type = "text/css"
     # Default to everything hidden while the stylesheet loads.
     styleSheet.innerHTML = "@import url(\"#{chrome.runtime.getURL("content_scripts/vimium.css")}\");"

--- a/tests/dom_tests/chrome.coffee
+++ b/tests/dom_tests/chrome.coffee
@@ -5,6 +5,9 @@
 root = exports ? window
 root.chromeMessages = []
 
+# Add a styleSheet property so that UIComponents and the Tween initialize themselves.
+root.styleSheet = {}
+
 document.hasFocus = -> true
 
 root.chrome =


### PR DESCRIPTION
Follow on from #1647.

@mrmr1993. Looks like we probably have to disable the `Tween` too (02aaa6d7d3d852154dc9b0904a17575d857fc9df). 