### PR TITLE
Set the parent tab when creating tabs.

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -204,6 +204,7 @@ openUrlInNewTab = (request, callback) ->
       index: tab.index + 1
       selected: true
       windowId: tab.windowId
+      openerTabId: tab.id
     # FIXME(smblott). openUrlInNewTab is being called in two different ways with different arguments.  We
     # should refactor it such that this check on callback isn't necessary.
     callback = (->) unless typeof callback == "function"

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -187,31 +187,28 @@ getCompletionKeysRequest = (request, keysToCheck = "") ->
   completionKeys: generateCompletionKeys(keysToCheck)
   validFirstKeys: validFirstKeys
 
-#
-# Opens the url in the current tab.
-#
-openUrlInCurrentTab = (request) ->
-  chrome.tabs.getSelected(null,
-    (tab) -> chrome.tabs.update(tab.id, { url: Utils.convertToUrl(request.url) }))
+TabOperations =
+  # Opens the url in the current tab.
+  openUrlInCurrentTab: (request, callback = (->)) ->
+    chrome.tabs.getSelected null, (tab) ->
+      callback = (->) unless typeof callback == "function"
+      chrome.tabs.update tab.id, { url: Utils.convertToUrl(request.url) }, callback
 
-#
-# Opens request.url in new tab and switches to it if request.selected is true.
-#
-openUrlInNewTab = (request, callback) ->
-  chrome.tabs.getSelected null, (tab) ->
-    tabConfig =
-      url: Utils.convertToUrl request.url
-      index: tab.index + 1
-      selected: true
-      windowId: tab.windowId
+  # Opens request.url in new tab and switches to it if request.selected is true.
+  openUrlInNewTab: (request, callback = (->)) ->
+    chrome.tabs.getSelected null, (tab) ->
+      tabConfig =
+        url: Utils.convertToUrl request.url
+        index: tab.index + 1
+        selected: true
+        windowId: tab.windowId
       openerTabId: tab.id
-    # FIXME(smblott). openUrlInNewTab is being called in two different ways with different arguments.  We
-    # should refactor it such that this check on callback isn't necessary.
-    callback = (->) unless typeof callback == "function"
-    chrome.tabs.create tabConfig, callback
+      callback = (->) unless typeof callback == "function"
+      chrome.tabs.create tabConfig, callback
 
-openUrlInIncognito = (request) ->
-  chrome.windows.create({ url: Utils.convertToUrl(request.url), incognito: true})
+  openUrlInIncognito: (request, callback = (->)) ->
+    callback = (->) unless typeof callback == "function"
+    chrome.windows.create {url: Utils.convertToUrl(request.url), incognito: true}, callback
 
 #
 # Copies or pastes some data (request.data) to/from the clipboard.
@@ -257,7 +254,7 @@ BackgroundCommands =
       if url == "pages/blank.html"
         # "pages/blank.html" does not work in incognito mode, so fall back to "chrome://newtab" instead.
         url = if tab.incognito then "chrome://newtab" else chrome.runtime.getURL url
-      openUrlInNewTab { url }, callback
+      TabOperations.openUrlInNewTab { url }, callback
   duplicateTab: (callback) ->
     chrome.tabs.getSelected(null, (tab) ->
       chrome.tabs.duplicate(tab.id)
@@ -297,8 +294,8 @@ BackgroundCommands =
               scrollX: tabQueueEntry.scrollX,
               scrollY: tabQueueEntry.scrollY)
           callback()))
-  openCopiedUrlInCurrentTab: (request) -> openUrlInCurrentTab({ url: Clipboard.paste() })
-  openCopiedUrlInNewTab: (request) -> openUrlInNewTab({ url: Clipboard.paste() })
+  openCopiedUrlInCurrentTab: (request) -> TabOperations.openUrlInCurrentTab({ url: Clipboard.paste() })
+  openCopiedUrlInNewTab: (request) -> TabOperations.openUrlInNewTab({ url: Clipboard.paste() })
   togglePinTab: (request) ->
     chrome.tabs.getSelected(null, (tab) ->
       chrome.tabs.update(tab.id, { pinned: !tab.pinned }))
@@ -653,9 +650,9 @@ portHandlers =
 sendRequestHandlers =
   getCompletionKeys: getCompletionKeysRequest
   getCurrentTabUrl: getCurrentTabUrl
-  openUrlInNewTab: openUrlInNewTab
-  openUrlInIncognito: openUrlInIncognito
-  openUrlInCurrentTab: openUrlInCurrentTab
+  openUrlInNewTab: TabOperations.openUrlInNewTab
+  openUrlInIncognito: TabOperations.openUrlInIncognito
+  openUrlInCurrentTab: TabOperations.openUrlInCurrentTab
   openOptionsPageInNewTab: openOptionsPageInNewTab
   registerFrame: registerFrame
   unregisterFrame: unregisterFrame
@@ -726,7 +723,7 @@ showUpgradeMessage = ->
           Settings.set "previousVersion", currentVersion
           chrome.notifications.onClicked.addListener (id) ->
             if id == notificationId
-              openUrlInNewTab url: "https://github.com/philc/vimium#release-notes"
+              TabOperations.openUrlInNewTab url: "https://github.com/philc/vimium#release-notes"
     else
       # We need to wait for the user to accept the "notifications" permission.
       chrome.permissions.onAdded.addListener showUpgradeMessage
@@ -741,3 +738,5 @@ chrome.windows.getAll { populate: true }, (windows) ->
       chrome.tabs.sendMessage(tab.id, { name: "getScrollPosition" }, createScrollPositionHandler())
 
 showUpgradeMessage()
+
+root.TabOperations = TabOperations

--- a/background_scripts/marks.coffee
+++ b/background_scripts/marks.coffee
@@ -82,7 +82,7 @@ Marks =
           @gotoPositionInTab extend markInfo, tabId: tab.id
       else
         # There is no existing matching tab, we'll have to create one.
-        chrome.tabs.create { url: @getBaseUrl markInfo.url }, (tab) =>
+        TabOperations.openUrlInNewTab { url: @getBaseUrl markInfo.url }, (tab) =>
           # Note. tabLoadedHandlers is defined in "main.coffee".  The handler below will be called when the tab
           # is loaded, its DOM is ready and it registers with the background page.
           tabLoadedHandlers[tab.id] = => @gotoPositionInTab extend markInfo, tabId: tab.id

--- a/content_scripts/mode_find.coffee
+++ b/content_scripts/mode_find.coffee
@@ -101,7 +101,7 @@ class FindMode extends Mode
     # character. here we grep for the relevant escape sequences.
     @query.isRegex = Settings.get 'regexFindMode'
     hasNoIgnoreCaseFlag = false
-    @query.parsedQuery = @query.rawQuery.replace /(\\{1,2})([rRI]?)/g, (match, slashes, flag) ->
+    @query.parsedQuery = @query.rawQuery.replace /(\\{1,2})([rRI]?)/g, (match, slashes, flag) =>
       return match if flag == "" or slashes.length != 1
       switch (flag)
         when "r"


### PR DESCRIPTION
Trivial change, but UX win.

When creating new tabs, set the parent tab.  If the tab is subsequently deleted, then we return to the original tab (as opposed to the one on its right).