### PR TITLE
Completion engine page

### DIFF
--- a/background_scripts/completion_engines.coffee
+++ b/background_scripts/completion_engines.coffee
@@ -43,15 +43,15 @@ class Google extends GoogleXMLRegexpEngine
 # A wrapper class for Google completions.  This adds prefix terms to the query, and strips those terms from
 # the resulting suggestions.  For example, for Google Maps, we add "map of" as a prefix, then strip "map of"
 # from the resulting suggestions.
-class GoogleWithPrefix
+class GoogleWithPrefix extends Google
   constructor: (prefix, args...) ->
-    @engine = new Google args...
-    @prefix = "#{prefix.trim()} "
-    @queryTerms = @prefix.split /\s+/
-  match: (args...) -> @engine.match args...
-  getUrl: (queryTerms) -> @engine.getUrl [ @queryTerms..., queryTerms... ]
+    super args...
+    prefix = prefix.trim()
+    @prefix = "#{prefix} "
+    @queryTerms = prefix.split /\s+/
+  getUrl: (queryTerms) -> super [ @queryTerms..., queryTerms... ]
   parse: (xhr) ->
-    @engine.parse(xhr)
+    super(xhr)
       .filter (suggestion) => suggestion.startsWith @prefix
       .map (suggestion) => suggestion[@prefix.length..].ltrim()
 

--- a/background_scripts/completion_engines.coffee
+++ b/background_scripts/completion_engines.coffee
@@ -34,7 +34,8 @@ class GoogleXMLRegexpEngine extends RegexpEngine
 class Google extends GoogleXMLRegexpEngine
   constructor: (regexps = null) ->
     super regexps ? "^https?://[a-z]+\\.google\\.(com|ie|co\\.uk|ca|com\\.au)/"
-    @example = "http://www.google.com/search?q=%s"
+    @exampleSearchUrl = "http://www.google.com/search?q=%s"
+    @exampleKeyword = "m"
 
   getUrl: (queryTerms) ->
     Utils.createSearchUrl queryTerms,
@@ -60,12 +61,15 @@ class GoogleWithPrefix extends Google
 class GoogleMaps extends GoogleWithPrefix
   constructor: ->
     super "map of", "^https?://[a-z]+\\.google\\.(com|ie|co\\.uk|ca|com\\.au)/maps"
-    @example = "https://www.google.com/maps?q=%s"
+    @exampleSearchUrl = "https://www.google.com/maps?q=%s"
+    @exampleKeyword = "m"
+    @exampleDescription = "Google maps"
 
 class Youtube extends GoogleXMLRegexpEngine
   constructor: ->
     super "^https?://[a-z]+\\.youtube\\.com/results"
-    @example = "http://www.youtube.com/results?search_query=%s"
+    @exampleSearchUrl = "http://www.youtube.com/results?search_query=%s"
+    @exampleKeyword = "y"
 
   getUrl: (queryTerms) ->
     Utils.createSearchUrl queryTerms,
@@ -74,7 +78,8 @@ class Youtube extends GoogleXMLRegexpEngine
 class Wikipedia extends RegexpEngine
   constructor: ->
     super "^https?://[a-z]+\\.wikipedia\\.org/"
-    @example = "http://www.wikipedia.org/w/index.php?title=Special:Search&search=%s"
+    @exampleSearchUrl = "http://www.wikipedia.org/w/index.php?title=Special:Search&search=%s"
+    @exampleKeyword = "y"
 
   getUrl: (queryTerms) ->
     Utils.createSearchUrl queryTerms,
@@ -84,17 +89,18 @@ class Wikipedia extends RegexpEngine
     JSON.parse(xhr.responseText)[1]
 
 class Bing extends RegexpEngine
-  # Example search URL: https://www.bing.com/search?q=%s
   constructor: ->
     super "^https?://www\\.bing\\.com/search"
-    @example = "https://www.bing.com/search?q=%s"
+    @exampleSearchUrl = "https://www.bing.com/search?q=%s"
+    @exampleKeyword = "b"
   getUrl: (queryTerms) -> Utils.createSearchUrl queryTerms, "http://api.bing.com/osjson.aspx?query=%s"
   parse: (xhr) -> JSON.parse(xhr.responseText)[1]
 
 class Amazon extends RegexpEngine
   constructor: ->
     super "^https?://www\\.amazon\\.(com|co\\.uk|ca|com\\.au)/s/"
