### PR TITLE
Use "keypress" for link hints (instead of "keydown")

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Release Notes
 - Bug fixes, including:
     - Bookmarklets accessed from the vomnibar.
     - Global marks on non-Windows platforms.
+    - Link-hints for non-Latin keyboards.
 
 1.51 (2015-05-02)
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Release Notes
 - A much improved interface for custom search engines.
 - Added <tt>\`\`</tt> to jump back to the previous position after selected jump-like movements.
 - Global marks are now persistent (across tab closes and browser sessions) and synced.
+- For filtered link hints (not the default), you can now use `Tab` to select hints.
 - Bug fixes, including:
     - Bookmarklets accessed from the vomnibar.
     - Global marks on non-Windows platforms.

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -456,6 +456,7 @@ class AlphabetHints
 # Use numbers (usually) for hints, and also filter links by their text.
 class FilterHints
   constructor: ->
+    @linkHintNumbers = Settings.get "linkHintNumbers"
     @activateOnEnter = true
     @hintKeystrokeQueue = []
     @linkTextKeystrokeQueue = []
@@ -476,7 +477,7 @@ class FilterHints
         @labelMap[forElement] = labelText
 
   generateHintString: (linkHintNumber) ->
-    (numberToHintString linkHintNumber + 1, Settings.get "linkHintNumbers").toUpperCase()
+    numberToHintString linkHintNumber + 1, @linkHintNumbers.toUpperCase()
 
   generateLinkText: (element) ->
     linkText = ""
@@ -536,7 +537,7 @@ class FilterHints
     { linksMatched: linksMatched, delay: delay }
 
   pushKeyChar: (keyChar, keydownKeyChar) ->
-    if 0 <= Settings.get("linkHintNumbers").indexOf keyChar
+    if 0 <= @linkHintNumbers.indexOf keyChar
       @hintKeystrokeQueue.push keyChar
     else
       # Since we might renumber the hints, we should reset the current hintKeyStrokeQueue.

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -19,6 +19,16 @@ OPEN_INCOGNITO = name: "incognito"
 DOWNLOAD_LINK_URL = name: "download"
 
 LinkHints =
+  activateMode: (mode = OPEN_IN_CURRENT_TAB) -> new LinkHintsMode mode
+
+  activateModeToOpenInNewTab: -> @activateMode OPEN_IN_NEW_BG_TAB
+  activateModeToOpenInNewForegroundTab: -> @activateMode OPEN_IN_NEW_FG_TAB
+  activateModeToCopyLinkUrl: -> @activateMode COPY_LINK_URL
+  activateModeWithQueue: -> @activateMode OPEN_WITH_QUEUE
+  activateModeToOpenIncognito: -> @activateMode OPEN_INCOGNITO
+  activateModeToDownloadLink: -> @activateMode DOWNLOAD_LINK_URL
+
+class LinkHintsMode
   hintMarkerContainingDiv: null
   # One of the enums listed at the top of this file.
   mode: undefined
@@ -35,15 +45,7 @@ LinkHints =
   # A count of the number of Tab presses since the last non-Tab keyboard event.
   tabCount: 0
 
-  # We need this as a top-level function because our command system doesn't yet support arguments.
-  activateModeToOpenInNewTab: -> @activateMode(OPEN_IN_NEW_BG_TAB)
-  activateModeToOpenInNewForegroundTab: -> @activateMode(OPEN_IN_NEW_FG_TAB)
-  activateModeToCopyLinkUrl: -> @activateMode(COPY_LINK_URL)
-  activateModeWithQueue: -> @activateMode(OPEN_WITH_QUEUE)
-  activateModeToOpenIncognito: -> @activateMode(OPEN_INCOGNITO)
-  activateModeToDownloadLink: -> @activateMode(DOWNLOAD_LINK_URL)
-
-  activateMode: (mode = OPEN_IN_CURRENT_TAB) ->
+  constructor: (mode = OPEN_IN_CURRENT_TAB) ->
     # we need documentElement to be ready in order to append links
     return unless document.documentElement
 

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -391,10 +391,11 @@ class AlphabetHints
 
   constructor: ->
     @linkHintCharacters = Settings.get "linkHintCharacters"
-    # We use the keyChar from keydown if the link-hint characters are all "a-z".  This is the default, and
-    # preserves the legacy behavior (which always used keydown) for users which are familiar with that
-    # behavior.  Otherwise, we use keyChar from keypress, which admits non-Latin characters. See #1722.
-    @useKeydown = /^[a-z]*$/.test @linkHintCharacters
+    # We use the keyChar from keydown if the link-hint characters are all "a-z0-9".  This is the default
+    # settings value, and preserves the legacy behavior (which always used keydown) for users which are
+    # familiar with that behavior.  Otherwise, we use keyChar from keypress, which admits non-Latin
+    # characters. See #1722.
+    @useKeydown = /^[a-z0-9]*$/.test @linkHintCharacters
     @activateOnEnter = false
     @hintKeystrokeQueue = []
 
@@ -537,6 +538,9 @@ class FilterHints
     { linksMatched: linksMatched, delay: delay }
 
   pushKeyChar: (keyChar, keydownKeyChar) ->
+    # For filtered hints, we *always* use the keyChar value from keypress, because there is no obvious and
+    # easy-to-understand meaning for choosing one of keyChar or keydownKeyChar (as there is for alphabet
+    # hints).
     if 0 <= @linkHintNumbers.indexOf keyChar
       @hintKeystrokeQueue.push keyChar
     else

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -48,9 +48,6 @@ class LinkHintsMode
   constructor: (mode = OPEN_IN_CURRENT_TAB) ->
     # we need documentElement to be ready in order to append links
     return unless document.documentElement
-
-    if @isActive
-      return
     @isActive = true
 
     elements = @getVisibleClickableElements()
@@ -84,10 +81,9 @@ class LinkHintsMode
     @setOpenLinkMode mode
 
     # Note(philc): Append these markers as top level children instead of as child nodes to the link itself,
-    # because some clickable elements cannot contain children, e.g. submit buttons. This has the caveat
-    # that if you scroll the page and the link has position=fixed, the marker will not stay fixed.
-    @hintMarkerContainingDiv = DomUtils.addElementList(hintMarkers,
-      { id: "vimiumHintMarkerContainer", className: "vimiumReset" })
+    # because some clickable elements cannot contain children, e.g. submit buttons.
+    @hintMarkerContainingDiv = DomUtils.addElementList hintMarkers,
+      id: "vimiumHintMarkerContainer", className: "vimiumReset"
 
   setOpenLinkMode: (@mode) ->
     if @mode is OPEN_IN_NEW_BG_TAB or @mode is OPEN_IN_NEW_FG_TAB or @mode is OPEN_WITH_QUEUE
@@ -327,18 +323,16 @@ class LinkHintsMode
   updateVisibleMarkers: (hintMarkers, activateActiveHint = false, tabCount = 0) ->
     keyResult = @markerMatcher.getMatchingHints hintMarkers, tabCount
     linksMatched = keyResult.linksMatched
-    if (linksMatched.length == 0)
+    if linksMatched.length == 0
       @deactivateMode()
     else if activateActiveHint
       tabCount = ((linksMatched.length * Math.abs tabCount) + tabCount) % linksMatched.length
-      @activateLink(linksMatched[tabCount], 0)
-    else if (linksMatched.length == 1)
-      @activateLink(linksMatched[0], keyResult.delay ? 0)
+      @activateLink linksMatched[tabCount], 0
+    else if linksMatched.length == 1
+      @activateLink linksMatched[0], keyResult.delay ? 0
     else
-      for marker in hintMarkers
-        @hideMarker(marker)
-      for matched in linksMatched
-        @showMarker(matched, @markerMatcher.hintKeystrokeQueue.length)
+      @hideMarker marker for marker in hintMarkers
+      @showMarker matched, @markerMatcher.hintKeystrokeQueue.length for matched in linksMatched
 
   #
   # When only one link hint remains, this function activates it in the appropriate way.

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -339,7 +339,7 @@ class LinkHintsMode
     clickEl = matchedLink.clickableItem
     if (DomUtils.isSelectable(clickEl))
       DomUtils.simulateSelect(clickEl)
-      @deactivateMode(delay, -> LinkHints.delayMode = false)
+      @deactivateMode delay
     else
       # TODO figure out which other input elements should not receive focus
       if (clickEl.nodeName.toLowerCase() == "input" and clickEl.type not in ["button", "submit"])
@@ -347,11 +347,9 @@ class LinkHintsMode
       DomUtils.flashRect(matchedLink.rect)
       @linkActivator(clickEl)
       if @mode is OPEN_WITH_QUEUE
-        @deactivateMode delay, ->
-          LinkHints.delayMode = false
-          LinkHints.activateModeWithQueue()
+        @deactivateMode delay, -> LinkHints.activateModeWithQueue()
       else
-        @deactivateMode(delay, -> LinkHints.delayMode = false)
+        @deactivateMode delay
 
   #
   # Shows the marker, highlighting matchingCharCount characters.
@@ -366,9 +364,7 @@ class LinkHintsMode
 
   hideMarker: (linkMarker) -> linkMarker.style.display = "none"
 
-  # If called without arguments, this exits immediately.  Othewise, it exits after 'delay'. After exiting,
-  # 'callback' is invoked (if it is provided).
-  deactivateMode: (delay, callback) ->
+  deactivateMode: (delay = 0, callback = null) ->
     deactivate = =>
       DomUtils.removeElement @hintMarkerContainingDiv if @hintMarkerContainingDiv
       @hintMarkerContainingDiv = null

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -70,6 +70,8 @@ LinkHints =
       passInitialKeyupEvents: true
       suppressAllKeyboardEvents: true
       exitOnEscape: true
+      exitOnClick: true
+      exitOnScroll: true
       keypress: @onKeyDownInMode.bind this, hintMarkers
 
     @hintMode.onExit =>

--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -101,6 +101,12 @@ class Mode
         "focus": (event) => @alwaysContinueBubbling =>
           @exit event if DomUtils.isFocusable event.target
 
+    # If @options.exitOnScroll is truthy, then the mode will exit on any scroll event.
+    if @options.exitOnScroll
+      @push
+        _name: "mode-#{@id}/exitOnScroll"
+        "scroll": (event) => @alwaysContinueBubbling => @exit event
+
     # Some modes are singletons: there may be at most one instance active at any time.  A mode is a singleton
     # if @options.singleton is truthy.  The value of @options.singleton should be the key which is intended to
     # be unique.  New instances deactivate existing instances with the same key.

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -90,6 +90,10 @@ div.internalVimiumHintMarker > .matchingCharacter {
   color: #D4AC3A;
 }
 
+div > .vimiumActiveHintMarker span {
+  color: #A07555 !important;
+}
+
 /* Input hints CSS */
 
 div.internalVimiumInputHint {

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -192,7 +192,7 @@ window.installListeners = ->
   unless installedListeners
     # Key event handlers fire on window before they do on document. Prefer window for key events so the page
     # can't set handlers to grab the keys before us.
-    for type in [ "keydown", "keypress", "keyup", "click", "focus", "blur", "mousedown" ]
+    for type in [ "keydown", "keypress", "keyup", "click", "focus", "blur", "mousedown", "scroll" ]
       do (type) -> installListener window, type, (event) -> handlerStack.bubbleEvent type, event
     installListener document, "DOMActivate", (event) -> handlerStack.bubbleEvent 'DOMActivate', event
     installedListeners = true

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -67,27 +67,27 @@ createGeneralHintTests = (isFilteredMode) ->
       document.getElementById("test-div").innerHTML = ""
 
     should "create hints when activated, discard them when deactivated", ->
-      LinkHints.activateMode()
-      assert.isFalse not LinkHints.hintMarkerContainingDiv?
-      LinkHints.deactivateMode()
-      assert.isTrue not LinkHints.hintMarkerContainingDiv?
+      linkHints = LinkHints.activateMode()
+      assert.isFalse not linkHints.hintMarkerContainingDiv?
+      linkHints.deactivateMode()
+      assert.isTrue not linkHints.hintMarkerContainingDiv?
 
     should "position items correctly", ->
       assertStartPosition = (element1, element2) ->
         assert.equal element1.getClientRects()[0].left, element2.getClientRects()[0].left
         assert.equal element1.getClientRects()[0].top, element2.getClientRects()[0].top
       stub document.body, "style", "static"
-      LinkHints.activateMode()
+      linkHints = LinkHints.activateMode()
       hintMarkers = getHintMarkers()
       assertStartPosition document.getElementsByTagName("a")[0], hintMarkers[0]
       assertStartPosition document.getElementsByTagName("a")[1], hintMarkers[1]
-      LinkHints.deactivateMode()
+      linkHints.deactivateMode()
       stub document.body.style, "position", "relative"
-      LinkHints.activateMode()
+      linkHints = LinkHints.activateMode()
       hintMarkers = getHintMarkers()
       assertStartPosition document.getElementsByTagName("a")[0], hintMarkers[0]
       assertStartPosition document.getElementsByTagName("a")[1], hintMarkers[1]
-      LinkHints.deactivateMode()
+      linkHints.deactivateMode()
 
 createGeneralHintTests false
 createGeneralHintTests true
@@ -142,10 +142,10 @@ context "Alphabetical link hints",
 
     # Three hints will trigger double hint chars.
     createLinks 3
-    LinkHints.activateMode()
+    @linkHints = LinkHints.activateMode()
 
   tearDown ->
-    LinkHints.deactivateMode()
+    @linkHints.deactivateMode()
     document.getElementById("test-div").innerHTML = ""
 
   should "label the hints correctly", ->
@@ -177,11 +177,11 @@ context "Filtered link hints",
       initializeModeState()
       testContent = "<a>test</a>" + "<a>tress</a>" + "<a>trait</a>" + "<a>track<img alt='alt text'/></a>"
       document.getElementById("test-div").innerHTML = testContent
-      LinkHints.activateMode()
+      @linkHints = LinkHints.activateMode()
 
     tearDown ->
       document.getElementById("test-div").innerHTML = ""
-      LinkHints.deactivateMode()
+      @linkHints.deactivateMode()
 
     should "label the hints", ->
       hintMarkers = getHintMarkers()
@@ -205,11 +205,11 @@ context "Filtered link hints",
       testContent = "<a><img alt='alt text'/></a><a><img alt='alt text' title='some title'/></a>
         <a><img title='some title'/></a>" + "<a><img src='' width='320px' height='100px'/></a>"
       document.getElementById("test-div").innerHTML = testContent
-      LinkHints.activateMode()
+      @linkHints = LinkHints.activateMode()
 
     tearDown ->
       document.getElementById("test-div").innerHTML = ""
-      LinkHints.deactivateMode()
+      @linkHints.deactivateMode()
 
     should "label the images", ->
       hintMarkers = getHintMarkers()
@@ -227,11 +227,11 @@ context "Filtered link hints",
         <input type='text' id='test-input' value='some value'/>
         <label for='test-input-2'/>a label: </label><input type='text' id='test-input-2' value='some value'/>"
       document.getElementById("test-div").innerHTML = testContent
-      LinkHints.activateMode()
+      @linkHints = LinkHints.activateMode()
 
     tearDown ->
       document.getElementById("test-div").innerHTML = ""
-      LinkHints.deactivateMode()
+      @linkHints.deactivateMode()
 
     should "label the input elements", ->
       hintMarkers = getHintMarkers()


### PR DESCRIPTION
Currently, if the user sets non-ASCII link-hint characters on the options page, they can't select links because we use the `keydown` event.  This uses `keypress` instead.  It should be the case that whatever characters the user can type into options-page option (from which we generate link hints), they can later type those same characters to activate link hints.

(Also, exit link-hints mode on `click` and `scroll` events.)

~~Fixes~~ Related to #1387 (I think).