### PR TITLE
Completion for google maps

### DIFF
--- a/background_scripts/completion_engines.coffee
+++ b/background_scripts/completion_engines.coffee
@@ -26,7 +26,6 @@ class RegexpEngine
 
 # Several Google completion engines package XML responses in this way.
 class GoogleXMLRegexpEngine extends RegexpEngine
-  doNotCache: false # true (disbaled, experimental)
   parse: (xhr) ->
     for suggestion in xhr.responseXML.getElementsByTagName "suggestion"
       continue unless suggestion = suggestion.getAttribute "data"
@@ -38,7 +37,6 @@ class Google extends GoogleXMLRegexpEngine
     regexps ?= [
       # We match the major English-speaking TLDs.
       new RegExp "^https?://[a-z]+\.google\.(com|ie|co\.uk|ca|com\.au)/"
-      new RegExp "localhost/cgi-bin/booky" # Only for smblott.
       ]
     super regexps
 
@@ -77,7 +75,6 @@ class Youtube extends GoogleXMLRegexpEngine
       "http://suggestqueries.google.com/complete/search?client=youtube&ds=yt&xml=t&q=%s"
 
 class Wikipedia extends RegexpEngine
-  doNotCache: false # true (disbaled, experimental)
   # Example search URL: http://www.wikipedia.org/w/index.php?title=Special:Search&search=%s
   constructor: ->
     super [ new RegExp "^https?://[a-z]+\.wikipedia\.org/" ]

--- a/background_scripts/completion_engines.coffee
+++ b/background_scripts/completion_engines.coffee
@@ -21,7 +21,7 @@
 
 # A base class for common regexp-based matching engines.
 class RegexpEngine
-  constructor: (args...) -> @regexps = args
+  constructor: (args...) -> @regexps = args.map (regexp) -> new RegExp regexp
   match: (searchUrl) -> Utils.matchesAnyRegexp @regexps, searchUrl
 
 # Several Google completion engines package XML responses in this way.
@@ -34,7 +34,7 @@ class GoogleXMLRegexpEngine extends RegexpEngine
 class Google extends GoogleXMLRegexpEngine
   # Example search URL: http://www.google.com/search?q=%s
   constructor: (regexps = null) ->
-    super regexps ? new RegExp "^https?://[a-z]+\.google\.(com|ie|co\.uk|ca|com\.au)/"
+    super regexps ? "^https?://[a-z]+\.google\.(com|ie|co\.uk|ca|com\.au)/"
 
   getUrl: (queryTerms) ->
     Utils.createSearchUrl queryTerms,
@@ -59,12 +59,12 @@ class GoogleWithPrefix
 # then strip "map of" from the resulting suggestions.
 class GoogleMaps extends GoogleWithPrefix
   # Example search URL: https://www.google.com/maps?q=%s
-  constructor: -> super "map of", new RegExp "https?://[a-z]+\.google\.(com|ie|co\.uk|ca|com\.au)/maps"
+  constructor: -> super "map of", "https?://[a-z]+\.google\.(com|ie|co\.uk|ca|com\.au)/maps"
 
 class Youtube extends GoogleXMLRegexpEngine
   # Example search URL: http://www.youtube.com/results?search_query=%s
   constructor: ->
-    super new RegExp "^https?://[a-z]+\.youtube\.com/results"
+    super "^https?://[a-z]+\.youtube\.com/results"
 
   getUrl: (queryTerms) ->
     Utils.createSearchUrl queryTerms,
@@ -73,7 +73,7 @@ class Youtube extends GoogleXMLRegexpEngine
 class Wikipedia extends RegexpEngine
   # Example search URL: http://www.wikipedia.org/w/index.php?title=Special:Search&search=%s
   constructor: ->
-    super new RegExp "^https?://[a-z]+\.wikipedia\.org/"
+    super "^https?://[a-z]+\.wikipedia\.org/"
 
   getUrl: (queryTerms) ->
     Utils.createSearchUrl queryTerms,
@@ -84,13 +84,13 @@ class Wikipedia extends RegexpEngine
 
 class Bing extends RegexpEngine
   # Example search URL: https://www.bing.com/search?q=%s
-  constructor: -> super new RegExp "^https?://www\.bing\.com/search"
+  constructor: -> super "^https?://www\.bing\.com/search"
   getUrl: (queryTerms) -> Utils.createSearchUrl queryTerms, "http://api.bing.com/osjson.aspx?query=%s"
   parse: (xhr) -> JSON.parse(xhr.responseText)[1]
 
 class Amazon extends RegexpEngine
   # Example search URL: http://www.amazon.com/s/?field-keywords=%s
-  constructor: -> super new RegExp "^https?://www\.amazon\.(com|co.uk|ca|com.au)/s/"
+  constructor: -> super "^https?://www\.amazon\.(com|co.uk|ca|com.au)/s/"
   getUrl: (queryTerms) ->
     Utils.createSearchUrl queryTerms,
       "https://completion.amazon.com/search/complete?method=completion&search-alias=aps&client=amazon-search-ui&mkt=1&q=%s"
@@ -98,15 +98,14 @@ class Amazon extends RegexpEngine
 
 class DuckDuckGo extends RegexpEngine
   # Example search URL: https://duckduckgo.com/?q=%s
-  constructor: -> super new RegExp "^https?://([a-z]+\.)?duckduckgo\.com/"
-  getUrl: (queryTerms) ->
+  constructor: -> super "^https?://([a-z]+\.)?duckduckgo\.com/"
   getUrl: (queryTerms) -> Utils.createSearchUrl queryTerms, "https://duckduckgo.com/ac/?q=%s"
   parse: (xhr) ->
     suggestion.phrase for suggestion in JSON.parse xhr.responseText
 
 class Webster extends RegexpEngine
   # Example search URL: http://www.merriam-webster.com/dictionary/%s
