### PR TITLE
Store default settings value and fix settings/sync problem

### DIFF
--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -6,6 +6,11 @@ Settings =
   onLoadedCallbacks: []
 
   init: ->
+    if Utils.isExtensionPage()
+      # On extension pages, we use localStorage (or a copy of it) as the cache.
+      @cache = if Utils.isBackgroundPage() then localStorage else extend {}, localStorage
+      @onLoaded()
+
     chrome.storage.local.get null, (localItems) =>
       localItems = {} if chrome.runtime.lastError
       @storage.get null, (syncedItems) =>

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -1,5 +1,5 @@
 
-# A "setting" is a stored key/value pair.  An "option" is setting which has a default value and whose value
+# A "setting" is a stored key/value pair.  An "option" is a setting which has a default value and whose value
 # can be changed on the options page.
 #
 # Option values which have never been changed by the user are in Settings.defaults.

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -1,4 +1,15 @@
 
+# A "setting" is a stored key/value pair.  An "option" is setting which has a default value and whose value
+# can be changed on the options page.
+#
+# Option values which have never been changed by the user are in Settings.defaults.
+#
+# Settings whose values have been changed are:
+# 1. stored either in chrome.storage.sync or in chrome.storage.local (but never both), and
+# 2. cached in Settings.cache; on extension pages, Settings.cache uses localStorage (so it persists).
+#
+# In all cases except Settings.defaults, values are stored as jsonified strings.
+
 Settings =
   storage: chrome.storage.sync
   cache: {}
@@ -159,7 +170,7 @@ if Utils.isBackgroundPage()
       chrome.storage.local.set findModeRawQueryList: (if rawQuery then [ rawQuery ] else [])
 
   # Migration (after 1.51, 2015/6/17).
-  # Copy settings with non-default values (and which are not in synced storage) to chrome.storage.local;
+  # Copy options with non-default values (and which are not in synced storage) to chrome.storage.local;
   # thereby making these settings accessible within content scripts.
   do (migrationKey = "copyNonDefaultsToChromeStorage-20150717") ->
     unless localStorage[migrationKey]

--- a/tests/unit_tests/settings_test.coffee
+++ b/tests/unit_tests/settings_test.coffee
@@ -27,12 +27,6 @@ context "settings",
     Settings.set 'scrollStepSize', 20
     assert.equal Settings.get('scrollStepSize'), 20
 
-  should "not store values equal to the default", ->
-    Settings.set 'scrollStepSize', 20
-    assert.isTrue Settings.has 'scrollStepSize'
-    Settings.set 'scrollStepSize', 60
-    assert.isFalse Settings.has 'scrollStepSize'
-
   should "revert to defaults if no key is stored", ->
     Settings.set 'scrollStepSize', 20
     Settings.clear 'scrollStepSize'
@@ -55,7 +49,7 @@ context "synced settings",
     Settings.set 'scrollStepSize', 20
     assert.equal Settings.get('scrollStepSize'), 20
     Settings.propagateChangesFromChromeStorage { scrollStepSize: { newValue: "60" } }
-    assert.isFalse Settings.has 'scrollStepSize'
+    assert.equal Settings.get('scrollStepSize'), 60
 
   should "propagate non-default values from synced storage", ->
     chrome.storage.sync.set { scrollStepSize: JSON.stringify(20) }
@@ -64,12 +58,12 @@ context "synced settings",
   should "propagate default values from synced storage", ->
     Settings.set 'scrollStepSize', 20
     chrome.storage.sync.set { scrollStepSize: JSON.stringify(60) }
-    assert.isFalse Settings.has 'scrollStepSize'
+    assert.equal Settings.get('scrollStepSize'), 60
 
   should "clear a setting from synced storage", ->
     Settings.set 'scrollStepSize', 20
     chrome.storage.sync.remove 'scrollStepSize'
-    assert.isFalse Settings.has 'scrollStepSize'
+    assert.equal Settings.get('scrollStepSize'), 60
 
   should "trigger a postUpdateHook", ->
     message = "Hello World"

--- a/tests/unit_tests/test_chrome_stubs.coffee
+++ b/tests/unit_tests/test_chrome_stubs.coffee
@@ -57,9 +57,9 @@ exports.chrome =
   storage:
     # chrome.storage.local
     local:
-      get: ->
-      set: ->
-      remove: ->
+      get: (_, callback) -> callback?()
+      set: (_, callback) -> callback?()
+      remove: (_, callback) -> callback?()
 
     # chrome.storage.onChanged
     onChanged:


### PR DESCRIPTION
(@mrmr1993: This is yet another approach to the Settings problem.)

With the new Settings implemetation, settings which have a non-default value and which are not in synced storage (that is, they have not been changed since synced storage was introduced) are not currently accessible to content scripts.  This commit makes such settings accessible via chrome.storage.local.

Important:

- There's a change to the established settings data model here.  Previously, settings with default values were not stored; here, they are.  This eliminates a considerable amount logic from Settings, but means that migrations will be required if default values are changed in future.  (Other than type changes, have we ever changed a default value?)

- There's also a change (bug fix?) to the behaviour when an affected setting is reset to its default value.  Previously, the change would *not* have been synced (whereas all other changes are).  Here, such changes *are* synced.  The previous behaviour was inconsistent with the syncing behaviour of all other options changes.

Note:

- This isn't particularly well tested.  It's being committed mainly just for consideration of the approach, initially.