### PR TITLE
fix a bug that `pasteFromClipboard` does not return text from clipboard

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -217,7 +217,7 @@ openUrlInIncognito = (request) ->
 # We return null to avoid the return value from the copy operations being passed to sendResponse.
 #
 copyToClipboard = (request) -> Clipboard.copy(request.data); null
-pasteFromClipboard = (request) -> Clipboard.paste(); null
+pasteFromClipboard = (request) -> Clipboard.paste()
 
 #
 # Selects the tab with the ID specified in request.id


### PR DESCRIPTION
In `main.coffee`, the `pasteFromClipboard` handler calls `Clipboard.paste` but returns `null`, which will be received by a `callback` in `mode_visual_edit.coffee:86`