-  constructor: -> super new RegExp "^https?://www.merriam-webster.com/dictionary/"
+  constructor: -> super "^https?://www.merriam-webster.com/dictionary/"
   getUrl: (queryTerms) -> Utils.createSearchUrl queryTerms, "http://www.merriam-webster.com/autocomplete?query=%s"
   parse: (xhr) -> JSON.parse(xhr.responseText).suggestions
 

--- a/background_scripts/completion_engines.coffee
+++ b/background_scripts/completion_engines.coffee
@@ -21,7 +21,7 @@
 
 # A base class for common regexp-based matching engines.
 class RegexpEngine
-  constructor: (@regexps) ->
+  constructor: (args...) -> @regexps = args
   match: (searchUrl) -> Utils.matchesAnyRegexp @regexps, searchUrl
 
 # Several Google completion engines package XML responses in this way.
@@ -34,11 +34,7 @@ class GoogleXMLRegexpEngine extends RegexpEngine
 class Google extends GoogleXMLRegexpEngine
   # Example search URL: http://www.google.com/search?q=%s
   constructor: (regexps = null) ->
-    regexps ?= [
-      # We match the major English-speaking TLDs.
-      new RegExp "^https?://[a-z]+\.google\.(com|ie|co\.uk|ca|com\.au)/"
-      ]
-    super regexps
+    super regexps ? new RegExp "^https?://[a-z]+\.google\.(com|ie|co\.uk|ca|com\.au)/"
 
   getUrl: (queryTerms) ->
     Utils.createSearchUrl queryTerms,
@@ -63,12 +59,12 @@ class GoogleWithPrefix
 # then strip "map of" from the resulting suggestions.
 class GoogleMaps extends GoogleWithPrefix
   # Example search URL: https://www.google.com/maps?q=%s
-  constructor: -> super "map of", [ new RegExp "https?://[a-z]+\.google\.(com|ie|co\.uk|ca|com\.au)/maps" ]
+  constructor: -> super "map of", new RegExp "https?://[a-z]+\.google\.(com|ie|co\.uk|ca|com\.au)/maps"
 
 class Youtube extends GoogleXMLRegexpEngine
   # Example search URL: http://www.youtube.com/results?search_query=%s
   constructor: ->
-    super [ new RegExp "^https?://[a-z]+\.youtube\.com/results" ]
+    super new RegExp "^https?://[a-z]+\.youtube\.com/results"
 
   getUrl: (queryTerms) ->
     Utils.createSearchUrl queryTerms,
@@ -77,7 +73,7 @@ class Youtube extends GoogleXMLRegexpEngine
 class Wikipedia extends RegexpEngine
   # Example search URL: http://www.wikipedia.org/w/index.php?title=Special:Search&search=%s
   constructor: ->
-    super [ new RegExp "^https?://[a-z]+\.wikipedia\.org/" ]
+    super new RegExp "^https?://[a-z]+\.wikipedia\.org/"
 
   getUrl: (queryTerms) ->
     Utils.createSearchUrl queryTerms,
@@ -88,13 +84,13 @@ class Wikipedia extends RegexpEngine
 
 class Bing extends RegexpEngine
   # Example search URL: https://www.bing.com/search?q=%s
-  constructor: -> super [ new RegExp "^https?://www\.bing\.com/search" ]
+  constructor: -> super new RegExp "^https?://www\.bing\.com/search"
   getUrl: (queryTerms) -> Utils.createSearchUrl queryTerms, "http://api.bing.com/osjson.aspx?query=%s"
   parse: (xhr) -> JSON.parse(xhr.responseText)[1]
 
 class Amazon extends RegexpEngine
   # Example search URL: http://www.amazon.com/s/?field-keywords=%s
-  constructor: -> super [ new RegExp "^https?://www\.amazon\.(com|co.uk|ca|com.au)/s/" ]
+  constructor: -> super new RegExp "^https?://www\.amazon\.(com|co.uk|ca|com.au)/s/"
   getUrl: (queryTerms) ->
     Utils.createSearchUrl queryTerms,
       "https://completion.amazon.com/search/complete?method=completion&search-alias=aps&client=amazon-search-ui&mkt=1&q=%s"
@@ -102,7 +98,7 @@ class Amazon extends RegexpEngine
 
 class DuckDuckGo extends RegexpEngine
   # Example search URL: https://duckduckgo.com/?q=%s
-  constructor: -> super [ new RegExp "^https?://([a-z]+\.)?duckduckgo\.com/" ]
+  constructor: -> super new RegExp "^https?://([a-z]+\.)?duckduckgo\.com/"
   getUrl: (queryTerms) ->
   getUrl: (queryTerms) -> Utils.createSearchUrl queryTerms, "https://duckduckgo.com/ac/?q=%s"
   parse: (xhr) ->
@@ -110,7 +106,7 @@ class DuckDuckGo extends RegexpEngine
 
 class Webster extends RegexpEngine
   # Example search URL: http://www.merriam-webster.com/dictionary/%s
-  constructor: -> super [ new RegExp "^https?://www.merriam-webster.com/dictionary/" ]
+  constructor: -> super new RegExp "^https?://www.merriam-webster.com/dictionary/"
   getUrl: (queryTerms) -> Utils.createSearchUrl queryTerms, "http://www.merriam-webster.com/autocomplete?query=%s"
   parse: (xhr) -> JSON.parse(xhr.responseText).suggestions
 


### PR DESCRIPTION
This adds search completion for Google Maps.  For example:

    gm: https://www.google.ie/maps?q=%s Google maps
    gm: https://www.google.com/maps?q=%s Google maps

(It also does some refactoring to simplify the specification of completion engines.)