### PR TITLE
Quick-fix: check that all settings have default values.

### DIFF
--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -22,6 +22,10 @@ class Option
     @element.addEventListener "change", @onUpdated
     @fetch()
     Option.all.push @
+    # All options-page settings must have default values.
+    # Note(smblott) It would be better to have a test for this.
+    unless bgSettings.defaults[@field]?
+      console.error "error: option #{@field} has no default value in settings."
 
   # Fetch a setting from localStorage, remember the @previous value and populate the DOM element.
   # Return the fetched value.


### PR DESCRIPTION
On the options page, this outputs a console error message if there is an options-page settings which does not have a default settings value.

The idea is to prevent issues like #1731.

It would be better to have a test, so this is really just a quick fix.  However, it does verify that there are no more missing default values.