### PR TITLE
Direct keyboard access to custom-search engines via keyword flag

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -24,13 +24,13 @@ Commands =
       noRepeat: options.noRepeat
       repeatLimit: options.repeatLimit
 
-  mapKeyToCommand: ({ key, command, extras }) ->
+  mapKeyToCommand: ({ key, command, options }) ->
     unless @availableCommands[command]
       console.log command, "doesn't exist!"
       return
 
-    extras ?= []
-    @keyToCommandRegistry[key] = extend { command, extras }, @availableCommands[command]
+    options ?= []
+    @keyToCommandRegistry[key] = extend { command, options }, @availableCommands[command]
 
   # Lower-case the appropriate portions of named keys.
   #
@@ -51,11 +51,11 @@ Commands =
         tokens = line.replace(/\s+$/, "").split /\s+/
         switch tokens[0]
           when "map"
-            [ _, key, command, extras... ] = tokens
+            [ _, key, command, options... ] = tokens
             if command? and @availableCommands[command]
               key = @normalizeKey key
               console.log "Mapping", key, "to", command
-              @mapKeyToCommand { key, command, extras }
+              @mapKeyToCommand { key, command, options }
 
           when "unmap"
             if tokens.length == 2

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -558,13 +558,13 @@ checkKeyQueue = (keysToCheck, tabId, frameId) ->
 
     if runCommand
       if not registryEntry.isBackgroundCommand
-        chrome.tabs.sendMessage(tabId,
-          name: "executePageCommand",
-          command: registryEntry.command,
-          frameId: frameId,
-          count: count,
-          passCountToFunction: registryEntry.passCountToFunction,
-          completionKeys: generateCompletionKeys(""))
+        chrome.tabs.sendMessage tabId,
+          name: "executePageCommand"
+          command: registryEntry.command
+          frameId: frameId
+          count: count
+          completionKeys: generateCompletionKeys ""
+          registryEntry: registryEntry
         refreshedCompletionKeys = true
       else
         if registryEntry.passCountToFunction

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -62,6 +62,7 @@ settings =
     helpDialog_showAdvancedCommands: null
     smoothScroll: null
     grabBackFocus: null
+    searchEngines: null
 
   init: ->
     @port = chrome.runtime.connect name: "settings"

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -314,7 +314,7 @@ executePageCommand = (request) ->
   # All other commands are handled in their frame (but only if Vimium is enabled).
   return unless frameId == request.frameId and isEnabledForUrl
 
-  if (request.passCountToFunction)
+  if request.registryEntry.passCountToFunction
     Utils.invokeCommandString(request.command, [request.count])
   else
     Utils.invokeCommandString(request.command) for i in [0...request.count]

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -307,7 +307,7 @@ executePageCommand = (request) ->
     if DomUtils.isTopFrame()
       # We pass the frameId from request.  That's the frame which originated the request, so that's the frame
       # which should receive the focus when the vomnibar closes.
-      Utils.invokeCommandString request.command, [ request.frameId ]
+      Utils.invokeCommandString request.command, [ request.frameId, request.registryEntry ]
       refreshCompletionKeys request
     return
 

--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -4,14 +4,22 @@
 Vomnibar =
   vomnibarUI: null
 
+  getOptions: (registryEntry = { extras: [] }) ->
+    extras = {}
+    for extra in registryEntry.extras
+      [ key, value ] = extra.split "="
+      extras.query = "#{value} " if key? and key == "keyword" and value? and 0 < value.length
+    extras
+
   # sourceFrameId here (and below) is the ID of the frame from which this request originates, which may be different
   # from the current frame.
