### PR TITLE
Only apply passkeys to single character keys explicitly

### DIFF
--- a/content_scripts/mode_passkeys.coffee
+++ b/content_scripts/mode_passkeys.coffee
@@ -12,7 +12,7 @@ class PassKeysMode extends Mode
   # passKey, then 'gt' and '99t' will neverthless be handled by Vimium.
   handleKeyChar: (event, keyChar) ->
     return @continueBubbling if event.altKey or event.ctrlKey or event.metaKey
-    if keyChar and not @keyQueue and 0 <= @passKeys.indexOf keyChar
+    if keyChar and not @keyQueue and keyChar.length == 1 and 0 <= @passKeys.indexOf keyChar
       @stopBubblingAndTrue
     else
       @continueBubbling


### PR DESCRIPTION
A string in `KeyboardUtils.keyNames` could have the key it represents disabled if
* its letters were in alphabetical order, and
* the user has set all of its letters as passkeys, with none in between.

For example, imagining that `del` (for delete) was in `KeyboardUtils.keyNames`, the passkeys `dpyl0e` would cause the delete key to be a passkey too.

This commit fixes the potential issue by only applying passkeys when `keyChar` is a single character.