-    @example = "http://www.amazon.com/s/?field-keywords=%s"
+    @exampleSearchUrl = "http://www.amazon.com/s/?field-keywords=%s"
+    @exampleKeyword = "a"
   getUrl: (queryTerms) ->
     Utils.createSearchUrl queryTerms,
       "https://completion.amazon.com/search/complete?method=completion&search-alias=aps&client=amazon-search-ui&mkt=1&q=%s"
@@ -103,7 +109,8 @@ class Amazon extends RegexpEngine
 class DuckDuckGo extends RegexpEngine
   constructor: ->
     super "^https?://([a-z]+\\.)?duckduckgo\\.com/"
-    @example = "https://duckduckgo.com/?q=%s"
+    @exampleSearchUrl = "https://duckduckgo.com/?q=%s"
+    @exampleKeyword = "d"
   getUrl: (queryTerms) -> Utils.createSearchUrl queryTerms, "https://duckduckgo.com/ac/?q=%s"
   parse: (xhr) ->
     suggestion.phrase for suggestion in JSON.parse xhr.responseText
@@ -111,7 +118,9 @@ class DuckDuckGo extends RegexpEngine
 class Webster extends RegexpEngine
   constructor: ->
     super "^https?://www.merriam-webster.com/dictionary/"
-    @example = "http://www.merriam-webster.com/dictionary/%s"
+    @exampleSearchUrl = "http://www.merriam-webster.com/dictionary/%s"
+    @exampleKeyword = "dw"
+    @exampleDescription = "Dictionary"
   getUrl: (queryTerms) -> Utils.createSearchUrl queryTerms, "http://www.merriam-webster.com/autocomplete?query=%s"
   parse: (xhr) -> JSON.parse(xhr.responseText).suggestions
 

--- a/background_scripts/completion_engines.coffee
+++ b/background_scripts/completion_engines.coffee
@@ -32,9 +32,9 @@ class GoogleXMLRegexpEngine extends RegexpEngine
       suggestion
 
 class Google extends GoogleXMLRegexpEngine
-  # Example search URL: http://www.google.com/search?q=%s
   constructor: (regexps = null) ->
     super regexps ? "^https?://[a-z]+\\.google\\.(com|ie|co\\.uk|ca|com\\.au)/"
+    @example = "http://www.google.com/search?q=%s"
 
   getUrl: (queryTerms) ->
     Utils.createSearchUrl queryTerms,
@@ -58,22 +58,23 @@ class GoogleWithPrefix extends Google
 # For Google Maps, we add the prefix "map of" to the query, and send it to Google's general search engine,
 # then strip "map of" from the resulting suggestions.
 class GoogleMaps extends GoogleWithPrefix
-  # Example search URL: https://www.google.com/maps?q=%s
-  constructor: -> super "map of", "^https?://[a-z]+\\.google\\.(com|ie|co\\.uk|ca|com\\.au)/maps"
+  constructor: ->
+    super "map of", "^https?://[a-z]+\\.google\\.(com|ie|co\\.uk|ca|com\\.au)/maps"
+    @example = "https://www.google.com/maps?q=%s"
 
 class Youtube extends GoogleXMLRegexpEngine
-  # Example search URL: http://www.youtube.com/results?search_query=%s
   constructor: ->
     super "^https?://[a-z]+\\.youtube\\.com/results"
+    @example = "http://www.youtube.com/results?search_query=%s"
 
   getUrl: (queryTerms) ->
     Utils.createSearchUrl queryTerms,
       "http://suggestqueries.google.com/complete/search?client=youtube&ds=yt&xml=t&q=%s"
 
 class Wikipedia extends RegexpEngine
-  # Example search URL: http://www.wikipedia.org/w/index.php?title=Special:Search&search=%s
   constructor: ->
     super "^https?://[a-z]+\\.wikipedia\\.org/"
+    @example = "http://www.wikipedia.org/w/index.php?title=Special:Search&search=%s"
 
   getUrl: (queryTerms) ->
     Utils.createSearchUrl queryTerms,
@@ -84,28 +85,33 @@ class Wikipedia extends RegexpEngine
 
 class Bing extends RegexpEngine
   # Example search URL: https://www.bing.com/search?q=%s
