### PR TITLE
Use "Tab" to select active link hint (in filtered mode only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Release Notes
   jump-like movements (`gg`, `G`, `/`, `n`, `N` and local mark movements).
 - Global marks are now persistent across tab closes and browser sessions, and
   are synced between browser instances.
+- If link hints are filtered by text (see the options page, not the default), then `Tab` now selects the next available hint.
 - Bug fixes, including:
     - Bookmarklets accessed from the vomnibar.
     - Global marks on non-Windows platforms.

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -439,6 +439,7 @@ filterHints =
   hintKeystrokeQueue: []
   linkTextKeystrokeQueue: []
   labelMap: {}
+  previousActiveHintMarker: null
 
   #
   # Generate a map of input element => label
@@ -496,6 +497,7 @@ filterHints =
       marker.showLinkText = linkTextObject.show
       @renderMarker(marker)
 
+    @highlightActiveHintMarker hintMarkers
     hintMarkers
 
   matchHintsByKey: (hintMarkers, event) ->
@@ -536,6 +538,7 @@ filterHints =
       # control back to command mode immediately after a match is found.
       delay = 200
 
+    @highlightActiveHintMarker linksMatched
     { linksMatched: linksMatched, delay: delay }
 
   #
@@ -560,10 +563,16 @@ filterHints =
 
     linksMatched
 
+  highlightActiveHintMarker: (linksMatched) ->
+    @previousActiveHintMarker?.classList.remove "vimiumActiveHintMarker"
+    @previousActiveHintMarker = linksMatched[0]
+    @previousActiveHintMarker?.classList.add "vimiumActiveHintMarker"
+
   deactivate: (delay, callback) ->
     @hintKeystrokeQueue = []
     @linkTextKeystrokeQueue = []
     @labelMap = {}
+    @previousActiveHintMarker = null
 
 #
 # Make each hint character a span, so that we can highlight the typed characters as you type them.

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -91,7 +91,7 @@ div.internalVimiumHintMarker > .matchingCharacter {
 }
 
 div > .vimiumActiveHintMarker span {
-  color: #906545 !important;
+  color: #A07555 !important;
 }
 
 /* Input hints CSS */

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -90,6 +90,10 @@ div.internalVimiumHintMarker > .matchingCharacter {
   color: #D4AC3A;
 }
 
+div > .vimiumActiveHintMarker span {
+  color: #906545 !important;
+}
+
 /* Input hints CSS */
 
 div.internalVimiumInputHint {


### PR DESCRIPTION
(This applies to link hints in filtered mode, that is when *Use the link's name and numbers for link-hint filtering* is selected.)

1. Make the active link hint (the one that will be activated if the user types `Enter`) visually distinct.
2. Make `Tab` (and `<Shift-Tab>`) select the activated link hint.

The visual indicator is quite subtle (perhaps too subtle).  It currently looks like this...

![150607-01-snapshot](https://cloud.githubusercontent.com/assets/2641335/8023133/af349daa-0cf4-11e5-9d74-06d4a727f7bd.png)
