### PR TITLE
Unified settings implementation

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -217,20 +217,6 @@ selectSpecificTab = (request) ->
     chrome.windows.update(tab.windowId, { focused: true })
     chrome.tabs.update(request.id, { selected: true }))
 
-#
-# Used by the content scripts to get settings from the local storage.
-#
-handleSettings = (request, port) ->
-  switch request.operation
-    when "get" # Get a single settings value.
-      port.postMessage key: request.key, value: Settings.get request.key
-    when "set" # Set a single settings value.
-      Settings.set request.key, request.value
-    when "fetch" # Fetch multiple settings values.
-      values = request.values
-      values[key] = Settings.get key for own key of values
-      port.postMessage { values }
-
 chrome.tabs.onSelectionChanged.addListener (tabId, selectionInfo) ->
   if (selectionChangedHandlers.length > 0)
     selectionChangedHandlers.pop().call()
@@ -650,7 +636,6 @@ bgLog = (request, sender) ->
 # Port handler mapping
 portHandlers =
   keyDown: handleKeyDown,
-  settings: handleSettings,
   completions: handleCompletions
 
 sendRequestHandlers =

--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -48,7 +48,7 @@ HUD =
     -> ready and document.body != null
 
   # A preference which can be toggled in the Options page. */
-  enabled: -> !settings.get("hideHud")
+  enabled: -> !Settings.get("hideHud")
 
 class Tween
   opacity: 0

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -29,7 +29,7 @@ LinkHints =
   # Handle the link hinting marker generation and matching. Must be initialized after settings have been
   # loaded, so that we can retrieve the option setting.
   getMarkerMatcher: ->
-    if settings.get("filterLinkHints") then filterHints else alphabetHints
+    if Settings.get("filterLinkHints") then filterHints else alphabetHints
   # lock to ensure only one instance runs at a time
   isActive: false
   # Call this function on exit (if defined).
@@ -60,7 +60,7 @@ LinkHints =
     # For these modes, we filter out those elements which don't have an HREF (since there's nothing we can do
     # with them).
     elements = (el for el in elements when el.element.href?) if mode in [ COPY_LINK_URL, OPEN_INCOGNITO ]
-    if settings.get "filterLinkHints"
+    if Settings.get "filterLinkHints"
       # When using text filtering, we sort the elements such that we visit descendants before their ancestors.
       # This allows us to exclude the text used for matching descendants from that used for matching their
       # ancestors.
@@ -389,7 +389,7 @@ alphabetHints =
   # may be of different lengths.
   #
   hintStrings: (linkCount) ->
-    linkHintCharacters = settings.get("linkHintCharacters")
+    linkHintCharacters = Settings.get("linkHintCharacters")
     # Determine how many digits the link hints will require in the worst case. Usually we do not need
     # all of these digits for every link single hint, so we can show shorter hints for a few of the links.
     digitsNeeded = Math.ceil(@logXOfBase(linkCount, linkHintCharacters.length))
@@ -460,7 +460,7 @@ filterHints =
         @labelMap[forElement] = labelText
 
   generateHintString: (linkHintNumber) ->
-    (numberToHintString linkHintNumber + 1, settings.get "linkHintNumbers").toUpperCase()
+    (numberToHintString linkHintNumber + 1, Settings.get "linkHintNumbers").toUpperCase()
 
   generateLinkText: (element) ->
     linkText = ""
@@ -519,7 +519,7 @@ filterHints =
       if (!@hintKeystrokeQueue.pop() && !@linkTextKeystrokeQueue.pop())
         return { linksMatched: [] }
     else if (keyChar)
-      if (settings.get("linkHintNumbers").indexOf(keyChar) >= 0)
+      if (Settings.get("linkHintNumbers").indexOf(keyChar) >= 0)
         @hintKeystrokeQueue.push(keyChar)
       else
         # since we might renumber the hints, the current hintKeyStrokeQueue

