### PR TITLE
Add a link to the wiki on the help page.

### DIFF
--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -208,13 +208,18 @@ div#vimiumHelpDialog a {
   text-decoration: underline;
 }
 
-div#vimiumHelpDialog .optionsPage {
+div#vimiumHelpDialog .wikiPage, div#vimiumHelpDialog .optionsPage {
   position: absolute;
   display: block;
   font-size: 11px;
   line-height: 130%;
-  right: 60px;
-  top: 8px;
+  top: 6px;
+}
+div#vimiumHelpDialog .optionsPage {
+  right: 40px;
+}
+div#vimiumHelpDialog .wikiPage {
+  right: 83px;
 }
 div#vimiumHelpDialog a.closeButton:hover {
   color:black;

--- a/pages/help_dialog.html
+++ b/pages/help_dialog.html
@@ -7,6 +7,7 @@
        page with the up-to-date key bindings when the dialog is shown. -->
   <div id="vimiumHelpDialog" class="vimiumReset">
   <a class="vimiumReset optionsPage" href="#">Options</a>
+  <a class="vimiumReset wikiPage" href="https://github.com/philc/vimium/wiki" target="_blank">Wiki</a>
   <a class="vimiumReset closeButton" href="#">&times;</a>
   <div id="vimiumTitle" class="vimiumReset"><span class="vimiumReset" style="color:#2f508e">Vim</span>ium {{title}}</div>
   <div class="vimiumReset vimiumColumn">


### PR DESCRIPTION
Looks like this...

![snapshot](https://cloud.githubusercontent.com/assets/2641335/7896103/d2c30cde-06a5-11e5-9892-a787e4438947.png)

Wiki opens in a new tab.

As suggested in by @LarryBattle in #1643.