### PR TITLE
Switch frame with link hints and refactor link hint modes

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -50,6 +50,17 @@ class LinkHintsMode
     return unless document.documentElement
     @isActive = true
 
+    @hintMode = new Mode
+      name: "hint/#{mode.name}"
+      indicator: false
+      passInitialKeyupEvents: true
+      suppressAllKeyboardEvents: true
+      exitOnEscape: true
+      exitOnClick: true
+      exitOnScroll: true
+
+    @setOpenLinkMode mode
+
     elements = @getVisibleClickableElements()
     # For these modes, we filter out those elements which don't have an HREF (since there's nothing we can do
     # with them).
@@ -64,22 +75,12 @@ class LinkHintsMode
     @markerMatcher = new (if Settings.get "filterLinkHints" then FilterHints else AlphabetHints)
     @markerMatcher.fillInMarkers hintMarkers
 
-    @hintMode = new Mode
-      name: "hint/#{mode.name}"
-      indicator: false
-      passInitialKeyupEvents: true
-      suppressAllKeyboardEvents: true
-      exitOnEscape: true
-      exitOnClick: true
-      exitOnScroll: true
+    @hintMode.push
       keydown: @onKeyDownInMode.bind this, hintMarkers
       keypress: @onKeyPressInMode.bind this, hintMarkers
 
     @hintMode.onExit =>
       @deactivateMode() if @isActive
-
-    @setOpenLinkMode mode
-
     # Note(philc): Append these markers as top level children instead of as child nodes to the link itself,
     # because some clickable elements cannot contain children, e.g. submit buttons.
     @hintMarkerContainingDiv = DomUtils.addElementList hintMarkers,

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -332,9 +332,10 @@ class LinkHintsMode
   activateLink: (matchedLink, delay = 0) ->
     @delayMode = true
     clickEl = matchedLink.clickableItem
+    callbackObject = {}
+
     if (DomUtils.isSelectable(clickEl))
       DomUtils.simulateSelect(clickEl)
-      @deactivateMode delay
     else
       # TODO figure out which other input elements should not receive focus
       if (clickEl.nodeName.toLowerCase() == "input" and clickEl.type not in ["button", "submit"])
@@ -342,9 +343,9 @@ class LinkHintsMode
       DomUtils.flashRect(matchedLink.rect)
       @linkActivator(clickEl)
       if @mode is OPEN_WITH_QUEUE
-        @deactivateMode delay, -> LinkHints.activateModeWithQueue()
-      else
-        @deactivateMode delay
+        callbackObject.callback = -> LinkHints.activateModeWithQueue()
+
+    @deactivateMode delay, callbackObject.callback
 
   #
   # Shows the marker, highlighting matchingCharCount characters.
@@ -359,7 +360,7 @@ class LinkHintsMode
 
   hideMarker: (linkMarker) -> linkMarker.style.display = "none"
 
-  deactivateMode: (delay = 0, callback = null) ->
+  deactivateMode: (delay = 0, callback) ->
     deactivate = =>
       DomUtils.removeElement @hintMarkerContainingDiv if @hintMarkerContainingDiv
       @hintMarkerContainingDiv = null

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -53,6 +53,15 @@ DOWNLOAD_LINK_URL =
   name: "download"
   indicator: "Download link URL."
   keys: altKey: true
+CHANGE_FRAME =
+  name: "frame"
+  indicator: "Move focus to new frame."
+  linkActivator: (frameElement) -> frameElement.contentWindow.focus()
+  getVisibleClickable: (element) ->
+    return [] unless element.tagName.toUpperCase() in ["IFRAME", "FRAME"]
+
+    clientRect = DomUtils.getVisibleClientRect element, true
+    if clientRect then [{element: element, rect: clientRect}] else []
 
 LinkHints =
   activateMode: (mode = OPEN_IN_CURRENT_TAB) -> new LinkHintsMode mode