--- a/content_scripts/scroller.coffee
+++ b/content_scripts/scroller.coffee
@@ -117,8 +117,7 @@ checkVisibility = (element) ->
 # CoreScroller contains the core function (scroll) and logic for relative scrolls.  All scrolls are ultimately
 # translated to relative scrolls.  CoreScroller is not exported.
 CoreScroller =
-  init: (frontendSettings) ->
-    @settings = frontendSettings
+  init: ->
     @time = 0
     @lastEvent = null
     @keyIsDown = false
@@ -215,11 +214,11 @@ CoreScroller =
 
 # Scroller contains the two main scroll functions which are used by clients.
 Scroller =
-  init: (frontendSettings) ->
+  init: ->
     handlerStack.push
       _name: 'scroller/active-element'
       DOMActivate: (event) -> handlerStack.alwaysContinueBubbling -> activatedElement = event.target
-    CoreScroller.init frontendSettings
+    CoreScroller.init()
 
   # scroll the active element in :direction by :amount * :factor.
   # :factor is needed because :amount can take on string values, which scrollBy converts to element dimensions.

--- a/content_scripts/scroller.coffee
+++ b/content_scripts/scroller.coffee
@@ -139,7 +139,7 @@ CoreScroller =
           @time += 1
 
   # Return true if CoreScroller would not initiate a new scroll right now.
-  wouldNotInitiateScroll: -> @lastEvent?.repeat and @settings.get "smoothScroll"
+  wouldNotInitiateScroll: -> @lastEvent?.repeat and Settings.get "smoothScroll"
 
   # Calibration fudge factors for continuous scrolling.  The calibration value starts at 1.0.  We then
   # increase it (until it exceeds @maxCalibration) if we guess that the scroll is too slow, or decrease it
@@ -153,7 +153,7 @@ CoreScroller =
   scroll: (element, direction, amount, continuous = true) ->
     return unless amount
 
-    unless @settings.get "smoothScroll"
+    unless Settings.get "smoothScroll"
       # Jump scrolling.
       performScroll element, direction, amount
       checkVisibility element

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -68,10 +68,6 @@ settings =
     @port = true
     Settings.init()
 
-  set: (key, value) ->
-    @init() unless @port
-    Settings.set key, value
-
   load: -> @init() unless @port
 
   addEventListener: Settings.addEventListener.bind Settings
@@ -1084,7 +1080,7 @@ window.showHelpDialog = (html, fid) ->
       event.preventDefault()
       showAdvanced = VimiumHelpDialog.getShowAdvancedCommands()
       VimiumHelpDialog.showAdvancedCommands(!showAdvanced)
-      settings.set("helpDialog_showAdvancedCommands", !showAdvanced)
+      Settings.set("helpDialog_showAdvancedCommands", !showAdvanced)
 
     showAdvancedCommands: (visible) ->
       VimiumHelpDialog.dialogElement.getElementsByClassName("toggleAdvancedCommands")[0].innerHTML =

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -46,9 +46,6 @@ textInputXPath = (->
 # must be called beforehand to ensure get() will return up-to-date values.
 #
 settings =
-  isLoaded: false
-  port: null
-  eventListeners: {}
   values:
     scrollStepSize: null
     linkHintCharacters: null
@@ -63,10 +60,6 @@ settings =
     smoothScroll: null
     grabBackFocus: null
     searchEngines: null
-
-  init: ->
-    @port = true
-    Settings.init()
 
 #
 # Give this frame a unique (non-zero) id.
@@ -98,7 +91,7 @@ class GrabBackFocus extends Mode
       # An input may already be focused. If so, grab back the focus.
       @grabBackFocus document.activeElement if document.activeElement
 
-    if settings.isLoaded then activate() else Settings.addEventListener "load", activate
+    if Settings.isLoaded then activate() else Settings.addEventListener "load", activate
 
   grabBackFocus: (element) ->
     return @continueBubbling unless DomUtils.isEditable element
@@ -147,7 +140,7 @@ window.initializeModes = ->
   new NormalMode
   new PassKeysMode
   new InsertMode permanent: true
-  Scroller.init settings
+  Scroller.init()
 
 #
 # Complete initialization work that sould be done prior to DOMReady.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -41,10 +41,9 @@ textInputXPath = (->
   DomUtils.makeXPath(inputElements)
 )()
 
