### PR TITLE
Sync localStorage to chrome.storage and bump version to 1.52

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Vimium",
-  "version": "1.51",
+  "version": "1.52",
   "description": "The Hacker's Browser. Vimium provides keyboard shortcuts for navigation and control in the spirit of Vim.",
   "icons": {  "16": "icons/icon16.png",
               "48": "icons/icon48.png",


### PR DESCRIPTION
This ensures that settings set in old versions of Vimium are not 'forgotten' when we switch to using `chrome.storage.sync` for all settings implementations.

@smblott-github this is what I meant over in #1731.