### PR TITLE
Improved global marks

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Using marks:
 
     ma, mA  set local mark "a" (global mark "A")
     `a, `A  jump to local mark "a" (global mark "A")
-    ``      jump back to the position before the previous jump -- before gg, G, n, N, / or `a
+    ``      jump back to the position before the previous jump
+               -- that is, before the previous gg, G, n, N, / or `a
 
 Additional advanced browsing commands:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Navigating the current page:
     F       open a link in a new tab
     r       reload
     gs      view source
-    i       enter insert mode -- all commands will be ignored until you hit esc to exit
+    i       enter insert mode -- all commands will be ignored until you hit Esc to exit
     yy      copy the current url to the clipboard
     yf      copy a link url to the clipboard
     gf      cycle forward to the next frame
@@ -57,7 +57,7 @@ Navigating to new pages:
 Using find:
 
     /       enter find mode
-              -- type your search query and hit enter to search, or ESC to cancel
+              -- type your search query and hit enter to search, or Esc to cancel
     n       cycle forward to the next find match
     N       cycle backward to the previous find match
 
@@ -90,8 +90,8 @@ Using marks:
 
 Additional advanced browsing commands:
 
-    ]]      Follow the link labeled 'next' or '>'. Helpful for browsing paginated sites.
-    [[      Follow the link labeled 'previous' or '<'. Helpful for browsing paginated sites.
+    ]], [[  Follow the link labeled 'next' or '>' ('previous' or '<')
+              - helpful for browsing paginated sites
     <a-f>   open multiple links in a new tab
     gi      focus the first (or n-th) text input box on the page
     gu      go up one level in the URL hierarchy
@@ -101,7 +101,7 @@ Additional advanced browsing commands:
     v       enter visual mode; use p/P to paste-and-go, use y to yank
     V       enter visual line mode
 
-Vimium supports command repetition so, for example, hitting `5t` will open 5 tabs in rapid succession. `<ESC>` (or
+Vimium supports command repetition so, for example, hitting `5t` will open 5 tabs in rapid succession. `<Esc>` (or
 `<c-[>`) will clear any partial commands in the queue and will also exit insert and find modes.
 
 There are some advanced commands which aren't documented here; refer to the help dialog (type `?`) for a full
@@ -383,7 +383,7 @@ does not support command repetition.
 -  Bug fixes related to entering insert mode when the page first loads, and when focusing Flash embeds.
 -  Added command listing to the Options page for easy reference.
 -  `J` & `K` have reversed for tab switching: `J` goes left and `K` goes right.
--  `<c-[>` is now equivalent to ESC, to match the behavior of VIM.
+-  `<c-[>` is now equivalent to `Esc`, to match the behavior of VIM.
 -  `<c-e>` and `<c-y>` are now mapped to scroll down and up respectively.
 -  The characters used for link hints are now configurable under Advanced Options.
 
@@ -393,7 +393,7 @@ does not support command repetition.
 -  Command `yy` to yank (copy) the current tab's url to the clipboard.
 -  Better Linux support.
 -  Fix for `Shift+F` link hints.
--  `ESC` now clears the keyQueue. So, for example, hitting `g`, `ESC`, `g` will no longer scroll the page.
+-  `Esc` now clears the keyQueue. So, for example, hitting `g`, `Esc`, `g` will no longer scroll the page.
 
 1.1 (2010-01-03)
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,6 @@ Navigating the current page:
     yf      copy a link url to the clipboard
     gf      cycle forward to the next frame
     gF      focus the main/top frame
-    ma, mA  set local (global) mark "a" ("A")
-    `a, `A  jump to local (global) mark "a" ("A")
-    ``      jump back to position before previous jump -- before gg, G, n, N, / and `a
 
 Navigating to new pages:
 
@@ -81,6 +78,12 @@ Manipulating tabs:
     X          restore closed tab (i.e. unwind the 'x' command)
     T          search through your open tabs
     <a-p>      pin/unpin current tab
+
+Using marks:
+
+    ma, mA  set local (global) mark "a" ("A")
+    `a, `A  jump to local (global) mark "a" ("A")
+    ``      jump back to position before previous jump -- before gg, G, n, N, / and `a
 
 Additional advanced browsing commands:
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Navigating the current page:
     yf      copy a link url to the clipboard
     gf      cycle forward to the next frame
     gF      focus the main/top frame
+    ma, mA  set local (global)  mark "a" ("A")
+    `a, `A  jump to local (global)  mark "a" ("A")
+    ``      jump back to position before previous jump -- before gg, G, n, N, / and `a
 
 Navigating to new pages:
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ Manipulating tabs:
 
 Using marks:
 
-    ma, mA  set local (global) mark "a" ("A")
-    `a, `A  jump to local (global) mark "a" ("A")
-    ``      jump back to position before previous jump -- before gg, G, n, N, / and `a
+    ma, mA  set local mark "a" (global mark "A")
+    `a, `A  jump to local mark "a" (global mark "A")
+    ``      jump back to the position before previous jump -- before gg, G, n, N, / and `a
 
 Additional advanced browsing commands:
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ list.
 Custom Key Mappings
 -------------------
 
-You may remap or unmap any of the default key bindings in the "Key mappings" section under "Advanced Options"
-on the options page.
+You may remap or unmap any of the default key bindings in the "Custom key mappings" on the options page.
 
 Enter one of the following key mapping commands per line:
 

--- a/README.md
+++ b/README.md
@@ -159,8 +159,10 @@ Release Notes
   ([here](https://github.com/philc/vimium/wiki/Search-Completion) and
   [here](https://github.com/philc/vimium/wiki/Tips-and-Tricks#repeat-recent-queries)).
 - A much improved interface for custom search engines.
-- Added "\`\`" to jump back to previous position after a jump.
-- Bug fixes: bookmarklets accessed from the vomnibar, global marks.
+- Added <tt>\`\`</tt> to jump back to the previous position after selected jump-like movements.
+- Bug fixes, including:
+    - Bookmarklets accessed from the vomnibar.
+    - Global marks on non-Windows platforms.
 
 1.51 (2015-05-02)
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Using marks:
 
     ma, mA  set local mark "a" (global mark "A")
     `a, `A  jump to local mark "a" (global mark "A")
-    ``      jump back to the position before previous jump -- before gg, G, n, N, / and `a
+    ``      jump back to the position before the previous jump -- before gg, G, n, N, / or `a
 
 Additional advanced browsing commands:
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Examples:
 - `unmap r` removes any mapping for the r key.
 
 Available Vimium commands can be found via the "Show available commands" link
-near the key mapping box one the options page. The command name appears to the
+near the key mapping box on the options page. The command name appears to the
 right of the description in parenthesis.
 
 You can add comments to key mappings by starting a line with `"` or `#`.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Release Notes
   ([here](https://github.com/philc/vimium/wiki/Search-Completion) and
   [here](https://github.com/philc/vimium/wiki/Tips-and-Tricks#repeat-recent-queries)).
 - A much improved interface for custom search engines.
+- Added "\`\`" to jump back to previous position after a jump.
 - Bug fixes: bookmarklets accessed from the vomnibar, global marks.
 
 1.51 (2015-05-02)

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Release Notes
   [here](https://github.com/philc/vimium/wiki/Tips-and-Tricks#repeat-recent-queries)).
 - A much improved interface for custom search engines.
 - Added <tt>\`\`</tt> to jump back to the previous position after selected jump-like movements.
+- Global marks are now persistent (across tab closes and browser sessions) and synced.
 - Bug fixes, including:
     - Bookmarklets accessed from the vomnibar.
     - Global marks on non-Windows platforms.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Release Notes
   ([here](https://github.com/philc/vimium/wiki/Search-Completion) and
   [here](https://github.com/philc/vimium/wiki/Tips-and-Tricks#repeat-recent-queries)).
 - A much improved interface for custom search engines.
-- Bug fixes: bookmarklets accessed from the vomnibar.
+- Bug fixes: bookmarklets accessed from the vomnibar, global marks.
 
 1.51 (2015-05-02)
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,12 @@ Navigating to new pages:
 
 Using find:
 
-    /       enter find mode -- type your search query and hit enter to search or esc to cancel
-            See here for advanced usage (regular expressions): https://github.com/philc/vimium/wiki/Find-Mode
+    /       enter find mode
+              -- type your search query and hit enter to search, or ESC to cancel
     n       cycle forward to the next find match
     N       cycle backward to the previous find match
+
+For advanced usage, see [regular expressions](https://github.com/philc/vimium/wiki/Find-Mode) on the wiki.
 
 Navigating your history:
 
@@ -84,7 +86,7 @@ Using marks:
     ma, mA  set local mark "a" (global mark "A")
     `a, `A  jump to local mark "a" (global mark "A")
     ``      jump back to the position before the previous jump
-               -- that is, before the previous gg, G, n, N, / or `a
+              -- that is, before the previous gg, G, n, N, / or `a
 
 Additional advanced browsing commands:
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Navigating the current page:
     yf      copy a link url to the clipboard
     gf      cycle forward to the next frame
     gF      focus the main/top frame
-    ma, mA  set local (global)  mark "a" ("A")
-    `a, `A  jump to local (global)  mark "a" ("A")
+    ma, mA  set local (global) mark "a" ("A")
+    `a, `A  jump to local (global) mark "a" ("A")
     ``      jump back to position before previous jump -- before gg, G, n, N, / and `a
 
 Navigating to new pages:

--- a/README.md
+++ b/README.md
@@ -127,10 +127,11 @@ Examples:
 - `unmap <c-d>` removes any mapping for ctrl+d and restores Chrome's default behavior.
 - `unmap r` removes any mapping for the r key.
 
-Available Vimium commands can be found via the "Show Available Commands" link near the key mapping box. The
-command name appears to the right of the description in parenthesis.
+Available Vimium commands can be found via the "Show available commands" link
+near the key mapping box one the options page. The command name appears to the
+right of the description in parenthesis.
 
-You can add comments to your key mappings by starting a line with `"` or `#`.
+You can add comments to key mappings by starting a line with `"` or `#`.
 
 The following special keys are available for mapping:
 

--- a/README.md
+++ b/README.md
@@ -68,16 +68,16 @@ Navigating your history:
 
 Manipulating tabs:
 
-    J, gT      go one tab left
-    K, gt      go one tab right
-    g0         go to the first tab
-    g$         go to the last tab
-    t          create tab
-    yt         duplicate current tab
-    x          close current tab
-    X          restore closed tab (i.e. unwind the 'x' command)
-    T          search through your open tabs
-    <a-p>      pin/unpin current tab
+    J, gT   go one tab left
+    K, gt   go one tab right
+    g0      go to the first tab
+    g$      go to the last tab
+    t       create tab
+    yt      duplicate current tab
+    x       close current tab
+    X       restore closed tab (i.e. unwind the 'x' command)
+    T       search through your open tabs
+    <a-p>   pin/unpin current tab
 
 Using marks:
 

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -30,7 +30,7 @@ Commands =
       return
 
     options ?= []
-    @keyToCommandRegistry[key] = extend { command, options, key }, @availableCommands[command]
+    @keyToCommandRegistry[key] = extend { command, options }, @availableCommands[command]
 
   # Lower-case the appropriate portions of named keys.
   #

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -30,7 +30,7 @@ Commands =
       return
 
     options ?= []
-    @keyToCommandRegistry[key] = extend { command, options }, @availableCommands[command]
+    @keyToCommandRegistry[key] = extend { command, options, key }, @availableCommands[command]
 
   # Lower-case the appropriate portions of named keys.
   #

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -35,7 +35,8 @@ namedKeyRegex = /^(<(?:[amc]-.|(?:[amc]-)?[a-z0-9]{2,5})>)(.*)$/
 
 # Event handlers
 selectionChangedHandlers = []
-tabLoadedHandlers = {} # tabId -> function()
+# Note. tabLoadedHandlers handlers is exported for use also by "marks.coffee".
+root.tabLoadedHandlers = {} # tabId -> function()
 
 # A secret, available only within the current instantiation of Vimium.  The secret is big, likely unguessable
 # in practice, but less than 2^31.

--- a/background_scripts/marks.coffee
+++ b/background_scripts/marks.coffee
@@ -81,6 +81,5 @@ Marks =
       tabsInWindow = tabs.filter (tab) -> tab.windowId == id
       continuation tabsInWindow[0] ? tabs[0]
 
-
 root = exports ? window
 root.Marks = Marks

--- a/background_scripts/marks.coffee
+++ b/background_scripts/marks.coffee
@@ -59,6 +59,11 @@ Marks =
           if baseUrl == @getBaseUrl tab.url
             # We have a matching tab.  We'll use it.
             return @gotoPositionInTab extend markInfo, tabId: tab.id
+      # There is no existing matching tab, we'll have to create one.
+      chrome.tabs.create { url: @getBaseUrl(markInfo.url) }, (tab) =>
+        # Note. tabLoadedHandlers is defined in "main.coffee".  This handler will be called when the tab has
+        # is loaded, its DOM is ready and it registers with the background page.
+        tabLoadedHandlers[tab.id] = => @gotoPositionInTab extend markInfo, tabId: tab.id
 
   getBaseUrl: (url) -> url.split("#")[0]
 

--- a/background_scripts/marks.coffee
+++ b/background_scripts/marks.coffee
@@ -63,18 +63,16 @@ Marks =
   # The tab we're trying to find no longer exists.  We either find another tab with a matching URL and use it,
   # or we create a new tab.
   focusOrLaunch: (markInfo) ->
-    chrome.windows.getAll { populate: true }, (windows) =>
-      for window in windows
-        for tab in window.tabs
-          if markInfo.url == @getBaseUrl tab.url
-            # We have a matching tab: use it.
-            @gotoPositionInTab extend markInfo, tabId: tab.id
-            return
-      # There is no existing matching tab, we'll have to create one.
-      chrome.tabs.create { url: @getBaseUrl markInfo.url }, (tab) =>
-        # Note. tabLoadedHandlers is defined in "main.coffee".  The handler below will be called when the tab
-        # is loaded, its DOM is ready and it registers with the background page.
-        tabLoadedHandlers[tab.id] = => @gotoPositionInTab extend markInfo, tabId: tab.id
+    chrome.tabs.query { url: markInfo.url }, (tabs) =>
+      if 0 < tabs.length
+        # We have a matching tab: use it.
+        @gotoPositionInTab extend markInfo, tabId: tabs[0].id
+      else
+        # There is no existing matching tab, we'll have to create one.
+        chrome.tabs.create { url: @getBaseUrl markInfo.url }, (tab) =>
+          # Note. tabLoadedHandlers is defined in "main.coffee".  The handler below will be called when the tab
+          # is loaded, its DOM is ready and it registers with the background page.
+          tabLoadedHandlers[tab.id] = => @gotoPositionInTab extend markInfo, tabId: tab.id
 
 root = exports ? window
 root.Marks = Marks

--- a/background_scripts/marks.coffee
+++ b/background_scripts/marks.coffee
@@ -7,20 +7,23 @@ Marks =
   getBaseUrl: (url) -> url.split("#")[0]
 
   # Create a global mark.  We record vimiumSecret with the mark so that we can tell later, when the mark is
-  # used, whether this is the original Vimium instantiation or a subsequent instantiation.  This affects
-  # whether or not tabId can be considered valid.
+  # used, whether this is the original Vimium session or a subsequent session.  This affects whether or not
+  # tabId can be considered valid.
   create: (req, sender) ->
     chrome.storage.local.get "vimiumSecret", (items) =>
       item = {}
       item[@getLocationKey req.markName] =
         vimiumSecret: items.vimiumSecret
-        tabId: sender.tab.id
+        markName: req.markName
         url: @getBaseUrl sender.tab.url
+        tabId: sender.tab.id
         scrollX: req.scrollX
         scrollY: req.scrollY
-        markName: req.markName
       chrome.storage.sync.set item
 
+  # Goto a global mark.  We try to find the original tab.  If we can't find that, then we try to find another
+  # tab with the original URL, and use that.  And if we can't find such an existing tab, then we create a new
+  # one.  Whichever of those we do, we then set the scroll position to the original scroll position.
   goto: (req, sender) ->
     chrome.storage.local.get "vimiumSecret", (items) =>
       vimiumSecret = items.vimiumSecret
@@ -33,12 +36,12 @@ Marks =
             name: "showHUDforDuration",
             text: "Global mark not set: '#{req.markName}'."
             duration: 1000
-        else if markInfo.vimiumSecret != items.vimiumSecret
+        else if markInfo.vimiumSecret != vimiumSecret
           # This is a different Vimium instantiation, so markInfo.tabId is definitely out of date.
           @focusOrLaunch markInfo
         else
           # Check whether markInfo.tabId still exists.  According to here (https://developer.chrome.com/extensions/tabs),
-          # tab Ids are unqiue within a Chrome session.  So, if we find a match, we can use.
+          # tab Ids are unqiue within a Chrome session.  So, if we find a match, we can use it.
           chrome.tabs.get markInfo.tabId, (tab) =>
             if not chrome.runtime.lastError and tab?.url and markInfo.url == @getBaseUrl tab.url
               # The original tab still exists.
@@ -47,6 +50,7 @@ Marks =
               # The original tab no longer exists.
               @focusOrLaunch markInfo
 
+  # Focus an existing tab and scroll to the given position within it.
   gotoPositionInTab: ({ tabId, scrollX, scrollY, markName }) ->
     chrome.tabs.update tabId, { selected: true }, ->
       chrome.tabs.sendMessage tabId,
@@ -67,7 +71,7 @@ Marks =
             @gotoPositionInTab extend markInfo, tabId: tab.id
             return
       # There is no existing matching tab, we'll have to create one.
-      chrome.tabs.create { url: @getBaseUrl(markInfo.url) }, (tab) =>
+      chrome.tabs.create { url: @getBaseUrl markInfo.url }, (tab) =>
         # Note. tabLoadedHandlers is defined in "main.coffee".  The handler below will be called when the tab
         # is loaded, its DOM is ready and it registers with the background page.
         tabLoadedHandlers[tab.id] = => @gotoPositionInTab extend markInfo, tabId: tab.id

--- a/background_scripts/marks.coffee
+++ b/background_scripts/marks.coffee
@@ -1,17 +1,21 @@
 
 Marks =
-  marks: {}
-
   # This returns the key which is used for storing mark locations in chrome.storage.local.
   getLocationKey: (markName) -> "vimiumGlobalMark|#{markName}"
 
+  # Get the part of a URL we use for matching here (that is, everything up to the first anchor).
+  getBaseUrl: (url) -> url.split("#")[0]
+
+  # Create a global mark.  We record vimiumSecret with the mark so that we can tell later, when the mark is
+  # used, whether this is the original Vimium instantiation or a subsequent instantiation.  This affects
+  # whether or not tabId can be considered valid.
   create: (req, sender) ->
     chrome.storage.local.get "vimiumSecret", (items) =>
       item = {}
       item[@getLocationKey req.markName] =
         vimiumSecret: items.vimiumSecret
         tabId: sender.tab.id
-        url: sender.tab.url
+        url: @getBaseUrl sender.tab.url
         scrollX: req.scrollX
         scrollY: req.scrollY
         markName: req.markName
@@ -31,14 +35,15 @@ Marks =
         # This is a different Vimium instantiation, so markInfo.tabId is definitely out of date.
         @focusOrLaunch markInfo
       else
-        # Check whether markInfo.tabId still exists.
+        # Check whether markInfo.tabId still exists.  According to here (https://developer.chrome.com/extensions/tabs),
+        # tab Ids are unqiue within a Chrome session.  So, if we find a match, we can use.
         chrome.tabs.get markInfo.tabId, (tab) =>
-          if chrome.runtime.lastError or not tab
-            # The original tab no longer exists.
-            @focusOrLaunch markInfo
-          else
+          if not chrome.runtime.lastError and tab?.url and markInfo.url == @getBaseUrl tab.url
             # The original tab still exists.
             @gotoPositionInTab markInfo
+          else
+            # The original tab no longer exists.
+            @focusOrLaunch markInfo
 
   gotoPositionInTab: ({ tabId, scrollX, scrollY, markName }) ->
     chrome.tabs.update tabId, { selected: true }, ->
@@ -49,23 +54,21 @@ Marks =
             text: "Jumped to global mark '#{markName}'."
             duration: 1000
 
-  # The tab we're trying to find no longer exists.  Either find another tab with a matching URL and use it, or
-  # create a new tab.
+  # The tab we're trying to find no longer exists.  We either find another tab with a matching URL and use it,
+  # or we create a new tab.
   focusOrLaunch: (markInfo) ->
     chrome.windows.getAll { populate: true }, (windows) =>
-      baseUrl = @getBaseUrl markInfo.url
       for window in windows
         for tab in window.tabs
-          if baseUrl == @getBaseUrl tab.url
-            # We have a matching tab.  We'll use it.
-            return @gotoPositionInTab extend markInfo, tabId: tab.id
+          if markInfo.url == @getBaseUrl tab.url
+            # We have a matching tab: use it.
+            @gotoPositionInTab extend markInfo, tabId: tab.id
+            return
       # There is no existing matching tab, we'll have to create one.
       chrome.tabs.create { url: @getBaseUrl(markInfo.url) }, (tab) =>
-        # Note. tabLoadedHandlers is defined in "main.coffee".  This handler will be called when the tab has
+        # Note. tabLoadedHandlers is defined in "main.coffee".  The handler below will be called when the tab
         # is loaded, its DOM is ready and it registers with the background page.
         tabLoadedHandlers[tab.id] = => @gotoPositionInTab extend markInfo, tabId: tab.id
-
-  getBaseUrl: (url) -> url.split("#")[0]
 
 root = exports ? window
 root.Marks = Marks

--- a/background_scripts/marks.coffee
+++ b/background_scripts/marks.coffee
@@ -23,12 +23,18 @@ removeMarksForTab = (id) ->
 
 root.goto = (req, sender) ->
   mark = marks[req.markName]
-  chrome.tabs.update mark.tabId, selected: true
-  chrome.tabs.sendMessage mark.tabId,
-    name: "setScrollPosition"
-    scrollX: mark.scrollX
-    scrollY: mark.scrollY
-  chrome.tabs.sendMessage mark.tabId,
-    name: "showHUDforDuration",
-    text: "Jumped to global mark '#{req.markName}'"
-    duration: 1000
+  if mark?
+    chrome.tabs.update mark.tabId, selected: true
+    chrome.tabs.sendMessage mark.tabId,
+      name: "setScrollPosition"
+      scrollX: mark.scrollX
+      scrollY: mark.scrollY
+    chrome.tabs.sendMessage mark.tabId,
+      name: "showHUDforDuration",
+      text: "Jumped to global mark '#{req.markName}'."
+      duration: 1000
+  else
+    chrome.tabs.sendMessage sender.tab.id,
+      name: "showHUDforDuration",
+      text: "Global mark not set: '#{req.markName}'."
+      duration: 1000

--- a/background_scripts/marks.coffee
+++ b/background_scripts/marks.coffee
@@ -1,40 +1,56 @@
-root = window.Marks = {}
 
-marks = {}
+Marks =
+  marks: {}
 
-root.create = (req, sender) ->
-  marks[req.markName] =
-    tabId: sender.tab.id
-    scrollX: req.scrollX
-    scrollY: req.scrollY
+  # This returns the key which is used for storing mark locations in chrome.storage.local.
+  getLocationKey: (markName) -> "vimiumGlobalMark|#{markName}"
 
-chrome.tabs.onUpdated.addListener (tabId, changeInfo, tab) ->
-  if changeInfo.url?
-    removeMarksForTab tabId
+  create: (req, sender) ->
+    chrome.storage.local.get "vimiumSecret", (items) =>
+      item = {}
+      item[@getLocationKey req.markName] =
+        vimiumSecret: items.vimiumSecret
+        tabId: sender.tab.id
+        url: sender.tab.url
+        scrollX: req.scrollX
+        scrollY: req.scrollY
+      console.log item
+      chrome.storage.local.set item
 
-chrome.tabs.onRemoved.addListener (tabId, removeInfo) ->
-  # XXX(jez): what about restored tabs?
-  removeMarksForTab tabId
+  goto: (req, sender) ->
+    key = @getLocationKey req.markName
+    chrome.storage.local.get [ "vimiumSecret", key ], (items) =>
+      markInfo = items[key]
+      if not markInfo
+        # The mark is not defined.
+        chrome.tabs.sendMessage sender.tab.id,
+          name: "showHUDforDuration",
+          text: "Global mark not set: '#{req.markName}'."
+          duration: 1000
+      else if markInfo.vimiumSecret != items.vimiumSecret
+        # This is a different Vimium instantiation, so markInfo.tabId is definitely out of date.
+        @focusOrLaunch markInfo
+      else
+        # Check whether markInfo.tabId still exists.
+        { tabId, url, scrollX, scrollY } = markInfo
+        chrome.tabs.get tabId, (tab) =>
+          if chrome.runtime.lastError or not tab
+            # The tab no longer exists.
+            @focusOrLaunch markInfo
+          else
+            # The original tab still exists.
+            chrome.tabs.update tabId, { selected: true }, ->
+              chrome.tabs.sendMessage tabId,
+                { name: "setScrollPosition", scrollX: scrollX, scrollY: scrollY }, ->
+                  chrome.tabs.sendMessage tabId,
+                    name: "showHUDforDuration",
+                    text: "Jumped to global mark '#{req.markName}'."
+                    duration: 1000
 
-removeMarksForTab = (id) ->
-  for markName, mark of marks
-    if mark.tabId is id
-      delete marks[markName]
+  # The tab we're trying to find no longer exists.  Either find another tab with a matching URL and use it, or
+  # create a new tab.
+  focusOrLaunch: (info) ->
+    console.log info
 
-root.goto = (req, sender) ->
-  mark = marks[req.markName]
-  if mark?
-    chrome.tabs.update mark.tabId, selected: true
-    chrome.tabs.sendMessage mark.tabId,
-      name: "setScrollPosition"
-      scrollX: mark.scrollX
-      scrollY: mark.scrollY
-    chrome.tabs.sendMessage mark.tabId,
-      name: "showHUDforDuration",
-      text: "Jumped to global mark '#{req.markName}'."
-      duration: 1000
-  else
-    chrome.tabs.sendMessage sender.tab.id,
-      name: "showHUDforDuration",
-      text: "Global mark not set: '#{req.markName}'."
-      duration: 1000
+root = exports ? window
+root.Marks = Marks

--- a/content_scripts/marks.coffee
+++ b/content_scripts/marks.coffee
@@ -1,7 +1,8 @@
 
 Marks =
+  previousPositionRegisters: [ "`", "'" ]
+  localRegisters: {}
   mode: null
-  previousPosition: null
 
   exit: (continuation = null) ->
     @mode?.exit()
@@ -16,7 +17,8 @@ Marks =
     JSON.stringify scrollX: window.scrollX, scrollY: window.scrollY
 
   setPreviousPosition: ->
-    @previousPosition = @getMarkString()
+    markString = @getMarkString()
+    @localRegisters[reg] = markString for reg in @previousPositionRegisters
 
   showMessage: (message, keyChar) ->
     HUD.showForDuration "#{message} \"#{keyChar}\".", 1000
@@ -45,11 +47,6 @@ Marks =
               @showMessage "Created local mark", keyChar
 
   activateGotoMode: (registryEntry) ->
-    # We pick off the last character of the key sequence used to launch this command. Usually this is just "`".
-    # We then use that character, so together usually the sequence "``", to jump back to the previous
-    # position.  The "previous position" is recorded below, and is registered via @setPreviousPosition()
-    # elsewhere for various other jump-like commands.
-    previousPositionKey = registryEntry.key[registryEntry.key.length-1..]
     @mode = new Mode
       name: "goto-mark"
       indicator: "Go to mark..."
@@ -63,8 +60,7 @@ Marks =
               handler: 'gotoMark'
               markName: keyChar
           else
-            markString =
-              if keyChar == previousPositionKey then @previousPosition else localStorage[@getLocationKey keyChar]
+            markString = @localRegisters[keyChar] ? localStorage[@getLocationKey keyChar]
             if markString?
               @setPreviousPosition()
               position = JSON.parse markString

--- a/content_scripts/marks.coffee
+++ b/content_scripts/marks.coffee
@@ -36,11 +36,14 @@ Marks =
         # characters.
         @exit =>
           if event.shiftKey
+            # We record the current scroll position, but only if this is the top frame within the tab.
+            # Otherwise, we'll fetch the scroll position of the top frame from the background page later.
+            [ scrollX, scrollY ] = [ window.scrollX, window.scrollY ] if DomUtils.isTopFrame()
             chrome.runtime.sendMessage
               handler: 'createMark'
               markName: keyChar
-              scrollX: window.scrollX
-              scrollY: window.scrollY
+              scrollX: scrollX
+              scrollY: scrollY
             , => @showMessage "Created global mark", keyChar
           else
             localStorage[@getLocationKey keyChar] = @getMarkString()

--- a/content_scripts/marks.coffee
+++ b/content_scripts/marks.coffee
@@ -1,45 +1,64 @@
-root = window.Marks = {}
 
-root.activateCreateMode = ->
-  handlerStack.push keydown: (e) ->
-    keyChar = KeyboardUtils.getKeyChar(event)
-    return unless keyChar isnt ""
+exit = (mode, continuation = null) ->
+  mode.exit()
+  continuation?()
+  false
 
-    if /[A-Z]/.test keyChar
-      chrome.runtime.sendMessage {
-        handler: 'createMark',
-        markName: keyChar
-        scrollX: window.scrollX,
-        scrollY: window.scrollY
-      }, -> HUD.showForDuration "Created global mark '#{keyChar}'", 1000
-    else if /[a-z]/.test keyChar
-      [baseLocation, sep, hash] = window.location.href.split '#'
-      localStorage["vimiumMark|#{baseLocation}|#{keyChar}"] = JSON.stringify
-        scrollX: window.scrollX,
-        scrollY: window.scrollY
-      HUD.showForDuration "Created local mark '#{keyChar}'", 1000
+Marks =
+  activateCreateMode: ->
+    mode = new Mode
+      name: "create-mark"
+      indicator: "Create mark?"
+      keypress: -> false
+      keyup: -> false
+      keydown: (event) ->
+        keyChar = KeyboardUtils.getKeyChar(event)
+        if /[A-Z]/.test keyChar
+          exit mode, ->
+            chrome.runtime.sendMessage
+              handler: 'createMark'
+              markName: keyChar
+              scrollX: window.scrollX
+              scrollY: window.scrollY
+            , -> HUD.showForDuration "Created global mark '#{keyChar}'.", 1000
+        else if /[a-z]/.test keyChar
+          [baseLocation, sep, hash] = window.location.href.split '#'
+          localStorage["vimiumMark|#{baseLocation}|#{keyChar}"] = JSON.stringify
+            scrollX: window.scrollX,
+            scrollY: window.scrollY
+          exit mode, -> HUD.showForDuration "Created local mark '#{keyChar}'.", 1000
+        else if event.shiftKey
+          false
+        else
+          exit mode
 
-    @remove()
+  activateGotoMode: ->
+    mode = new Mode
+      name: "goto-mark"
+      indicator: "Go to mark?"
+      keypress: -> false
+      keyup: -> false
+      keydown: (event) ->
+        keyChar = KeyboardUtils.getKeyChar(event)
+        if /[A-Z]/.test keyChar
+          exit mode, ->
+            chrome.runtime.sendMessage
+              handler: 'gotoMark'
+              markName: keyChar
+        else if /[a-z]/.test keyChar
+          [baseLocation, sep, hash] = window.location.href.split '#'
+          markString = localStorage["vimiumMark|#{baseLocation}|#{keyChar}"]
+          exit mode, ->
+            if markString?
+              mark = JSON.parse markString
+              window.scrollTo mark.scrollX, mark.scrollY
+              HUD.showForDuration "Jumped to local mark '#{keyChar}'", 1000
+            else
+              HUD.showForDuration "Local mark not set: '#{keyChar}'.", 1000
+        else if event.shiftKey
+          false
+        else
+          exit mode
 
-    false
-
-root.activateGotoMode = ->
-  handlerStack.push keydown: (e) ->
-    keyChar = KeyboardUtils.getKeyChar(event)
-    return unless keyChar isnt ""
-
-    if /[A-Z]/.test keyChar
-      chrome.runtime.sendMessage
-        handler: 'gotoMark'
-        markName: keyChar
-    else if /[a-z]/.test keyChar
-      [baseLocation, sep, hash] = window.location.href.split '#'
-      markString = localStorage["vimiumMark|#{baseLocation}|#{keyChar}"]
-      if markString?
-        mark = JSON.parse markString
-        window.scrollTo mark.scrollX, mark.scrollY
-        HUD.showForDuration "Jumped to local mark '#{keyChar}'", 1000
-
-    @remove()
-
-    false
+root = exports ? window
+root.Marks =  Marks

--- a/content_scripts/marks.coffee
+++ b/content_scripts/marks.coffee
@@ -54,16 +54,15 @@ Marks =
       indicator: "Go to mark..."
       suppressAllKeyboardEvents: true
       keypress: (event) =>
-        keyChar = String.fromCharCode event.charCode
-        if event.shiftKey
-          @exit ->
+        @exit =>
+          keyChar = String.fromCharCode event.charCode
+          if event.shiftKey
             chrome.runtime.sendMessage
               handler: 'gotoMark'
               markName: keyChar
-        else
-          markString =
-            if keyChar == previousPositionKey then @previousPosition else localStorage[@getLocationKey keyChar]
-          @exit =>
+          else
+            markString =
+              if keyChar == previousPositionKey then @previousPosition else localStorage[@getLocationKey keyChar]
             if markString?
               @setPreviousPosition()
               position = JSON.parse markString

--- a/content_scripts/marks.coffee
+++ b/content_scripts/marks.coffee
@@ -2,15 +2,13 @@
 exit = (mode, continuation = null) ->
   mode.exit()
   continuation?()
-  false
 
 Marks =
   activateCreateMode: ->
     mode = new Mode
       name: "create-mark"
       indicator: "Create mark?"
-      keypress: -> false
-      keyup: -> false
+      suppressAllKeyboardEvents: true
       keydown: (event) ->
         keyChar = KeyboardUtils.getKeyChar(event)
         if /[A-Z]/.test keyChar
@@ -27,17 +25,14 @@ Marks =
             scrollX: window.scrollX,
             scrollY: window.scrollY
           exit mode, -> HUD.showForDuration "Created local mark '#{keyChar}'.", 1000
-        else if event.shiftKey
-          false
-        else
+        else if not event.shiftKey
           exit mode
 
   activateGotoMode: ->
     mode = new Mode
       name: "goto-mark"
       indicator: "Go to mark?"
-      keypress: -> false
-      keyup: -> false
+      suppressAllKeyboardEvents: true
       keydown: (event) ->
         keyChar = KeyboardUtils.getKeyChar(event)
         if /[A-Z]/.test keyChar
@@ -55,9 +50,7 @@ Marks =
               HUD.showForDuration "Jumped to local mark '#{keyChar}'", 1000
             else
               HUD.showForDuration "Local mark not set: '#{keyChar}'.", 1000
-        else if event.shiftKey
-          false
-        else
+        else if not event.shiftKey
           exit mode
 
 root = exports ? window

--- a/content_scripts/marks.coffee
+++ b/content_scripts/marks.coffee
@@ -36,15 +36,15 @@ Marks =
         # characters.
         @exit =>
           if event.shiftKey
-              chrome.runtime.sendMessage
-                handler: 'createMark'
-                markName: keyChar
-                scrollX: window.scrollX
-                scrollY: window.scrollY
-              , => @showMessage "Created global mark", keyChar
+            chrome.runtime.sendMessage
+              handler: 'createMark'
+              markName: keyChar
+              scrollX: window.scrollX
+              scrollY: window.scrollY
+            , => @showMessage "Created global mark", keyChar
           else
-              localStorage[@getLocationKey keyChar] = @getMarkString()
-              @showMessage "Created local mark", keyChar
+            localStorage[@getLocationKey keyChar] = @getMarkString()
+            @showMessage "Created local mark", keyChar
 
   activateGotoMode: (registryEntry) ->
     @mode = new Mode

--- a/content_scripts/marks.coffee
+++ b/content_scripts/marks.coffee
@@ -31,19 +31,17 @@ Marks =
         # If <Shift> is depressed, then it's a global mark, otherwise it's a local mark.  This is consistent
         # vim's [A-Z] for global marks, [a-z] for local marks.  However, it also admits other non-Latin
         # characters.
-        if event.shiftKey
-          @exit =>
-            chrome.runtime.sendMessage
-              handler: 'createMark'
-              markName: keyChar
-              scrollX: window.scrollX
-              scrollY: window.scrollY
-            , => @showMessage "Created global mark", keyChar
-        else
-          @exit =>
-            markString = JSON.stringify scrollX: window.scrollX, scrollY: window.scrollY
-            localStorage[@getLocationKey keyChar] = @getMarkString()
-            @showMessage "Created local mark", keyChar
+        @exit =>
+          if event.shiftKey
+              chrome.runtime.sendMessage
+                handler: 'createMark'
+                markName: keyChar
+                scrollX: window.scrollX
+                scrollY: window.scrollY
+              , => @showMessage "Created global mark", keyChar
+          else
+              localStorage[@getLocationKey keyChar] = @getMarkString()
+              @showMessage "Created local mark", keyChar
 
   activateGotoMode: (registryEntry) ->
     # We pick off the last character of the key sequence used to launch this command. Usually this is just "`".

--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -48,12 +48,11 @@ class Mode
     @log "activate:", @id
 
     # If options.suppressAllKeyboardEvents is truthy, then all keyboard events are suppressed.  This avoids
-    # the need for modes which block all keyboard events 1) to provide handlers for all keyboard events,
-    # and 2) to worry about their return values.
+    # the need for modes which suppress all keyboard events 1) to provide handlers for all of those events,
+    # or 2) to worry about event suppression and event-handler return values.
     if @options.suppressAllKeyboardEvents
       for type in [ "keydown", "keypress", "keyup" ]
-        do (handler = @options[type]) =>
-          @options[type] = (event) => handler? event; @stopBubblingAndFalse
+        @options[type] = @alwaysSuppressEvent @options[type]
 
     @push
       keydown: @options.keydown || null
@@ -178,6 +177,13 @@ class Mode
   # yields @continueBubbling instead.  This simplifies handlers if they always continue bubbling (a common
   # case), because they do not need to be concerned with the value they yield.
   alwaysContinueBubbling: handlerStack.alwaysContinueBubbling
+
+  # Shorthand for an event handler which always suppresses event propagation.
+  alwaysSuppressEvent: (handler = null) ->
+    (event) =>
+      handler? event
+      DomUtils.suppressPropagation event
+      @stopBubblingAndFalse
 
   # Activate a new instance of this mode, together with all of its original options (except its main
   # keybaord-event handlers; these will be recreated).

--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -48,8 +48,8 @@ class Mode
     @log "activate:", @id
 
     # If options.suppressAllKeyboardEvents is truthy, then all keyboard events are suppressed.  This avoids
-    # the need for modes which block all keyboard events to 1) provide handlers for all keyboard events,
-    # and 2) worry about their return value.
+    # the need for modes which block all keyboard events 1) to provide handlers for all keyboard events,
+    # and 2) to worry about their return values.
     if @options.suppressAllKeyboardEvents
       for type in [ "keydown", "keypress", "keyup" ]
         do (handler = @options[type]) =>

--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -54,7 +54,7 @@ class Mode
       for type in [ "keydown", "keypress", "keyup" ]
         do (type) =>
           handler = @options[type]
-          @options[type] = (event) -> handler? event; false
+          @options[type] = (event) => handler? event; @stopBubblingAndFalse
 
     @push
       keydown: @options.keydown || null

--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -47,6 +47,15 @@ class Mode
     @id = "#{@name}-#{@count}"
     @log "activate:", @id
 
+    # If options.suppressAllKeyboardEvents is truthy, then all keyboard events are suppressed.  This avoids
+    # the need for modes which block all keyboard events to 1) provide handlers for all keyboard events,
+    # and 2) worry about their return value.
+    if options.suppressAllKeyboardEvents
+      for type in [ "keydown", "keypress", "keyup" ]
+        do (type) ->
+          handler = options[type]
+          options[type] = (event) -> handler? event; false
+
     @push
       keydown: @options.keydown || null
       keypress: @options.keypress || null

--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -52,8 +52,7 @@ class Mode
     # and 2) worry about their return value.
     if @options.suppressAllKeyboardEvents
       for type in [ "keydown", "keypress", "keyup" ]
-        do (type) =>
-          handler = @options[type]
+        do (handler = @options[type]) =>
           @options[type] = (event) => handler? event; @stopBubblingAndFalse
 
     @push

--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -50,11 +50,11 @@ class Mode
     # If options.suppressAllKeyboardEvents is truthy, then all keyboard events are suppressed.  This avoids
     # the need for modes which block all keyboard events to 1) provide handlers for all keyboard events,
     # and 2) worry about their return value.
-    if options.suppressAllKeyboardEvents
+    if @options.suppressAllKeyboardEvents
       for type in [ "keydown", "keypress", "keyup" ]
-        do (type) ->
-          handler = options[type]
-          options[type] = (event) -> handler? event; false
+        do (type) =>
+          handler = @options[type]
+          @options[type] = (event) -> handler? event; false
 
     @push
       keydown: @options.keydown || null

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -147,7 +147,7 @@ initializePreDomReady = ->
     focusFrame: (request) -> if (frameId == request.frameId) then focusThisFrame request
     refreshCompletionKeys: refreshCompletionKeys
     getScrollPosition: -> scrollX: window.scrollX, scrollY: window.scrollY
-    setScrollPosition: (request) -> setScrollPosition request.scrollX, request.scrollY
+    setScrollPosition: setScrollPosition
     executePageCommand: executePageCommand
     currentKeyQueue: (request) ->
       keyQueue = request.keyQueue
@@ -264,11 +264,15 @@ executePageCommand = (request) ->
 
   refreshCompletionKeys(request)
 
-setScrollPosition = (scrollX, scrollY) ->
-  if (scrollX > 0 || scrollY > 0)
-    DomUtils.documentReady ->
-      Marks.setPreviousPosition()
-      window.scrollTo scrollX, scrollY
+# Set the scroll position (but only in the main frame).  Some pages (like Facebook) get confused if you set
+# the scroll position in all frames.
+setScrollPosition = ({ scrollX, scrollY }) ->
+  if DomUtils.isTopFrame()
+    if scrollX > 0 or scrollY > 0
+      DomUtils.documentReady ->
+        window.focus()
+        Marks.setPreviousPosition()
+        window.scrollTo scrollX, scrollY
 
 #
 # Called from the backend in order to change frame focus.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -255,9 +255,7 @@ executePageCommand = (request) ->
   # All other commands are handled in their frame (but only if Vimium is enabled).
   return unless frameId == request.frameId and isEnabledForUrl
 
-  if commandType == "Marks"
-    Utils.invokeCommandString request.command, [request.registryEntry]
-  else if request.registryEntry.passCountToFunction
+  if request.registryEntry.passCountToFunction
     Utils.invokeCommandString(request.command, [request.count])
   else
     Utils.invokeCommandString(request.command) for i in [0...request.count]

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -142,7 +142,7 @@ initializePreDomReady = ->
     window.removeEventListener "focus", onFocus
 
   requestHandlers =
-    showHUDforDuration: (request) -> HUD.showForDuration request.text, request.duration
+    showHUDforDuration: handleShowHUDforDuration
     toggleHelpDialog: (request) -> toggleHelpDialog(request.dialogHtml, request.frameId)
     focusFrame: (request) -> if (frameId == request.frameId) then focusThisFrame request
     refreshCompletionKeys: refreshCompletionKeys
@@ -264,13 +264,16 @@ executePageCommand = (request) ->
 
   refreshCompletionKeys(request)
 
-# Set the scroll position (but only in the main frame).  Some pages (like Facebook) get confused if you set
-# the scroll position in all frames.
+handleShowHUDforDuration = ({ text, duration }) ->
+  if DomUtils.isTopFrame()
+    DomUtils.documentReady -> HUD.showForDuration text, duration
+
 setScrollPosition = ({ scrollX, scrollY }) ->
   if DomUtils.isTopFrame()
-    if scrollX > 0 or scrollY > 0
-      DomUtils.documentReady ->
-        window.focus()
+    DomUtils.documentReady ->
+      window.focus()
+      document.body.focus()
+      if 0 < scrollX or 0 < scrollY
         Marks.setPreviousPosition()
         window.scrollTo scrollX, scrollY
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -267,7 +267,7 @@ executePageCommand = (request) ->
 setScrollPosition = (scrollX, scrollY) ->
   if (scrollX > 0 || scrollY > 0)
     DomUtils.documentReady ->
-      Marks.markPosition()
+      Marks.setPreviousPosition()
       window.scrollTo scrollX, scrollY
 
 #
@@ -305,10 +305,10 @@ window.focusThisFrame = do ->
 
 extend window,
   scrollToBottom: ->
-    Marks.markPosition()
+    Marks.setPreviousPosition()
     Scroller.scrollTo "y", "max"
   scrollToTop: ->
-    Marks.markPosition()
+    Marks.setPreviousPosition()
     Scroller.scrollTo "y", 0
   scrollToLeft: -> Scroller.scrollTo "x", 0
   scrollToRight: -> Scroller.scrollTo "x", "max"
@@ -870,7 +870,7 @@ window.getFindModeQuery = (backwards) ->
     findModeQuery.parsedQuery
 
 findAndFocus = (backwards) ->
-  Marks.markPosition()
+  Marks.setPreviousPosition()
   query = getFindModeQuery backwards
 
   findModeQueryHasResults =
@@ -1017,7 +1017,7 @@ findModeRestoreSelection = (range = findModeInitialRange) ->
 
 # Enters find mode.  Returns the new find-mode instance.
 window.enterFindMode = (options = {}) ->
-  Marks.markPosition()
+  Marks.setPreviousPosition()
   # Save the selection, so performFindInPlace can restore it.
   findModeSaveSelection()
   findModeQuery = rawQuery: ""

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -266,7 +266,9 @@ executePageCommand = (request) ->
 
 setScrollPosition = (scrollX, scrollY) ->
   if (scrollX > 0 || scrollY > 0)
-    DomUtils.documentReady(-> window.scrollTo(scrollX, scrollY))
+    DomUtils.documentReady ->
+      Marks.markPosition()
+      window.scrollTo scrollX, scrollY
 
 #
 # Called from the backend in order to change frame focus.


### PR DESCRIPTION
This makes global marks:
- persistent across tab closures and browser sessions, and
- synchronised between browser instances.

Effectively, this makes global marks another kind of bookmark.

This PR includes and is an extension of #1714.  The differences are difficult to see in the diff.  They are:
- [this](https://github.com/smblott-github/vimium/blob/global-marks/background_scripts/main.coffee#L38) line, so that we can set the scroll position after a tab has been opened, and
- all of [this](https://github.com/smblott-github/vimium/blob/global-marks/background_scripts/marks.coffee) file.

Here's the approach:
- If the tab still exists, use it.
- Otherwise, if another tab exists with a matching URL, then use that instead.
- Otherwise, create a new tab and set the scroll position within that.

We use `vimiumSecret` to detect whether we can re-use a tab Id.  Global marks are stored not in memory, as previously, by in `chrome.storage.sync`.