-#
-# settings provides a browser-global localStorage-backed dict. get() and set() are synchronous, but load()
-# must be called beforehand to ensure get() will return up-to-date values.
-#
+# NOTE(mrmr1993): we use Settings everywhere instead of the dedicated implementation that was here.
+# Previously, only the values listed below would be loaded. If the space used by settings across all of our
+# content scripts is becoming an issue, then we can restrict the values we load to the list below.
 settings =
   values:
     scrollStepSize: null

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -70,8 +70,6 @@ settings =
 
   load: -> @init() unless @port
 
-  addEventListener: Settings.addEventListener.bind Settings
-
 #
 # Give this frame a unique (non-zero) id.
 #
@@ -102,7 +100,7 @@ class GrabBackFocus extends Mode
       # An input may already be focused. If so, grab back the focus.
       @grabBackFocus document.activeElement if document.activeElement
 
-    if settings.isLoaded then activate() else settings.addEventListener "load", activate
+    if settings.isLoaded then activate() else Settings.addEventListener "load", activate
 
   grabBackFocus: (element) ->
     return @continueBubbling unless DomUtils.isEditable element
@@ -157,7 +155,7 @@ window.initializeModes = ->
 # Complete initialization work that sould be done prior to DOMReady.
 #
 initializePreDomReady = ->
-  settings.addEventListener("load", LinkHints.init.bind(LinkHints))
+  Settings.addEventListener "load", LinkHints.init.bind LinkHints
   settings.load()
 
   initializeModes()

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -68,8 +68,6 @@ settings =
     @port = true
     Settings.init()
 
-  get: Settings.get.bind Settings
-
   set: (key, value) ->
     @init() unless @port
     Settings.set key, value
@@ -101,7 +99,7 @@ class GrabBackFocus extends Mode
       mousedown: => @alwaysContinueBubbling => @exit()
 
     activate = =>
-      return @exit() unless settings.get "grabBackFocus"
+      return @exit() unless Settings.get "grabBackFocus"
       @push
         _name: "grab-back-focus-focus"
         focus: (event) => @grabBackFocus event.target
@@ -345,14 +343,14 @@ extend window,
   scrollToTop: -> Scroller.scrollTo "y", 0
   scrollToLeft: -> Scroller.scrollTo "x", 0
   scrollToRight: -> Scroller.scrollTo "x", "max"
-  scrollUp: -> Scroller.scrollBy "y", -1 * settings.get("scrollStepSize")
-  scrollDown: -> Scroller.scrollBy "y", settings.get("scrollStepSize")
+  scrollUp: -> Scroller.scrollBy "y", -1 * Settings.get("scrollStepSize")
+  scrollDown: -> Scroller.scrollBy "y", Settings.get("scrollStepSize")
   scrollPageUp: -> Scroller.scrollBy "y", "viewSize", -1/2
   scrollPageDown: -> Scroller.scrollBy "y", "viewSize", 1/2
   scrollFullPageUp: -> Scroller.scrollBy "y", "viewSize", -1
   scrollFullPageDown: -> Scroller.scrollBy "y", "viewSize"
-  scrollLeft: -> Scroller.scrollBy "x", -1 * settings.get("scrollStepSize")
-  scrollRight: -> Scroller.scrollBy "x", settings.get("scrollStepSize")
+  scrollLeft: -> Scroller.scrollBy "x", -1 * Settings.get("scrollStepSize")
+  scrollRight: -> Scroller.scrollBy "x", Settings.get("scrollStepSize")
 
 extend window,
   reload: -> window.location.reload()