@@ -63,6 +72,7 @@ LinkHints =
   activateModeWithQueue: -> @activateMode OPEN_WITH_QUEUE
   activateModeToOpenIncognito: -> @activateMode OPEN_INCOGNITO
   activateModeToDownloadLink: -> @activateMode DOWNLOAD_LINK_URL
+  activateModeToChangeFrame: -> @activateMode CHANGE_FRAME
 
 class LinkHintsMode
   hintMarkerContainingDiv: null

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -100,15 +100,18 @@ class LinkHintsMode
 
   setOpenLinkMode: (@mode) ->
     @hintMode.setIndicator @mode.indicator
+    keys = {}
+    # Default to clicking the link with the modifier keys described in `keys`. This is overridden for modes
+    # which use another kind of activator.
+    @linkActivator = (link) -> DomUtils.simulateClick link, keys
     if @mode is OPEN_IN_NEW_BG_TAB or @mode is OPEN_IN_NEW_FG_TAB or @mode is OPEN_WITH_QUEUE
-      @linkActivator = (link) ->
-        # When "clicking" on a link, dispatch the event with the appropriate meta key (CMD on Mac, CTRL on
-        # windows) to open it in a new tab if necessary.
-        DomUtils.simulateClick link,
-          shiftKey: @mode is OPEN_IN_NEW_FG_TAB
-          metaKey: KeyboardUtils.platform == "Mac"
-          ctrlKey: KeyboardUtils.platform != "Mac"
-          altKey: false
+      # When "clicking" on a link, dispatch the event with the appropriate meta key (CMD on Mac, CTRL on
+      # windows) to open it in a new tab if necessary.
+      keys =
+        shiftKey: @mode is OPEN_IN_NEW_FG_TAB
+        metaKey: KeyboardUtils.platform == "Mac"
+        ctrlKey: KeyboardUtils.platform != "Mac"
+        altKey: false
     else if @mode is COPY_LINK_URL
       @linkActivator = (link) =>
         if link.href?
@@ -122,10 +125,9 @@ class LinkHintsMode
       @linkActivator = (link) ->
         chrome.runtime.sendMessage handler: 'openUrlInIncognito', url: link.href
     else if @mode is DOWNLOAD_LINK_URL
-      @linkActivator = (link) ->
-        DomUtils.simulateClick link, altKey: true, ctrlKey: false, metaKey: false
+      keys = altKey: true, ctrlKey: false, metaKey: false
     else # OPEN_IN_CURRENT_TAB
-      @linkActivator = (link) -> DomUtils.simulateClick.bind(DomUtils, link)()
+      keys = {}
 
   #
   # Creates a link marker for the given link.

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -149,6 +149,8 @@ class LinkHintsMode
   # the viewport.  There may be more than one part of element which is clickable (for example, if it's an
   # image), therefore we always return a array of element/rect pairs (which may also be a singleton or empty).
   #
+  # If the active mode object has the property getVisibleClickable, that will be called instead of this.
+  #
   getVisibleClickable: (element) ->
     tagName = element.tagName.toLowerCase()
     isClickable = false
@@ -230,7 +232,7 @@ class LinkHintsMode
     # NOTE(mrmr1993): Our previous method (combined XPath and DOM traversal for jsaction) couldn't provide
     # this, so it's necessary to check whether elements are clickable in order, as we do below.
     for element in elements
-      visibleElement = @getVisibleClickable element
+      visibleElement = (@mode.getVisibleClickable ? @getVisibleClickable) element
       visibleElements.push visibleElement...
 
     # TODO(mrmr1993): Consider z-index. z-index affects behviour as follows:

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -10,13 +10,27 @@
 #
 # The "name" property below is a short-form name to appear in the link-hints mode's name.  It's for debug only.
 #