-  constructor: -> super "^https?://www\\.bing\\.com/search"
+  constructor: ->
+    super "^https?://www\\.bing\\.com/search"
+    @example = "https://www.bing.com/search?q=%s"
   getUrl: (queryTerms) -> Utils.createSearchUrl queryTerms, "http://api.bing.com/osjson.aspx?query=%s"
   parse: (xhr) -> JSON.parse(xhr.responseText)[1]
 
 class Amazon extends RegexpEngine
-  # Example search URL: http://www.amazon.com/s/?field-keywords=%s
-  constructor: -> super "^https?://www\\.amazon\\.(com|co\\.uk|ca|com\\.au)/s/"
+  constructor: ->
+    super "^https?://www\\.amazon\\.(com|co\\.uk|ca|com\\.au)/s/"
+    @example = "http://www.amazon.com/s/?field-keywords=%s"
   getUrl: (queryTerms) ->
     Utils.createSearchUrl queryTerms,
       "https://completion.amazon.com/search/complete?method=completion&search-alias=aps&client=amazon-search-ui&mkt=1&q=%s"
   parse: (xhr) -> JSON.parse(xhr.responseText)[1]
 
 class DuckDuckGo extends RegexpEngine
-  # Example search URL: https://duckduckgo.com/?q=%s
-  constructor: -> super "^https?://([a-z]+\\.)?duckduckgo\\.com/"
+  constructor: ->
+    super "^https?://([a-z]+\\.)?duckduckgo\\.com/"
+    @example = "https://duckduckgo.com/?q=%s"
   getUrl: (queryTerms) -> Utils.createSearchUrl queryTerms, "https://duckduckgo.com/ac/?q=%s"
   parse: (xhr) ->
     suggestion.phrase for suggestion in JSON.parse xhr.responseText
 
 class Webster extends RegexpEngine
-  # Example search URL: http://www.merriam-webster.com/dictionary/%s
-  constructor: -> super "^https?://www.merriam-webster.com/dictionary/"
+  constructor: ->
+    super "^https?://www.merriam-webster.com/dictionary/"
+    @example = "http://www.merriam-webster.com/dictionary/%s"
   getUrl: (queryTerms) -> Utils.createSearchUrl queryTerms, "http://www.merriam-webster.com/autocomplete?query=%s"
   parse: (xhr) -> JSON.parse(xhr.responseText).suggestions
 

--- a/manifest.json
+++ b/manifest.json
@@ -72,6 +72,7 @@
   "web_accessible_resources": [
     "pages/vomnibar.html",
     "content_scripts/vimium.css",
-    "pages/hud.html"
+    "pages/hud.html",
+    "pages/completion_engines.html"
   ]
 }

--- a/pages/completion_engines.coffee
+++ b/pages/completion_engines.coffee
@@ -1,0 +1,2 @@
+
+console.log "hello"

--- a/pages/completion_engines.coffee
+++ b/pages/completion_engines.coffee
@@ -6,27 +6,27 @@ cleanUpRegexp = (re) ->
     .replace /\\\//g, "/"
 
 DomUtils.documentReady ->
-  html = ""
+  html = []
   for engine in CompletionEngines[0...CompletionEngines.length-1]
     engine = new engine
-    html += "<h4>#{engine.constructor.name}</h4>\n"
-    html += "<div class=\"engine\">"
+    html.push "<h4>#{engine.constructor.name}</h4>\n"
+    html.push "<div class=\"engine\">"
     if engine.regexps
-      html += "<pre>"
-      html += "#{cleanUpRegexp re}\n" for re in engine.regexps
-      html += "</pre>"
+      html.push "<pre>"
+      html.push "#{cleanUpRegexp re}\n" for re in engine.regexps
+      html.push "</pre>"
     if engine.prefix
-      html += "<p>This uses the general Google completion engine, but adds the prefix \"<tt>#{engine.prefix.trim()}</tt>\" to the query.</p>"
+      html.push "<p>This uses the general Google completion engine, but adds the prefix \"<tt>#{engine.prefix.trim()}</tt>\" to the query.</p>"
     if engine.exampleSearchUrl and engine.exampleKeyword
       engine.exampleDescription ||= engine.constructor.name
-      html += "<p>"
-      html += "Example:"
-      html += "<pre>"
-      html += "#{engine.exampleKeyword}: #{engine.exampleSearchUrl} #{engine.exampleDescription}"
-      html += "</pre>"
-      html += "</p>"
-    html += "</div>"
+      html.push "<p>"
+      html.push "Example:"
+      html.push "<pre>"
+      html.push "#{engine.exampleKeyword}: #{engine.exampleSearchUrl} #{engine.exampleDescription}"
+      html.push "</pre>"
+      html.push "</p>"
+    html.push "</div>"
 