@@ -698,7 +696,7 @@ updateFindModeQuery = ->
   # the query can be treated differently (e.g. as a plain string versus regex depending on the presence of
   # escape sequences. '\' is the escape character and needs to be escaped itself to be used as a normal
   # character. here we grep for the relevant escape sequences.
-  findModeQuery.isRegex = settings.get 'regexFindMode'
+  findModeQuery.isRegex = Settings.get 'regexFindMode'
   hasNoIgnoreCaseFlag = false
   findModeQuery.parsedQuery = findModeQuery.rawQuery.replace /(\\{1,2})([rRI]?)/g, (match, slashes, flag) ->
     return match if flag == "" or slashes.length != 1
@@ -1010,12 +1008,12 @@ findAndFollowRel = (value) ->
         return true
 
 window.goPrevious = ->
-  previousPatterns = settings.get("previousPatterns") || ""
+  previousPatterns = Settings.get("previousPatterns") || ""
   previousStrings = previousPatterns.split(",").filter( (s) -> s.trim().length )
   findAndFollowRel("prev") || findAndFollowLink(previousStrings)
 
 window.goNext = ->
-  nextPatterns = settings.get("nextPatterns") || ""
+  nextPatterns = Settings.get("nextPatterns") || ""
   nextStrings = nextPatterns.split(",").filter( (s) -> s.trim().length )
   findAndFollowRel("next") || findAndFollowLink(nextStrings)
 
@@ -1070,7 +1068,7 @@ window.showHelpDialog = (html, fid) ->
 
   VimiumHelpDialog =
     # This setting is pulled out of local storage. It's false by default.
-    getShowAdvancedCommands: -> settings.get("helpDialog_showAdvancedCommands")
+    getShowAdvancedCommands: -> Settings.get("helpDialog_showAdvancedCommands")
 
     init: () ->
       this.dialogElement = document.getElementById("vimiumHelpDialog")

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -68,8 +68,6 @@ settings =
     @port = true
     Settings.init()
 
-  load: -> @init() unless @port
-
 #
 # Give this frame a unique (non-zero) id.
 #
@@ -156,7 +154,7 @@ window.initializeModes = ->
 #
 initializePreDomReady = ->
   Settings.addEventListener "load", LinkHints.init.bind LinkHints
-  settings.load()
+  Settings.init()
 
   initializeModes()
   checkIfEnabledForUrl()
@@ -240,7 +238,6 @@ window.installListeners = ->
 #
 onFocus = (event) ->
   if event.target == window
-    settings.load()
     chrome.runtime.sendMessage handler: "frameFocused", frameId: frameId
     checkIfEnabledForUrl true
 

--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -8,7 +8,7 @@ Vomnibar =
   # the form "keyword=X", for direct activation of a custom search engine.
   parseRegistryEntry: (registryEntry = { options: [] }, callback = null) ->
     options = {}
-    searchEngines = settings.get("searchEngines") ? ""
+    searchEngines = Settings.get("searchEngines") ? ""
     SearchEngines.refreshAndUse searchEngines, (engines) ->
       for option in registryEntry.options
         [ key, value ] = option.split "="

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -30,6 +30,7 @@ Sync =
       unless chrome.runtime.lastError
         for own key, value of items
           Settings.storeAndPropagate key, value if @shouldSyncKey key
+        Settings.isLoaded = true
 
   # Asynchronous message from synced storage.
   handleStorageUpdate: (changes, area) ->
@@ -58,15 +59,20 @@ Sync =
 if Utils.isExtensionPage()
   if Utils.isBackgroundPage()
     settingsCache = localStorage
+    isPreloaded = true
   else
     settingsCache = extend {}, localStorage # Make a copy of the cached settings from localStorage