-OPEN_IN_CURRENT_TAB = name: "curr-tab"
-OPEN_IN_NEW_BG_TAB = name: "bg-tab"
-OPEN_IN_NEW_FG_TAB = name: "fg-tab"
-OPEN_WITH_QUEUE = name: "queue"
-COPY_LINK_URL = name: "link"
-OPEN_INCOGNITO = name: "incognito"
-DOWNLOAD_LINK_URL = name: "download"
+OPEN_IN_CURRENT_TAB =
+  name: "curr-tab"
+  indicator: "Open link in current tab."
+OPEN_IN_NEW_BG_TAB =
+  name: "bg-tab"
+  indicator: "Open link in new tab."
+OPEN_IN_NEW_FG_TAB =
+  name: "fg-tab"
+  indicator: "Open link in new tab and switch to it."
+OPEN_WITH_QUEUE =
+  name: "queue"
+  indicator: "Open multiple links in new tabs."
+COPY_LINK_URL =
+  name: "link"
+  indicator: "Copy link URL to Clipboard."
+OPEN_INCOGNITO =
+  name: "incognito"
+  indicator: "Open link in incognito window."
+DOWNLOAD_LINK_URL =
+  name: "download"
+  indicator: "Download link URL."
 
 LinkHints =
   activateMode: (mode = OPEN_IN_CURRENT_TAB) -> new LinkHintsMode mode
@@ -85,13 +99,8 @@ class LinkHintsMode
       id: "vimiumHintMarkerContainer", className: "vimiumReset"
 
   setOpenLinkMode: (@mode) ->
+    @hintMode.setIndicator @mode.indicator
     if @mode is OPEN_IN_NEW_BG_TAB or @mode is OPEN_IN_NEW_FG_TAB or @mode is OPEN_WITH_QUEUE
-      if @mode is OPEN_IN_NEW_BG_TAB
-        @hintMode.setIndicator "Open link in new tab."
-      else if @mode is OPEN_IN_NEW_FG_TAB
-        @hintMode.setIndicator "Open link in new tab and switch to it."
-      else
-        @hintMode.setIndicator "Open multiple links in new tabs."
       @linkActivator = (link) ->
         # When "clicking" on a link, dispatch the event with the appropriate meta key (CMD on Mac, CTRL on
         # windows) to open it in a new tab if necessary.
@@ -101,7 +110,6 @@ class LinkHintsMode
           ctrlKey: KeyboardUtils.platform != "Mac"
           altKey: false
     else if @mode is COPY_LINK_URL
-      @hintMode.setIndicator "Copy link URL to Clipboard."
       @linkActivator = (link) =>
         if link.href?
           chrome.runtime.sendMessage handler: "copyToClipboard", data: link.href
@@ -111,15 +119,12 @@ class LinkHintsMode
         else
           @onExit = -> HUD.showForDuration "No link to yank.", 2000
     else if @mode is OPEN_INCOGNITO
-      @hintMode.setIndicator "Open link in incognito window."
       @linkActivator = (link) ->
         chrome.runtime.sendMessage handler: 'openUrlInIncognito', url: link.href
     else if @mode is DOWNLOAD_LINK_URL
-      @hintMode.setIndicator "Download link URL."
       @linkActivator = (link) ->
         DomUtils.simulateClick link, altKey: true, ctrlKey: false, metaKey: false
     else # OPEN_IN_CURRENT_TAB
-      @hintMode.setIndicator "Open link in current tab."
       @linkActivator = (link) -> DomUtils.simulateClick.bind(DomUtils, link)()
 
   #


### PR DESCRIPTION
This PR
* refactors the code for modes in `LinkHints` to
  - allow diffferent `linkActivators` and `getVisibleClickable` implementations for each mode
  - make it clearer which mode does what
  - make new mode definitions orthoganal to the definition of `LinkHintsMode`
* fixes bugs where `COPY_LINK_URL` and `OPEN_INCOGNITO` focus the `contentEditable` element containing a link instead of working on the link itself
* adds a new command (`activateModeToChangeFrame`) that selects frames using link hints
  - this is not yet exposed as a mappable command
  - when cross-frame link hints are implemented, this can be exposed to fix issue #494

This is the first part of an effort towards cross-frame link hints (#602), and also allows for useful possibilities such as #425. Each commit here is atomic, and so the commits may be easier to check than the PR diff.