### PR TITLE
Initialise modes and install listeners at the same time.

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -126,7 +126,6 @@ window.initializeModes = ->
 # Complete initialization work that sould be done prior to DOMReady.
 #
 initializePreDomReady = ->
-  initializeModes()
   checkIfEnabledForUrl()
   refreshCompletionKeys()
 
@@ -190,6 +189,7 @@ installListener = (element, event, callback) ->
 installedListeners = false
 window.installListeners = ->
   unless installedListeners
+    initializeModes()
     # Key event handlers fire on window before they do on document. Prefer window for key events so the page
     # can't set handlers to grab the keys before us.
     for type in [ "keydown", "keypress", "keyup", "click", "focus", "blur", "mousedown", "scroll" ]


### PR DESCRIPTION
Previously, we initialised modes early, but then installed our listeners only after DOM ready, and then only after we'd heard back from the background page in `checkIfEnabledForUrl`.  This creates a gap during which modes are installed, but they're not receiving events.

If an input is focused during that gap, then we don't pick it up when the modes are installed, and we don't pick it up when the input is focussed (because we're not listening).  This commit moves these two initialisation steps together, so they happen at the same time and there is no gap.

Fixes #1738.