+    isPreloaded = true
 else
   settingsCache = {}
+  isPreloaded = false
 
 root.Settings = Settings =
+  isLoaded: isPreloaded
   cache: settingsCache
   init: -> Sync.init()
   get: (key) ->
+    console.log "WARNING: Settings have not loaded yet; using the default value for #{key}." unless @isLoaded
     if (key of @cache) then JSON.parse(@cache[key]) else @defaults[key]
 
   set: (key, value) ->

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -81,7 +81,7 @@ root.Settings = Settings =
 
   get: (key) ->
     console.log "WARNING: Settings have not loaded yet; using the default value for #{key}." unless @isLoaded
-    if (key of @cache) then JSON.parse(@cache[key]) else @defaults[key]
+    if key of @cache and @cache[key]? then JSON.parse(@cache[key]) else @defaults[key]
 
   set: (key, value) ->
     # Don't store the value if it is equal to the default, so we can change the defaults in the future

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -198,6 +198,7 @@ root.Settings = Settings =
     grabBackFocus: false
 
     settingsVersion: Utils.getCurrentVersion()
+    helpDialog_showAdvancedCommands: false
 
 # Export Sync via Settings for tests.
 root.Settings.Sync = Sync

--- a/manifest.json
+++ b/manifest.json
@@ -41,6 +41,7 @@
              "lib/rect.js",
              "lib/handler_stack.js",
              "lib/clipboard.js",
+             "lib/settings.js",
              "content_scripts/ui_component.js",
              "content_scripts/link_hints.js",
              "content_scripts/vomnibar.js",

--- a/tests/dom_tests/chrome.coffee
+++ b/tests/dom_tests/chrome.coffee
@@ -7,6 +7,9 @@ root.chromeMessages = []
 
 document.hasFocus = -> true
 
+fakeManifest =
+  version: "1.51"
+
 root.chrome =
   runtime:
     connect: ->
@@ -18,7 +21,7 @@ root.chrome =
     onMessage:
       addListener: ->
     sendMessage: (message) -> chromeMessages.unshift message
-    getManifest: ->
+    getManifest: -> fakeManifest
     getURL: (url) -> "../../#{url}"
   storage:
     local:
@@ -31,3 +34,4 @@ root.chrome =
       addListener: ->
   extension:
     inIncognitoContext: false
+    getURL: (url) -> chrome.runtime.getURL url

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -34,11 +34,19 @@ initializeModeState = ->
   handlerStack.bubbleEvent "registerKeyQueue",
     keyQueue: ""
 
+# Tell Settings that it's been loaded.
+Settings.isLoaded = true
+
+# Shoulda.js doesn't support async code, so we try not to use any.
+Utils.nextTick = (func) -> func()
+
 #
 # Retrieve the hint markers as an array object.
 #
 getHintMarkers = ->
   Array::slice.call document.getElementsByClassName("vimiumHintMarker"), 0
+
+stubSettings = (key, value) -> stub Settings.cache, key, JSON.stringify value
 
 #
 # Generate tests that are common to both default and filtered
@@ -52,8 +60,8 @@ createGeneralHintTests = (isFilteredMode) ->
       initializeModeState()
       testContent = "<a>test</a>" + "<a>tress</a>"
       document.getElementById("test-div").innerHTML = testContent
-      stub settings.values, "filterLinkHints", false
-      stub settings.values, "linkHintCharacters", "ab"
+      stubSettings "filterLinkHints", false
+      stubSettings "linkHintCharacters", "ab"
 
     tearDown ->
       document.getElementById("test-div").innerHTML = ""
@@ -92,8 +100,8 @@ context "Test link hints for focusing input elements correctly",
     testDiv = document.getElementById("test-div")
     testDiv.innerHTML = ""
 