-  document.getElementById("engineList").innerHTML = html
+  document.getElementById("engineList").innerHTML = html.join ""
 
 

--- a/pages/completion_engines.coffee
+++ b/pages/completion_engines.coffee
@@ -17,9 +17,13 @@ DomUtils.documentReady ->
       html += "</pre>"
     if engine.prefix
       html += "<p>This uses the general Google completion engine, but adds the prefix \"<tt>#{engine.prefix.trim()}</tt>\" to the query.</p>"
-    if engine.example
+    if engine.exampleSearchUrl and engine.exampleKeyword
+      engine.exampleDescription ||= engine.constructor.name
       html += "<p>"
-      html += "Example search URL: \"<tt>#{engine.example}</tt>\"."
+      html += "Example:"
+      html += "<pre>"
+      html += "#{engine.exampleKeyword}: #{engine.exampleSearchUrl} #{engine.exampleDescription}"
+      html += "</pre>"
       html += "</p>"
     html += "</div>"
 

--- a/pages/completion_engines.coffee
+++ b/pages/completion_engines.coffee
@@ -1,4 +1,10 @@
 
+cleanUpRegexp = (re) ->
+  re.toString()
+    .replace /^\//, ''
+    .replace /\/$/, ''
+    .replace /\\\//g, "/"
+
 DomUtils.documentReady ->
   html = ""
   for engine in CompletionEngines[0...CompletionEngines.length-1]
@@ -7,9 +13,7 @@ DomUtils.documentReady ->
     html += "<div class=\"engine\">"
     if engine.regexps
       html += "<pre>"
