### PR TITLE
Sync localStorage to chrome.storage.local and bump version to 1.52

### DIFF
--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -206,12 +206,18 @@ if Utils.isBackgroundPage()
   # backed Settings in the frontend. Here, we push settings in localStorage to chrome.storage.
   # NOTE(mrmr1993): We only push settings for which there is no corresponding value in chrome.storage.sync.
   # If there is a corresponding value, our value is either the most recent, or will be updated to it soon.
-  if Utils.compareVersions("1.52", Settings.get("settingsVersion")) == 1
+  lessThan152 = Utils.compareVersions("1.52", Settings.get("settingsVersion")) == 1
+  if lessThan152 or not Settings.get "localStorageMigrated"
+    if lessThan152
+      delete localStorage["localStorageMigrated"]
+    else
+      localStorage["localStorageMigrated"] = true
+
     localStorageClone = {}
     for key, value of localStorage
       localStorageClone[key] = value if Settings.shouldSyncKey key
     chrome.storage.sync.get Object.keys(localStorageClone), (items) ->
-      delete localStorageClone[key] for key of items
+      delete localStorageClone[key] for own key of items
       chrome.storage.local.set localStorageClone
 
   Settings.set("settingsVersion", Utils.getCurrentVersion())

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -171,7 +171,7 @@ if Utils.isBackgroundPage()
       localStorageClone[key] = value if Settings.shouldSyncKey key
     chrome.storage.sync.get Object.keys(localStorageClone), (items) ->
       delete localStorageClone[key] for key of items
-      chrome.storage.sync.set localStorageClone
+      chrome.storage.local.set localStorageClone
 
   Settings.set("settingsVersion", Utils.getCurrentVersion())
 

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -159,6 +159,20 @@ if Utils.isBackgroundPage()
   # We use settingsVersion to coordinate any necessary schema changes.
   if Utils.compareVersions("1.42", Settings.get("settingsVersion")) != -1
     Settings.set("scrollStepSize", parseFloat Settings.get("scrollStepSize"))
+
+  # Any settings set before we started using chrome.storage.sync were only stored in localStorage. If they've
+  # remained unchanged, then they won't be in chrome.storage.sync, and hence unusable with chrome.storage-
+  # backed Settings in the frontend. Here, we push settings in localStorage to chrome.storage.
+  # NOTE(mrmr1993): We only push settings for which there is no corresponding value in chrome.storage.sync.
+  # If there is a corresponding value, our value is either the most recent, or will be updated to it soon.
+  if Utils.compareVersions("1.52", Settings.get("settingsVersion")) == 1
+    localStorageClone = {}
+    for key, value of localStorage
+      localStorageClone[key] = value if Settings.shouldSyncKey key
+    chrome.storage.sync.get Object.keys(localStorageClone), (items) ->
+      delete localStorageClone[key] for key of items
+      chrome.storage.sync.set localStorageClone
+
   Settings.set("settingsVersion", Utils.getCurrentVersion())
 
   # Migration (after 1.49, 2015/2/1).

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -43,7 +43,9 @@ Settings =
           # If change.newValue is non-null, a value has been added to chrome.storage.sync. For settings,
           # the only values we care about here, this should only happen on the first run after the 1.52
           # version bump. Everything else is filtered out in the following function call.
-          @handleUpdateFromChromeStorage key, change.newValue if change?.newValue?
+          # If @localSettings[key] is non-null, we've been using this key's value from chrome.storage.local
+          # before, and so we propagate its updated value too.
+          @handleUpdateFromChromeStorage key, change.newValue if change?.newValue? or @localSettings[key]
 
       @onLoaded()
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Vimium",
-  "version": "1.51",
+  "version": "1.52",
   "description": "The Hacker's Browser. Vimium provides keyboard shortcuts for navigation and control in the spirit of Vim.",
   "icons": {  "16": "icons/icon16.png",
               "48": "icons/icon48.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Vimium",
-  "version": "1.52",
+  "version": "1.51",
   "description": "The Hacker's Browser. Vimium provides keyboard shortcuts for navigation and control in the spirit of Vim.",
   "icons": {  "16": "icons/icon16.png",
               "48": "icons/icon48.png",

--- a/tests/unit_tests/exclusion_test.coffee
+++ b/tests/unit_tests/exclusion_test.coffee
@@ -15,6 +15,7 @@ root.Marks =
 extend(global, require "../../lib/utils.js")
 Utils.getCurrentVersion = -> '1.44'
 extend(global,require "../../lib/settings.js")
+Settings.isLoaded = true
 extend(global, require "../../background_scripts/exclusions.js")
 extend(global, require "../../background_scripts/commands.js")
 extend(global, require "../../background_scripts/main.js")


### PR DESCRIPTION
This PR ensures that any setting available from `localStorage` in the background page is also available to content scripts, via `chrome.storage.local`. This fixes the issue:
* any setting set before Vimium 1.45 (and unchanged since) hadn't been propagated to `chrome.storage`, and so is unavailable to content scripts.

@smblott-github this also makes your statement from PR #1733 true, namely:

> the behaviour in a particular chrome instance doesn't change unless the user actively does something.