-    stub settings.values, "filterLinkHints", false
-    stub settings.values, "linkHintCharacters", "ab"
+    stubSettings "filterLinkHints", false
+    stubSettings "linkHintCharacters", "ab"
 
     # Every HTML5 input type except for hidden. We should be able to activate all of them with link hints.
     inputTypes = ["button", "checkbox", "color", "date", "datetime", "datetime-local", "email", "file",
@@ -129,8 +137,8 @@ context "Alphabetical link hints",
 
   setup ->
     initializeModeState()
-    stub settings.values, "filterLinkHints", false
-    stub settings.values, "linkHintCharacters", "ab"
+    stubSettings "filterLinkHints", false
+    stubSettings "linkHintCharacters", "ab"
 
     # Three hints will trigger double hint chars.
     createLinks 3
@@ -161,8 +169,8 @@ context "Filtered link hints",
   # elements.
 
   setup ->
-    stub settings.values, "filterLinkHints", true
-    stub settings.values, "linkHintNumbers", "0123456789"
+    stubSettings "filterLinkHints", true
+    stubSettings "linkHintNumbers", "0123456789"
 
   context "Text hints",
 
@@ -289,7 +297,7 @@ context "Find prev / next links",
     <a href='#first'>nextcorrupted</a>
     <a href='#second'>next page</a>
     """
-    stub settings.values, "nextPatterns", "next"
+    stubSettings "nextPatterns", "next"
     goNext()
     assert.equal '#second', window.location.hash
 
@@ -297,7 +305,7 @@ context "Find prev / next links",
     document.getElementById("test-div").innerHTML = """
     <a href='#first'>&gt;&gt;</a>
     """
-    stub settings.values, "nextPatterns", ">>"
+    stubSettings "nextPatterns", ">>"
     goNext()
     assert.equal '#first', window.location.hash
 
@@ -306,7 +314,7 @@ context "Find prev / next links",
     <a href='#first'>lorem ipsum next</a>
     <a href='#second'>next!</a>
     """
-    stub settings.values, "nextPatterns", "next"
+    stubSettings "nextPatterns", "next"
     goNext()
     assert.equal '#second', window.location.hash
 

--- a/tests/dom_tests/dom_tests.html
+++ b/tests/dom_tests/dom_tests.html
@@ -35,6 +35,7 @@
     <script type="text/javascript" src="../../lib/rect.js"></script>
     <script type="text/javascript" src="../../lib/handler_stack.js"></script>
     <script type="text/javascript" src="../../lib/clipboard.js"></script>
+    <script type="text/javascript" src="../../lib/settings.js"></script>
     <script type="text/javascript" src="../../content_scripts/ui_component.js"></script>
     <script type="text/javascript" src="../../content_scripts/link_hints.js"></script>
     <script type="text/javascript" src="../../content_scripts/vomnibar.js"></script>


### PR DESCRIPTION
This is a follow-on to #1599 which replaces the frontend-only settings implementation `settings` with the version used everywhere else (`Settings`, in `lib/settings.coffee`). Benefits:
* no more duplicated settings code
* updated settings are passed to everywhere they're needed as soon as they are updated
* less code in `vimium_frontend.coffee` and `main.coffee`

Potential issues:
* the setting for toggling advanced commands in the help dialog is now updated from `chrome.storage.sync`
  - the value was already *stored* in `chrome.storage.sync`
  - updates from `chrome.storage.sync` were ignored by `Settings`, since it had no default value
  - the value in use was the one from `localStorage` in the background page (which should be the same as the one in `chrome.storage.sync` for nearly all users, especially those on a single machine).
* the settings loaded in content scripts are no longer limited to the reduced list from `settings.values`
  - I've left this list in the code, in case this is something we want/need to add back in at some point for eg. memory use
* `Utils.nextTick` had to be overridden for tests, since shoulda.js' lack of async support was causing tests to fail (relevant: #1386).

@smblott-github this is working nicely for me, and pretty much finishes what I'd been wanting to do towards unified settings; could you give it a look?