### PR TITLE
Make "Show Advanced Options" state persistent.

### DIFF
--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -150,6 +150,7 @@ Settings =
 
     settingsVersion: Utils.getCurrentVersion()
     helpDialog_showAdvancedCommands: false
+    optionsPage_showAdvancedOptions: false
 
 Settings.init()
 

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -197,18 +197,20 @@ initOptionsPage = ->
       show $("linkHintCharacters")
       hide $("linkHintNumbers")
 
-  toggleAdvancedOptions =
-    do (advancedMode=false) ->
-      (event) ->
-        if advancedMode
-          $("advancedOptions").style.display = "none"
-          $("advancedOptionsButton").innerHTML = "Show Advanced Options"
-        else
-          $("advancedOptions").style.display = "table-row-group"
-          $("advancedOptionsButton").innerHTML = "Hide Advanced Options"
-        advancedMode = !advancedMode
-        $("advancedOptionsButton").blur()
-        event.preventDefault()
+  maintainAdvancedOptions = ->
+    if bgSettings.get "optionsPage_showAdvancedOptions"
+      $("advancedOptions").style.display = "table-row-group"
+      $("advancedOptionsButton").innerHTML = "Hide Advanced Options"
+    else
+      $("advancedOptions").style.display = "none"
+      $("advancedOptionsButton").innerHTML = "Show Advanced Options"
+  maintainAdvancedOptions()
+
+  toggleAdvancedOptions = (event) ->
+    bgSettings.set "optionsPage_showAdvancedOptions", not bgSettings.get "optionsPage_showAdvancedOptions"
+    maintainAdvancedOptions()
+    $("advancedOptionsButton").blur()
+    event.preventDefault()
 
   activateHelpDialog = ->
     showHelpDialog chrome.extension.getBackgroundPage().helpDialogHtml(true, true, "Command Listing"), frameId

--- a/pages/options.html
+++ b/pages/options.html
@@ -283,7 +283,7 @@ b: http://b.com/?q=%s description
               </span>
             </td>
             <td id="saveOptionsTableData" nowrap>
-              <button id="advancedOptionsButton">Show Advanced Options</button>
+              <button id="advancedOptionsButton"></button>
               <button id="saveOptions" disabled="true">No Changes</button>
             </td>
           </tr>


### PR DESCRIPTION
The "Show advanced commands" toggle on the help page is persistent (and synced).  This makes the "Show Advanced Options" state on the options page similarly persistent.

This helps with the use case where a user is twiddling with an advanced option, and constantly has to open the options-page fold.

(Separately, I dislike the fold.  This has the side effect of hiding the fold permanently for me.)