-      for re in engine.regexps
-        re = re.toString().replace(/^\//, '').replace /\/$/, ''
-        html += "#{re}\n"
+      html += "#{cleanUpRegexp re}\n" for re in engine.regexps
       html += "</pre>"
     if engine.prefix
       html += "<p>This uses the general Google completion engine, but adds the prefix \"<tt>#{engine.prefix.trim()}</tt>\" to the query.</p>"

--- a/pages/completion_engines.coffee
+++ b/pages/completion_engines.coffee
@@ -1,1 +1,20 @@
 
+DomUtils.documentReady ->
+  html = ""
+  for engine in CompletionEngines[0...CompletionEngines.length-1]
+    engine = new engine
+    html += "<h4>#{engine.constructor.name}</h4>\n"
+    html += "<div class=\"engine\">"
+    if engine.regexps
+      html += "<pre>"
+      for re in engine.regexps
+        re = re.toString().replace(/^\//, '').replace /\/$/, ''
+        html += "#{re}\n"
+      html += "</pre>"
+    if engine.prefix
+      html += "<p>This uses the general Google completion engine, but adds the prefix \"<tt>#{engine.prefix.trim()}</tt>\" to the query.</p>"
+    html += "</div>"
+
+  document.getElementById("engineList").innerHTML = html
+
+

--- a/pages/completion_engines.coffee
+++ b/pages/completion_engines.coffee
@@ -17,6 +17,10 @@ DomUtils.documentReady ->
       html += "</pre>"
     if engine.prefix
       html += "<p>This uses the general Google completion engine, but adds the prefix \"<tt>#{engine.prefix.trim()}</tt>\" to the query.</p>"
+    if engine.example
+      html += "<p>"
+      html += "Example search URL: \"<tt>#{engine.example}</tt>\"."
+      html += "</p>"
     html += "</div>"
 
   document.getElementById("engineList").innerHTML = html

--- a/pages/completion_engines.coffee
+++ b/pages/completion_engines.coffee
@@ -1,2 +1,1 @@
 
-console.log "hello"

--- a/pages/completion_engines.css
+++ b/pages/completion_engines.css
@@ -1,0 +1,15 @@
+
+div#wrapper
+{
+  width: 730px;
+}
+
+h4, h5
+{
+   color: #777;
+}
+
+div.engine
+{
+  margin-left: 20px;
+}

--- a/pages/completion_engines.html
+++ b/pages/completion_engines.html
@@ -1,0 +1,30 @@
+<html>
+  <head>
+    <title>Vimium Search Completion</title>
+    <!-- We re-use some styling from the options page, so that the look and feel here is similar -->
+    <link rel="stylesheet" type="text/css" href="options.css">
+    <script src="content_script_loader.js"></script>
+    <script type="text/javascript" src="../lib/settings.js"></script>
+    <script src="completion_engines.js"></script>
+  </head>
+
+  <body>
+    <div id="wrapper">
+      <header>Vimium Search Completion</header>
+      <p>
+        Search completion is available for custom search engines whose search URL matches one of Vimium's
+        built-in completion engines.  Search completion is not available for the default search engine.
+      </p>
+      <p>
+        Custom search engines are configured on the <a href="options.html">options</a> page.
+      </p>
+      <header>Available Completion Engines</header>
+      <p>
+        The following completion engines are available.
+        <dl id="engineList">
+          {{{ENGINES}}}
+        </dl>
+      </p>
+    </div>
+  </body>
+</html>

--- a/pages/completion_engines.html
+++ b/pages/completion_engines.html
@@ -3,8 +3,10 @@
     <title>Vimium Search Completion</title>
     <!-- We re-use some styling from the options page, so that the look and feel here is similar -->
     <link rel="stylesheet" type="text/css" href="options.css">
+    <link rel="stylesheet" type="text/css" href="completion_engines.css">
     <script src="content_script_loader.js"></script>
     <script type="text/javascript" src="../lib/settings.js"></script>
+    <script src="../background_scripts/completion_engines.js"></script>
     <script src="completion_engines.js"></script>
   </head>
 
@@ -13,17 +15,17 @@
       <header>Vimium Search Completion</header>
       <p>
         Search completion is available for custom search engines whose search URL matches one of Vimium's
-        built-in completion engines.  Search completion is not available for the default search engine.
+        built-in completion engines; that is, the search URL matches one of the regular expressions below.
+        Search completion is not available for the default search engine.
       </p>
       <p>
-        Custom search engines are configured on the <a href="options.html">options</a> page.
+        Custom search engines can be configured on the <a href="options.html" target="_blank">options</a>
+        page. <br/>
+        Further information is available on the <a href="https://github.com/philc/vimium/wiki/Search-Completion">wiki</a>.
       </p>
       <header>Available Completion Engines</header>
       <p>
-        The following completion engines are available.
-        <dl id="engineList">
-          {{{ENGINES}}}
-        </dl>
+        <dl id="engineList"></dl>
       </p>
     </div>
   </body>

--- a/pages/options.css
+++ b/pages/options.css
@@ -114,7 +114,7 @@ input#scrollStepSize, input#omniSearchWeight {
 }
 textarea#userDefinedLinkHintCss, textarea#keyMappings, textarea#searchEngines {
   width: 100%;;
-  min-height: 130px;
+  min-height: 140px;
   white-space: nowrap;
 }
 input#previousPatterns, input#nextPatterns {

--- a/pages/options.html
+++ b/pages/options.html
@@ -44,7 +44,7 @@ unmap j
 unmapAll
 " this is a comment
 # this is also a comment</pre>
-                <a href="#" id="showCommands">Show available commands.</a>
+                <a href="#" id="showCommands">Show available commands</a>.
               </div>
             </div>
             <textarea id="keyMappings" type="text"></textarea>
@@ -61,7 +61,8 @@ a: http://a.com/?q=%s
 b: http://b.com/?q=%s description
 " this is a comment
 # this is also a comment</pre>
-                  %s is replaced with the search terms.
+                  %s is replaced with the search terms. <br/>
+                  For search completion, see <a href="completion_engines.html" target="_blank">here</a>.
                 </div>
               </div>
               <textarea id="searchEngines"></textarea>


### PR DESCRIPTION
#1703, but done better.

Add *built-in* documentation of the available completion engines.  The documentation is generated on-the-fly from the actual completion engines themselves.

The documentation page looks like this...

![150531-03-snapshot](https://cloud.githubusercontent.com/assets/2641335/7902195/6c4e219c-07a8-11e5-87a3-6036eb86617d.png)

It is accessed from the link at the bottom right, here...

![snapshot](https://cloud.githubusercontent.com/assets/2641335/7902196/873dd48e-07a8-11e5-910f-4c93943924a8.png)

Edit: eabf8f9df81a511c971c2b3cb7ab1cedf476aff9 tidies up the regular expressions so that we don't have all of those unnecessary backslashes.