### PR TITLE
Move Vomnibar commands to own category on help page.

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -121,19 +121,20 @@ Commands =
       "LinkHints.activateModeWithQueue",
       "LinkHints.activateModeToDownloadLink",
       "LinkHints.activateModeToOpenIncognito",
-      "Vomnibar.activate",
-      "Vomnibar.activateInNewTab",
-      "Vomnibar.activateTabSelection",
-      "Vomnibar.activateBookmarks",
-      "Vomnibar.activateBookmarksInNewTab",
       "goPrevious",
       "goNext",
       "nextFrame",
       "mainFrame",
       "Marks.activateCreateMode",
-      "Vomnibar.activateEditUrl",
-      "Vomnibar.activateEditUrlInNewTab",
       "Marks.activateGotoMode"]
+    vomnibarCommands:
+      ["Vomnibar.activate",
+      "Vomnibar.activateInNewTab",
+      "Vomnibar.activateTabSelection",
+      "Vomnibar.activateBookmarks",
+      "Vomnibar.activateBookmarksInNewTab",
+      "Vomnibar.activateEditUrl",
+      "Vomnibar.activateEditUrlInNewTab"]
     findCommands: ["enterFindMode", "performFind", "performBackwardsFind"]
     historyNavigation:
       ["goBack", "goForward"]

--- a/pages/help_dialog.html
+++ b/pages/help_dialog.html
@@ -20,6 +20,8 @@
   <div class="vimiumReset vimiumColumn">
     <table class="vimiumReset" >
       <tbody class="vimiumReset">
+      <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Using the vomnibar</td></tr>
+      {{vomnibarCommands}}
       <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Using find</td></tr>
       {{findCommands}}
       <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Navigating history</td></tr>


### PR DESCRIPTION
The help page gets pretty lopsided when advanced commands are shown.  This balances things out a bit by creating a new category for Vomnibar commands in the right-hand column.  Like this...

![snapshot](https://cloud.githubusercontent.com/assets/2641335/7896824/7b8922b0-06bd-11e5-89ca-33e920e88c7e.png)

We could break up that left-hand column a bit, too.  Perhaps separate out the scrolling commands.