### PR TITLE
Initialise options-page link-hint mode correctly (and an hilarious? bug)

### DIFF
--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -229,8 +229,6 @@ initOptionsPage = ->
     element.className = element.className + " example info"
     element.innerHTML = "Leave empty to reset this option."
 
-  $("filterLinkHints").checked = bgSettings.get "filterLinkHints"
-  maintainLinkHintsView()
   window.onbeforeunload = -> "You have unsaved changes to options." unless $("saveOptions").disabled
 
   document.addEventListener "keyup", (event) ->
@@ -259,6 +257,8 @@ initOptionsPage = ->
   # Populate options. The constructor adds each new object to "Option.all".
   for name, type of options
     new type(name,onUpdated)
+
+  maintainLinkHintsView()
 
 initPopupPage = ->
   chrome.tabs.getSelected null, (tab) ->

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -229,6 +229,7 @@ initOptionsPage = ->
     element.className = element.className + " example info"
     element.innerHTML = "Leave empty to reset this option."
 
+  $("filterLinkHints").checked = bgSettings.get "filterLinkHints"
   maintainLinkHintsView()
   window.onbeforeunload = -> "You have unsaved changes to options." unless $("saveOptions").disabled
 


### PR DESCRIPTION
Trivial:
- We haven't been initialising the options page correctly (see diff).

Possibly hilarious?
- The `linkHintNumbers` option has been (pretty much) ignored for as far back as I've checked.  We ignore it when generating hints.  So setting it to anything other than its default value has (almost) no effect. Well, its effect is to make it impossible to select links by their hint.

(This is not quite true.  It does affect which characters are ignored when filtering link texts.  However, that's not at all its billing.)

What should we do? Probably just remove it as an option.