-  activate: (sourceFrameId) -> @open sourceFrameId, {completer:"omni"}
-  activateInNewTab: (sourceFrameId) -> @open sourceFrameId, {
-    completer: "omni"
-    selectFirst: false
-    newTab: true
-  }
+
+  activate: (sourceFrameId, registryEntry) ->
+    @open sourceFrameId, extend @getOptions(registryEntry), completer:"omni"
+
+  activateInNewTab: (sourceFrameId, registryEntry) ->
+    @open sourceFrameId, extend @getOptions(registryEntry), completer: "omni", newTab: true
+
   activateTabSelection: (sourceFrameId) -> @open sourceFrameId, {
     completer: "tabs"
     selectFirst: true

--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -8,7 +8,7 @@ Vomnibar =
     extras = {}
     for extra in registryEntry.extras
       [ key, value ] = extra.split "="
-      extras.query = "#{value} " if key? and key == "keyword" and value? and 0 < value.length
+      extras.keyword = value if key? and key == "keyword" and value? and 0 < value.length
     extras
 
   # sourceFrameId here (and below) is the ID of the frame from which this request originates, which may be different

--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -6,20 +6,20 @@ Vomnibar =
 
   # Parse any additional options from the command's registry entry.  Currently, this only includes a flag of
   # the form "keyword=X", for direct activation of a custom search engine.
-  parseRegistryEntry: (registryEntry = { extras: [] }, callback = null) ->
+  parseRegistryEntry: (registryEntry = { options: [] }, callback = null) ->
     options = {}
     searchEngines = settings.get("searchEngines") ? ""
     SearchEngines.refreshAndUse searchEngines, (engines) ->
-      for extra in registryEntry.extras
-        [ key, value ] = extra.split "="
+      for option in registryEntry.options
+        [ key, value ] = option.split "="
         switch key
           when "keyword"
             if value? and engines[value]?
               options.keyword = value
             else
-              console.log "Vimium configuration error: no such custom search engine: #{extra}."
+              console.log "Vimium configuration error: no such custom search engine: #{option}."
           else
-              console.log "Vimium configuration error: unused flag: #{extra}."
+              console.log "Vimium configuration error: unused flag: #{option}."
 
       callback? options
 

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -245,14 +245,10 @@ SearchEngines =
           tokens = line.split /\s+/
           continue unless 2 <= tokens.length
           keyword = tokens[0].split(":")[0]
-          url = tokens[1]
+          searchUrl = tokens[1]
           description = tokens[2..].join(" ") || "search (#{keyword})"
-          continue unless Utils.hasFullUrlPrefix url
-          engines[keyword] =
-            keyword: keyword
-            searchUrl: url
-            description: description
-            searchUrlPrefix: url.split("%s")[0]
+          continue unless Utils.hasFullUrlPrefix searchUrl
+          engines[keyword] = { keyword, searchUrl, description }
 
         callback engines
 

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -228,6 +228,42 @@ Utils =
   # Like Nodejs's nextTick.
   nextTick: (func) -> @setTimeout 0, func
 
+# Utility for parsing and using the custom search-engine configuration.  We re-use the previous parse if the
+# search-engine configuration is unchanged.
+SearchEngines =
+  previousSearchEngines: null
+  searchEngines: null
+
+  refresh: (searchEngines) ->
+    unless @previousSearchEngines? and searchEngines == @previousSearchEngines
+      @previousSearchEngines = searchEngines
+      @searchEngines = new AsyncDataFetcher (callback) ->
+        engines = {}
+        for line in searchEngines.split "\n"
+          line = line.trim()
+          continue if /^[#"]/.test line
+          tokens = line.split /\s+/
+          continue unless 2 <= tokens.length
+          keyword = tokens[0].split(":")[0]
+          url = tokens[1]
+          description = tokens[2..].join(" ") || "search (#{keyword})"
+          continue unless Utils.hasFullUrlPrefix url
+          engines[keyword] =
+            keyword: keyword
+            searchUrl: url
+            description: description
+            searchUrlPrefix: url.split("%s")[0]
+
+        callback engines
+
+  # Use the parsed search-engine configuration, possibly asynchronously.
+  use: (callback) ->
+    @searchEngines.use callback
+
+  # Both set (refresh) the search-engine configuration and use it at the same time.
+  refreshAndUse: (searchEngines, callback) ->
+    @refresh searchEngines
+    @use callback
 
 # This creates a new function out of an existing function, where the new function takes fewer arguments. This
 # allows us to pass around functions instead of functions + a partial list of arguments.
@@ -325,6 +361,7 @@ class JobRunner
 
 root = exports ? window
 root.Utils = Utils
+root.SearchEngines = SearchEngines
 root.SimpleCache = SimpleCache
 root.AsyncDataFetcher = AsyncDataFetcher
 root.JobRunner = JobRunner

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -17,6 +17,7 @@ Vomnibar =
       query: ""
       newTab: false
       selectFirst: false
+      keyword: null
     extend options, userOptions
     extend options, refreshInterval: if options.completer == "omni" then 150 else 0
 
@@ -28,6 +29,7 @@ Vomnibar =
     @vomnibarUI.setRefreshInterval options.refreshInterval
     @vomnibarUI.setForceNewTab options.newTab
     @vomnibarUI.setQuery options.query
+    @vomnibarUI.setKeyword options.keyword
     @vomnibarUI.update true
 
   hide: -> @vomnibarUI?.hide()
@@ -40,6 +42,7 @@ class VomnibarUI
     @initDom()
 
   setQuery: (query) -> @input.value = query
+  setKeyword: (keyword) -> @customSearchMode = keyword
   setInitialSelectionValue: (@initialSelectionValue) ->
   setRefreshInterval: (@refreshInterval) ->
   setForceNewTab: (@forceNewTab) ->

--- a/tests/dom_tests/vomnibar_test.coffee
+++ b/tests/dom_tests/vomnibar_test.coffee
@@ -1,4 +1,5 @@
 vomnibarFrame = null
+SearchEngines.refresh ""
 
 context "Keep selection within bounds",
 


### PR DESCRIPTION
This extends the `map` command for *Custom key mappings* such that mappings (only for `vomnibar.activate`, here) can optionally take extra flags.  This idea was first mooted in #1269.

Here, the extra flag is a custom search-engine keyword.  Something like:

    map s vomnibar.activate keyword=g

Assuming a custom search engine...

    g: http://www.google.com/search?q=%s Google

the user can then launch Google search (with completion) with a single keystroke. So, with this example, the user types `s` and immediately gets...

![snapshot](https://cloud.githubusercontent.com/assets/2641335/7881336/c3af8c38-05f9-11e5-97d0-8d8a4ff3269e.png)

This is an alternative to #1695 (a better alternative, I think, since 1) it does not require a new command, and 2) it just feels slicker.

The idea is that this is an advanced feature, and would not be listed on the help page (`?`).  It would be described in the wiki.