### PR TITLE
Disable UIComponent for XML documents

### DIFF
--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -57,6 +57,12 @@ class Tween
 
   constructor: (@cssSelector, insertionPoint = document.documentElement) ->
     @styleElement = document.createElement "style"
+
+    unless @styleElement.style
+      # We're in an XML document, so we shouldn't inject any elements. See the comment in UIComponent.
+      Tween::fade = Tween::stop = Tween::updateStyle = ->
+      return
+
     @styleElement.type = "text/css"
     @styleElement.innerHTML = ""
     insertionPoint.appendChild @styleElement

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -7,6 +7,14 @@ class UIComponent
 
   constructor: (iframeUrl, className, @handleMessage) ->
     styleSheet = document.createElement "style"
+
+    # If this is an XML document, nothing we do here works:
+    # * <style> elements show their contents inline,
+    # * <iframe> elements don't load any content,
+    # * document.createElement generates elements that have style == null and ignore CSS.
+    # We bail here if this is the case so we're polluting the DOM to no or negative effect.
+    return unless styleSheet.style
+
     styleSheet.type = "text/css"
     # Default to everything hidden while the stylesheet loads.
     styleSheet.innerHTML = "@import url(\"#{chrome.runtime.getURL("content_scripts/vimium.css")}\");"

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -8,12 +8,16 @@ class UIComponent
   constructor: (iframeUrl, className, @handleMessage) ->
     styleSheet = document.createElement "style"
 
-    # If this is an XML document, nothing we do here works:
-    # * <style> elements show their contents inline,
-    # * <iframe> elements don't load any content,
-    # * document.createElement generates elements that have style == null and ignore CSS.
-    # We bail here if this is the case so we're polluting the DOM to no or negative effect.
-    return unless styleSheet.style
+    unless styleSheet.style
+      # If this is an XML document, nothing we do here works:
+      # * <style> elements show their contents inline,
+      # * <iframe> elements don't load any content,
+      # * document.createElement generates elements that have style == null and ignore CSS.
+      # If this is the case we don't want to pollute the DOM to no or negative effect.  So we bail
+      # immediately, and disable all externally-called methods.
+      @postMessage = @activate = @show = @hide = ->
+        console.log "This vimium feature is disabled because it is incompatible with this page."
+      return
 
     styleSheet.type = "text/css"
     # Default to everything hidden while the stylesheet loads.


### PR DESCRIPTION
This is #1647, with improvements. From there:

> If the page is an XML document, nothing we do works:
* `<style>` elements show their contents inline,
* `<iframe>` elements don't load any content,
* `document.createElement` generates elements that
  - have `element.style == null`, and
  - ignore CSS.

> This PR stops us from injecting anything into the DOM from `UIComponent`, fixing #1640.