### PR TITLE
Fix tab move.

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -239,9 +239,12 @@ repeatFunction = (func, totalCount, currentCount, frameId) ->
 
 moveTab = (count) ->
   chrome.tabs.getAllInWindow null, (tabs) ->
+    pinnedCount = 0
+    for tab in tabs
+      pinnedCount += 1 if tab.pinned
     chrome.tabs.getSelected null, (tab) ->
       chrome.tabs.move tab.id,
-        index: Math.max 0, Math.min tabs.length - 1, tab.index + count
+        index: Math.max pinnedCount, Math.min tabs.length - 1, tab.index + count
 
 # Start action functions
 

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -237,11 +237,11 @@ repeatFunction = (func, totalCount, currentCount, frameId) ->
       -> repeatFunction(func, totalCount, currentCount + 1, frameId),
       frameId)
 
-moveTab = (callback, direction) ->
-  chrome.tabs.getSelected(null, (tab) ->
-    # Use Math.max to prevent -1 as the new index, otherwise the tab of index n will wrap to the far RHS when
-    # moved left by exactly (n+1) places.
-    chrome.tabs.move(tab.id, {index: Math.max(0, tab.index + direction) }, callback))
+moveTab = (count) ->
+  chrome.tabs.getAllInWindow null, (tabs) ->
+    chrome.tabs.getSelected null, (tab) ->
+      chrome.tabs.move tab.id,
+        index: Math.max 0, Math.min tabs.length - 1, tab.index + count
 
 # Start action functions
 
@@ -304,8 +304,8 @@ BackgroundCommands =
     chrome.tabs.getSelected(null, (tab) ->
       chrome.tabs.sendMessage(tab.id,
         { name: "toggleHelpDialog", dialogHtml: helpDialogHtml(), frameId:frameId }))
-  moveTabLeft: (count) -> moveTab(null, -count)
-  moveTabRight: (count) -> moveTab(null, count)
+  moveTabLeft: (count) -> moveTab -count
+  moveTabRight: (count) -> moveTab count
   nextFrame: (count,frameId) ->
     chrome.tabs.getSelected null, (tab) ->
       frameIdsForTab[tab.id] = cycleToFrame frameIdsForTab[tab.id], frameId, count

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -239,9 +239,7 @@ repeatFunction = (func, totalCount, currentCount, frameId) ->
 
 moveTab = (count) ->
   chrome.tabs.getAllInWindow null, (tabs) ->
-    pinnedCount = 0
-    for tab in tabs
-      pinnedCount += 1 if tab.pinned
+    pinnedCount = (tabs.filter (tab) -> tab.pinned).length
     chrome.tabs.getSelected null, (tab) ->
       chrome.tabs.move tab.id,
         index: Math.max pinnedCount, Math.min tabs.length - 1, tab.index + count


### PR DESCRIPTION
There are two problems with `tabMoveLeft/Right`:
- For negative `count`, if there are pinned tabs, then the index we calculate is invalid.
- For positive `count`, if count is too large, then the index we calculate is invalid.

Fixes #1727 (kind of).