### PR TITLE
Normal mode key handling in frontend as a generic inheritable class

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -499,13 +499,6 @@ root.refreshCompletionKeysAfterMappingSave = ->
 
   sendRequestToAllTabs(getCompletionKeysRequest())
 
-splitKeyQueue = (queue) ->
-  match = /([1-9][0-9]*)?(.*)/.exec(queue)
-  count = parseInt(match[1], 10)
-  command = match[2]
-
-  { count: count, command: command }
-
 handleKeyDown = (request, port) ->
   {keyChar: key, keyQueue: queue} = request
   if queue?

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -25,7 +25,6 @@ tabInfoMap = {} # tabId -> object with various tab properties
 # Queue of keys typed. If keyQueueArray.numericPrefix is true, its 0th entry is the current command's numeric
 # prefix.
 keyQueueArray = []
-validFirstKeys = {}
 commandKeys = []
 focusedFrame = null
 frameIdsForTab = {}
@@ -468,19 +467,12 @@ splitByKeys = (key) ->
       key = key[1..]
   returnArray
 
-populateValidFirstKeys = ->
-  validFirstKeys = {}
-  for keys in commandKeys
-    if (keys.length > 1)
-      validFirstKeys[keys[0]] = true
-
 populateCommandKeys = ->
   commandKeys = (splitByKeys key for key of Commands.keyToCommandRegistry)
 
 # Invoked by options.coffee.
 root.refreshCompletionKeysAfterMappingSave = ->
   populateCommandKeys()
-  populateValidFirstKeys()
 
   sendRequestToAllTabs(getCompletionKeysRequest())
 
@@ -695,7 +687,6 @@ if Settings.has("keyMappings")
   Commands.parseCustomKeyMappings(Settings.get("keyMappings"))
 
 populateCommandKeys()
-populateValidFirstKeys()
 
 # Show notification on upgrade.
 showUpgradeMessage = ->

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -470,16 +470,19 @@ getActualKeyStrokeLength = (key) ->
     key.length
 
 populateValidFirstKeys = ->
+  validFirstKeys = {}
   for key of Commands.keyToCommandRegistry
     if (getActualKeyStrokeLength(key) == 2)
       validFirstKeys[splitKeyIntoFirstAndSecond(key).first] = true
 
 populateSingleKeyCommands = ->
+  singleKeyCommands = []
   for key of Commands.keyToCommandRegistry
     if (getActualKeyStrokeLength(key) == 1)
       singleKeyCommands.push(key)
 
 populateCommandKeys = ->
+  commandKeys = []
   for key of Commands.keyToCommandRegistry
     splitKey = splitKeyIntoFirstAndSecond(key)
     if splitKey.second
@@ -489,10 +492,6 @@ populateCommandKeys = ->
 
 # Invoked by options.coffee.
 root.refreshCompletionKeysAfterMappingSave = ->
-  validFirstKeys = {}
-  singleKeyCommands = []
-  commandKeys = []
-
   populateCommandKeys()
   populateValidFirstKeys()
   populateSingleKeyCommands()

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -506,10 +506,8 @@ generateCompletionKeys = (keysToCheck) ->
   completionKeys = singleKeyCommands.slice(0)
 
   if (getActualKeyStrokeLength(command) == 1)
-    for key of Commands.keyToCommandRegistry
-      splitKey = splitKeyIntoFirstAndSecond(key)
-      if (splitKey.first == command)
-        completionKeys.push(splitKey.second)
+    for keys of commandKeys
+      completionKeys.push keys[1] if keys[0] == command
 
   completionKeys
 

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -475,9 +475,7 @@ populateValidFirstKeys = ->
       validFirstKeys[keys[0]] = true
 
 populateCommandKeys = ->
-  commandKeys = []
-  for key of Commands.keyToCommandRegistry
-    commandKeys.push splitByKeys key
+  commandKeys = (splitByKeys key for key of Commands.keyToCommandRegistry)
 
 # Invoked by options.coffee.
 root.refreshCompletionKeysAfterMappingSave = ->

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -515,16 +515,17 @@ checkKeyQueue = (keysToCheck, tabId, frameId) ->
 
   return keysToCheck if command.length == 0
 
-  registryEntry = Commands.keyToCommandRegistry[command.join ""]
-  if registryEntry
-    executeCommand registryEntry, count, tabId, frameId
-    newKeyQueue = []
-  else
-    partiallyMatchingCommands = commandKeys.filter keysPartialMatch.bind null, command
-    if partiallyMatchingCommands.length > 0
-      newKeyQueue = keys
+  partiallyMatchingCommands = commandKeys.filter keysPartialMatch.bind null, command
+
+  if partiallyMatchingCommands.length > 0
+    registryEntry = Commands.keyToCommandRegistry[command.join ""]
+    if registryEntry
+      executeCommand registryEntry, count, tabId, frameId
+      newKeyQueue = []
     else
-      newKeyQueue = checkKeyQueue command[1..], tabId, frameId
+      newKeyQueue = keys
+  else
+    newKeyQueue = checkKeyQueue command[1..], tabId, frameId
 
   newKeyQueue
 

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -22,9 +22,9 @@ currentVersion = Utils.getCurrentVersion()
 tabQueue = {} # windowId -> Array
 tabInfoMap = {} # tabId -> object with various tab properties
 
-# Queue of keys typed. If keyQueueArray.numericPrefix is true, its 0th entry is the current command's numeric
+# Queue of keys typed. If keyQueue.numericPrefix is true, its 0th entry is the current command's numeric
 # prefix.
-keyQueueArray = []
+keyQueue = []
 commandKeys = []
 focusedFrame = null
 frameIdsForTab = {}
@@ -485,12 +485,12 @@ handleKeyDown = (request, port) ->
       console.log "Incomplete key queue passed to the background page. This should not happen."
   else if (key == "<ESC>")
     console.log("clearing keyQueue")
-    keyQueueArray = []
+    keyQueue = []
   else
-    keyQueueArray.push key
-    console.log("checking keyQueue: [", keyQueueArray.join(""), "]")
-    keyQueueArray = checkKeyQueue(keyQueueArray, port.sender.tab.id, request.frameId)
-    console.log("new KeyQueue: " + keyQueueArray.join(""))
+    keyQueue.push key
+    console.log("checking keyQueue: [", keyQueue.join(""), "]")
+    keyQueue = checkKeyQueue(keyQueue, port.sender.tab.id, request.frameId)
+    console.log("new KeyQueue: " + keyQueue.join(""))
   # Tell the content script whether there are keys in the queue.
   # FIXME: There is a race condition here.  The behaviour in the content script depends upon whether this message gets
   # back there before or after the next keystroke.
@@ -498,7 +498,7 @@ handleKeyDown = (request, port) ->
   # Steve (23 Aug, 14).
   chrome.tabs.sendMessage(port.sender.tab.id,
     name: "currentKeyQueue",
-    keyQueue: keyQueueArray)
+    keyQueue: keyQueue)
 
 simplifyNumericPrefix = (keys) ->
   keys = keys[0..] # Make a copy of keys so the passed array isn't mutated.

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -463,12 +463,6 @@ splitKeyIntoFirstAndSecond = (key) ->
   else
     { first: key[0], second: key.slice(1) }
 
-getActualKeyStrokeLength = (key) ->
-  if (key.search(namedKeyRegex) == 0)
-    1 + getActualKeyStrokeLength(RegExp.$2)
-  else
-    key.length
-
 populateValidFirstKeys = ->
   validFirstKeys = {}
   for keys in commandKeys

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -185,7 +185,6 @@ fetchFileContents = (extensionFileName) ->
 #
 getCompletionKeysRequest = (request, keysToCheck = "") ->
   name: "refreshCompletionKeys"
-  completionKeys: generateCompletionKeys(keysToCheck)
   commandKeys: commandKeys
 
 TabOperations =

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -542,7 +542,7 @@ handleKeyDown = (request, port) ->
   # Steve (23 Aug, 14).
   chrome.tabs.sendMessage(port.sender.tab.id,
     name: "currentKeyQueue",
-    keyQueue: keyQueueArray.join(""))
+    keyQueue: keyQueueArray)
 
 simplifyNumericPrefix = (keys) ->
   keys = keys[0..] # Make a copy of keys so the passed array isn't mutated.

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -27,7 +27,6 @@ tabInfoMap = {} # tabId -> object with various tab properties
 keyQueueArray = []
 validFirstKeys = {}
 commandKeys = []
-singleKeyCommands = []
 focusedFrame = null
 frameIdsForTab = {}
 root.urlForTab = {}
@@ -476,12 +475,6 @@ populateValidFirstKeys = ->
     if (keys.length > 1)
       validFirstKeys[keys[0]] = true
 
-populateSingleKeyCommands = ->
-  singleKeyCommands = []
-  for keys in commandKeys
-    if (keys.length == 1)
-      singleKeyCommands.push(keys[0])
-
 populateCommandKeys = ->
   commandKeys = []
   for key of Commands.keyToCommandRegistry
@@ -495,7 +488,6 @@ populateCommandKeys = ->
 root.refreshCompletionKeysAfterMappingSave = ->
   populateCommandKeys()
   populateValidFirstKeys()
-  populateSingleKeyCommands()
 
   sendRequestToAllTabs(getCompletionKeysRequest())
 
@@ -712,7 +704,6 @@ if Settings.has("keyMappings")
 
 populateCommandKeys()
 populateValidFirstKeys()
-populateSingleKeyCommands()
 
 # Show notification on upgrade.
 showUpgradeMessage = ->

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -23,6 +23,7 @@ tabQueue = {} # windowId -> Array
 tabInfoMap = {} # tabId -> object with various tab properties
 keyQueue = "" # Queue of keys typed
 validFirstKeys = {}
+commandKeys = []
 singleKeyCommands = []
 focusedFrame = null
 frameIdsForTab = {}
@@ -186,6 +187,7 @@ getCompletionKeysRequest = (request, keysToCheck = "") ->
   name: "refreshCompletionKeys"
   completionKeys: generateCompletionKeys(keysToCheck)
   validFirstKeys: validFirstKeys
+  commandKeys: commandKeys
 
 TabOperations =
   # Opens the url in the current tab.
@@ -477,11 +479,21 @@ populateSingleKeyCommands = ->
     if (getActualKeyStrokeLength(key) == 1)
       singleKeyCommands.push(key)
 
+populateCommandKeys = ->
+  for key of Commands.keyToCommandRegistry
+    splitKey = splitKeyIntoFirstAndSecond(key)
+    if splitKey.second
+      commandKeys.push [splitKey.first, splitKey.second]
+    else
+      commandKeys.push [splitKey.first]
+
 # Invoked by options.coffee.
 root.refreshCompletionKeysAfterMappingSave = ->
   validFirstKeys = {}
   singleKeyCommands = []
+  commandKeys = []
 
+  populateCommandKeys()
   populateValidFirstKeys()
   populateSingleKeyCommands()
 
@@ -701,6 +713,7 @@ Commands.clearKeyMappingsAndSetDefaults()
 if Settings.has("keyMappings")
   Commands.parseCustomKeyMappings(Settings.get("keyMappings"))
 
+populateCommandKeys()
 populateValidFirstKeys()
 populateSingleKeyCommands()
 

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -474,7 +474,6 @@ root.refreshCompletionKeysAfterMappingSave = ->
 
 handleKeyDown = (request, port) ->
   {keyChar: key, keyQueue} = request
-  keyQueue = checkKeyQueue(keyQueue, request.frameId, port.sender)
   # Tell the content script whether there are keys in the queue.
   # FIXME: There is a race condition here.  The behaviour in the content script depends upon whether this message gets
   # back there before or after the next keystroke.
@@ -483,51 +482,6 @@ handleKeyDown = (request, port) ->
   chrome.tabs.sendMessage(port.sender.tab.id,
     name: "currentKeyQueue",
     keyQueue: keyQueue)
-
-simplifyNumericPrefix = (keys) ->
-  keys = keys[0..] # Make a copy of keys so the passed array isn't mutated.
-  keys.numericPrefix = /^[1-9]/.test (keys[0] or "")
-
-  if keys.numericPrefix
-    i = 1
-    i++ while i < keys.length and /^[0-9]/.test keys[i]
-    # keysToCheck[1..i] are numeric, remove them from the array and append them to the prefix.
-    keys[0] += keys.splice(1, i - 1).join ""
-
-  keys
-
-# Returns true if the keys in keys1 match the first keys in keys2.
-keysPartialMatch = (keys1, keys2) ->
-  return false if keys1.length > keys2.length
-  for key, i in keys1
-    return false if key != keys2[i]
-  true
-
-checkKeyQueue = (keysToCheck, frameId, sender) ->
-  keys = simplifyNumericPrefix keysToCheck
-
-  if keys.numericPrefix
-    [count, command...] = keys
-    count = (parseInt count, 10) or 1
-  else
-    command = keys
-    count = 1
-
-  return keysToCheck if command.length == 0
-
-  partiallyMatchingCommands = commandKeys.filter keysPartialMatch.bind null, command
-
-  if partiallyMatchingCommands.length > 0
-    [finalCommand] = partiallyMatchingCommands.filter ({length}) -> command.length == length
-    if finalCommand
-      executeCommand {command: finalCommand.join(""), count, frameId}, sender
-      newKeyQueue = []
-    else
-      newKeyQueue = keys
-  else
-    newKeyQueue = checkKeyQueue command[1..], tabId, frameId
-
-  newKeyQueue
 
 executeCommand = (request, sender) ->
   {command, count, frameId} = request

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -457,11 +457,16 @@ updatePositionsAndWindowsForAllTabsInWindow = (windowId) ->
         openTabInfo.positionIndex = tab.index
         openTabInfo.windowId = tab.windowId)
 
-splitKeyIntoFirstAndSecond = (key) ->
-  if (key.search(namedKeyRegex) == 0)
-    { first: RegExp.$1, second: RegExp.$2 }
-  else
-    { first: key[0], second: key.slice(1) }
+splitByKeys = (key) ->
+  returnArray = []
+  while key
+    if (key.search(namedKeyRegex) == 0)
+      returnArray.push RegExp.$1
+      key = RegExp.$2
+    else
+      returnArray.push key[0]
+      key = key[1..]
+  returnArray
 
 populateValidFirstKeys = ->
   validFirstKeys = {}
@@ -472,11 +477,7 @@ populateValidFirstKeys = ->
 populateCommandKeys = ->
   commandKeys = []
   for key of Commands.keyToCommandRegistry
-    splitKey = splitKeyIntoFirstAndSecond(key)
-    if splitKey.second
-      commandKeys.push [splitKey.first, splitKey.second]
-    else
-      commandKeys.push [splitKey.first]
+    commandKeys.push splitByKeys key
 
 # Invoked by options.coffee.
 root.refreshCompletionKeysAfterMappingSave = ->

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -473,15 +473,6 @@ root.refreshCompletionKeysAfterMappingSave = ->
   sendRequestToAllTabs(getCompletionKeysRequest())
 
 handleKeyDown = (request, port) ->
-  {keyChar: key, keyQueue} = request
-  # Tell the content script whether there are keys in the queue.
-  # FIXME: There is a race condition here.  The behaviour in the content script depends upon whether this message gets
-  # back there before or after the next keystroke.
-  # That being said, I suspect there are other similar race conditions here, for example in checkKeyQueue().
-  # Steve (23 Aug, 14).
-  chrome.tabs.sendMessage(port.sender.tab.id,
-    name: "currentKeyQueue",
-    keyQueue: keyQueue)
 
 executeCommand = (request, sender) ->
   {command, count, frameId} = request

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -474,14 +474,7 @@ root.refreshCompletionKeysAfterMappingSave = ->
 
 handleKeyDown = (request, port) ->
   {keyChar: key, keyQueue} = request
-  if (key == "<ESC>")
-    console.log("clearing keyQueue")
-    keyQueue = []
-  else
-    keyQueue.push key
-    console.log("checking keyQueue: [", keyQueue.join(""), "]")
-    keyQueue = checkKeyQueue(keyQueue, port.sender.tab.id, request.frameId)
-    console.log("new KeyQueue: " + keyQueue.join(""))
+  keyQueue = checkKeyQueue(keyQueue, port.sender.tab.id, request.frameId)
   # Tell the content script whether there are keys in the queue.
   # FIXME: There is a race condition here.  The behaviour in the content script depends upon whether this message gets
   # back there before or after the next keystroke.

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -518,9 +518,9 @@ checkKeyQueue = (keysToCheck, tabId, frameId) ->
   partiallyMatchingCommands = commandKeys.filter keysPartialMatch.bind null, command
 
   if partiallyMatchingCommands.length > 0
-    registryEntry = Commands.keyToCommandRegistry[command.join ""]
-    if registryEntry
-      executeCommand registryEntry, count, tabId, frameId
+    [finalCommand] = partiallyMatchingCommands.filter ({length}) -> command.length == length
+    if finalCommand
+      executeCommand finalCommand.join(""), count, tabId, frameId
       newKeyQueue = []
     else
       newKeyQueue = keys
@@ -529,7 +529,8 @@ checkKeyQueue = (keysToCheck, tabId, frameId) ->
 
   newKeyQueue
 
-executeCommand = (registryEntry, count, tabId, frameId) ->
+executeCommand = (command, count, tabId, frameId) ->
+  registryEntry = Commands.keyToCommandRegistry[command]
   runCommand = true
 
   if registryEntry.noRepeat

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -471,9 +471,9 @@ getActualKeyStrokeLength = (key) ->
 
 populateValidFirstKeys = ->
   validFirstKeys = {}
-  for key of Commands.keyToCommandRegistry
-    if (getActualKeyStrokeLength(key) == 2)
-      validFirstKeys[splitKeyIntoFirstAndSecond(key).first] = true
+  for keys in commandKeys
+    if (keys.length > 1)
+      validFirstKeys[keys[0]] = true
 
 populateSingleKeyCommands = ->
   singleKeyCommands = []

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -21,10 +21,6 @@ chrome.runtime.onInstalled.addListener ({ reason }) ->
 currentVersion = Utils.getCurrentVersion()
 tabQueue = {} # windowId -> Array
 tabInfoMap = {} # tabId -> object with various tab properties
-
-# Queue of keys typed. If keyQueue.numericPrefix is true, its 0th entry is the current command's numeric
-# prefix.
-keyQueue = []
 commandKeys = []
 focusedFrame = null
 frameIdsForTab = {}
@@ -477,13 +473,8 @@ root.refreshCompletionKeysAfterMappingSave = ->
   sendRequestToAllTabs(getCompletionKeysRequest())
 
 handleKeyDown = (request, port) ->
-  {keyChar: key, keyQueue: queue} = request
-  if queue?
-    newKeyQueue = checkKeyQueue(queue, port.sender.tab.id, request.frameId)
-    unless newKeyQueue == []
-      # The queue passed wasn't for a whole command. This shouldn't happen, so we log a message if it does.
-      console.log "Incomplete key queue passed to the background page. This should not happen."
-  else if (key == "<ESC>")
+  {keyChar: key, keyQueue} = request
+  if (key == "<ESC>")
     console.log("clearing keyQueue")
     keyQueue = []
   else

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -520,6 +520,13 @@ simplifyNumericPrefix = (keys) ->
 
   keys
 
+# Returns true if the keys in keys1 match the first keys in keys2.
+keysPartialMatch = (keys1, keys2) ->
+  return false if keys1.length > keys2.length
+  for key, i in keys1
+    return false if key != keys2[i]
+  true
+
 checkKeyQueue = (keysToCheck, tabId, frameId) ->
   keys = simplifyNumericPrefix keysToCheck
 
@@ -536,14 +543,12 @@ checkKeyQueue = (keysToCheck, tabId, frameId) ->
   if registryEntry
     executeCommand registryEntry, count, tabId, frameId
     newKeyQueue = []
-  else if (command.length > 1)
-    # The second key might be a valid command by its self.
-    if (Commands.keyToCommandRegistry[command[1]])
-      newKeyQueue = checkKeyQueue(command[1..], tabId, frameId)
-    else
-      newKeyQueue = (if validFirstKeys[command[1]] then [command[1]] else [])
   else
-    newKeyQueue = (if validFirstKeys[command] then keys  else [])
+    partiallyMatchingCommands = commandKeys.filter keysPartialMatch.bind null, command
+    if partiallyMatchingCommands.length > 0
+      newKeyQueue = keys
+    else
+      newKeyQueue = checkKeyQueue command[1..], tabId, frameId
 
   newKeyQueue
 

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -499,20 +499,6 @@ root.refreshCompletionKeysAfterMappingSave = ->
 
   sendRequestToAllTabs(getCompletionKeysRequest())
 
-# Generates a list of keys that can complete a valid command given the current key queue or the one passed in
-generateCompletionKeys = (keysToCheck) ->
-  splitHash = splitKeyQueue(keysToCheck || keyQueueArray.join(""))
-  command = splitHash.command
-  count = splitHash.count
-
-  completionKeys = singleKeyCommands.slice(0)
-
-  if (getActualKeyStrokeLength(command) == 1)
-    for keys of commandKeys
-      completionKeys.push keys[1] if keys[0] == command
-
-  completionKeys
-
 splitKeyQueue = (queue) ->
   match = /([1-9][0-9]*)?(.*)/.exec(queue)
   count = parseInt(match[1], 10)
@@ -591,7 +577,6 @@ checkKeyQueue = (keysToCheck, tabId, frameId) ->
           command: registryEntry.command
           frameId: frameId
           count: count
-          completionKeys: generateCompletionKeys ""
           registryEntry: registryEntry
         refreshedCompletionKeys = true
       else

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -186,7 +186,6 @@ fetchFileContents = (extensionFileName) ->
 getCompletionKeysRequest = (request, keysToCheck = "") ->
   name: "refreshCompletionKeys"
   completionKeys: generateCompletionKeys(keysToCheck)
-  validFirstKeys: validFirstKeys
   commandKeys: commandKeys
 
 TabOperations =

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -523,8 +523,13 @@ splitKeyQueue = (queue) ->
   { count: count, command: command }
 
 handleKeyDown = (request, port) ->
-  key = request.keyChar
-  if (key == "<ESC>")
+  {keyChar: key, keyQueue: queue} = request
+  if queue?
+    newKeyQueue = checkKeyQueue(queue, port.sender.tab.id, request.frameId)
+    unless newKeyQueue == ""
+      # The queue passed wasn't for a whole command. This shouldn't happen, so we log a message if it does.
+      console.log "Incomplete key queue passed to the background page. This should not happen."
+  else if (key == "<ESC>")
     console.log("clearing keyQueue")
     keyQueue = ""
   else

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -499,23 +499,6 @@ root.refreshCompletionKeysAfterMappingSave = ->
 
   sendRequestToAllTabs(getCompletionKeysRequest())
 
-keyQueueToKeyQueueArray = (keyQueue) ->
-  {count, command} = splitKeyQueue keyQueue
-
-  newKeyQueueArray = [] if command.length == 0
-
-  splitKey = splitKeyIntoFirstAndSecond(command)
-  if splitKey.second
-    newKeyQueueArray = [splitKey.first, splitKey.second]
-  else
-    newKeyQueueArray = [splitKey.first]
-
-  unless isNaN count
-    newKeyQueueArray.numericPrefix = true
-    newKeyQueueArray.unshift count.toString()
-
-  newKeyQueueArray
-
 # Generates a list of keys that can complete a valid command given the current key queue or the one passed in
 generateCompletionKeys = (keysToCheck) ->
   splitHash = splitKeyQueue(keysToCheck || keyQueueArray.join(""))

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -477,9 +477,9 @@ populateValidFirstKeys = ->
 
 populateSingleKeyCommands = ->
   singleKeyCommands = []
-  for key of Commands.keyToCommandRegistry
-    if (getActualKeyStrokeLength(key) == 1)
-      singleKeyCommands.push(key)
+  for keys in commandKeys
+    if (keys.length == 1)
+      singleKeyCommands.push(keys[0])
 
 populateCommandKeys = ->
   commandKeys = []

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -522,8 +522,6 @@ simplifyNumericPrefix = (keys) ->
   keys
 
 checkKeyQueue = (keysToCheck, tabId, frameId) ->
-  refreshedCompletionKeys = false
-
   keys = simplifyNumericPrefix keysToCheck
 
   if keys.numericPrefix
@@ -557,7 +555,6 @@ checkKeyQueue = (keysToCheck, tabId, frameId) ->
           frameId: frameId
           count: count
           registryEntry: registryEntry
-        refreshedCompletionKeys = true
       else
         if registryEntry.passCountToFunction
           BackgroundCommands[registryEntry.command](count, frameId)
@@ -575,11 +572,6 @@ checkKeyQueue = (keysToCheck, tabId, frameId) ->
       newKeyQueue = (if validFirstKeys[command[1]] then [command[1]] else [])
   else
     newKeyQueue = (if validFirstKeys[command] then keys  else [])
-
-  # If we haven't sent the completion keys piggybacked on executePageCommand,
-  # send them by themselves.
-  unless refreshedCompletionKeys
-    chrome.tabs.sendMessage(tabId, getCompletionKeysRequest(null, newKeyQueue), null)
 
   newKeyQueue
 

--- a/content_scripts/mode_mapping.coffee
+++ b/content_scripts/mode_mapping.coffee
@@ -68,7 +68,7 @@ checkKeyQueue = (keysToCheck, commandKeys, successCallback, partialMatchCallback
 
   if command.length == 0
     partialMatchCallback? "", count if keys.numericPrefix
-    return keysToCheck
+    return keys
 
   partiallyMatchingCommands = commandKeys.filter keysPartialMatch.bind null, command
 

--- a/content_scripts/mode_mapping.coffee
+++ b/content_scripts/mode_mapping.coffee
@@ -165,23 +165,17 @@ onKeydown = (event) ->
       event.keyIdentifier && event.keyIdentifier.slice(0, 2) != "U+"))
     keyChar = KeyboardUtils.getKeyChar(event)
     # Again, ignore just modifiers. Maybe this should replace the keyCode>31 condition.
-    if (keyChar != "")
-      modifiers = []
+    if keyChar != ""
+      keyChar = keyChar.toUpperCase() if event.shiftKey
 
-      if (event.shiftKey)
-        keyChar = keyChar.toUpperCase()
-      if (event.metaKey)
-        modifiers.push("m")
-      if (event.ctrlKey)
-        modifiers.push("c")
-      if (event.altKey)
-        modifiers.push("a")
+      modifiers = ""
 
-      for i of modifiers
-        keyChar = modifiers[i] + "-" + keyChar
+      modifiers += "m-" if event.metaKey
+      modifiers += "c-" if event.ctrlKey
+      modifiers += "a-" if event.altKey
 
-      if (modifiers.length > 0 || keyChar.length > 1)
-        keyChar = "<" + keyChar + ">"
+      keyChar = modifiers + keyChar
+      keyChar = "<#{keyChar}>" if keyChar.length > 1
 
   if (keyChar)
     if @pushKeyToKeyQueue keyChar

--- a/content_scripts/mode_mapping.coffee
+++ b/content_scripts/mode_mapping.coffee
@@ -2,5 +2,83 @@ class MappingMode extends Mode
   constructor: (options) ->
     super options
 
+    # Queue of keys typed. If keyQueue.numericPrefix is true, its 0th entry is the current command's numeric
+    # prefix.
+    @keyQueue = []
+    @push
+      _name: "mode-#{@id}/registerKeyQueue"
+      registerKeyQueue: ({keyQueue}) => @alwaysContinueBubbling => @keyQueue = keyQueue
+
+  isCommandKey: (key) ->
+    matched = false
+    checkKeyQueue @keyQueue.concat([key]), @getCommandKeys(), (-> matched = true), (-> matched = true)
+    matched
+
+  clearKeyQueue: ->
+    bgLog "clearing keyQueue"
+    @keyQueue = []
+
+  pushKeyToKeyQueue: (key) ->
+    @keyQueue.push key
+    bgLog "checking keyQueue: [", @keyQueue.join(""), "]"
+    matched = false
+
+    @keyQueue = checkKeyQueue @keyQueue, @getCommandKeys(), ((command, count) =>
+      @matchedKeyHandler command, count
+      matched = true
+    ), (-> matched = true)
+
+    handlerStack.bubbleEvent "registerKeyQueue", {keyQueue: @keyQueue}
+    bgLog "new KeyQueue: " + @keyQueue.join("")
+    matched
+
+# Returns true if the keys in keys1 match the first keys in keys2.
+keysPartialMatch = (keys1, keys2) ->
+  return false if keys1.length > keys2.length
+  for key, i in keys1
+    return false if key != keys2[i]
+  true
+
+simplifyNumericPrefix = (keys) ->
+  keys = keys[0..] # Make a copy of keys so the passed array isn't mutated.
+  keys.numericPrefix = /^[1-9]/.test (keys[0] or "")
+
+  if keys.numericPrefix
+    i = 1
+    i++ while i < keys.length and /^[0-9]/.test keys[i]
+    # keysToCheck[1..i] are numeric, remove them from the array and append them to the prefix.
+    keys[0] += keys.splice(1, i - 1).join ""
+
+  keys
+
+checkKeyQueue = (keysToCheck, commandKeys, successCallback, partialMatchCallback) ->
+  keys = simplifyNumericPrefix keysToCheck
+
+  if keys.numericPrefix
+    [count, command...] = keys
+    count = (parseInt count, 10) or 1
+  else
+    command = keys
+    count = 1
+
+  if command.length == 0
+    partialMatchCallback? "", count if keys.numericPrefix
+    return keysToCheck
+
+  partiallyMatchingCommands = commandKeys.filter keysPartialMatch.bind null, command
+
+  if partiallyMatchingCommands.length > 0
+    [finalCommand] = partiallyMatchingCommands.filter ({length}) -> command.length == length
+    if finalCommand
+      successCallback? command.join(""), count
+      newKeyQueue = []
+    else
+      newKeyQueue = keys
+      partialMatchCallback? command.join(""), count
+  else
+    newKeyQueue = checkKeyQueue command[1..], commandKeys, successCallback, partialMatchCallback
+
+  newKeyQueue
+
 root = exports ? window
 root.MappingMode = MappingMode

--- a/content_scripts/mode_mapping.coffee
+++ b/content_scripts/mode_mapping.coffee
@@ -1,0 +1,6 @@
+class MappingMode extends Mode
+  constructor: (options) ->
+    super options
+
+root = exports ? window
+root.MappingMode = MappingMode

--- a/content_scripts/mode_mapping.coffee
+++ b/content_scripts/mode_mapping.coffee
@@ -1,5 +1,10 @@
 class MappingMode extends Mode
   constructor: (options) ->
+    extend options,
+      keydown: (event) => onKeydown.call @, event
+      keypress: (event) => onKeypress.call @, event
+      keyup: (event) => onKeyup.call @, event
+
     super options
 
     # Queue of keys typed. If keyQueue.numericPrefix is true, its 0th entry is the current command's numeric
@@ -79,6 +84,86 @@ checkKeyQueue = (keysToCheck, commandKeys, successCallback, partialMatchCallback
     newKeyQueue = checkKeyQueue command[1..], commandKeys, successCallback, partialMatchCallback
 
   newKeyQueue
+
+#
+# Sends everything except i & ESC to the handler in background_page. i & ESC are special because they control
+# insert mode which is local state to the page. The key will be are either a single ascii letter or a
+# key-modifier pair, e.g. <c-a> for control a.
+#
+# Note that some keys will only register keydown events and not keystroke events, e.g. ESC.
+#
+# @/this, here, is the the normal-mode Mode object.
+onKeypress = (event) ->
+  keyChar = ""
+
+  # Ignore modifier keys by themselves.
+  if (event.keyCode > 31)
+    keyChar = String.fromCharCode(event.charCode)
+
+    if (keyChar)
+      if @pushKeyToKeyQueue keyChar
+        DomUtils.suppressEvent(event)
+        return @stopBubblingAndTrue
+
+  return @continueBubbling
+
+# @/this, here, is the the normal-mode Mode object.
+onKeydown = (event) ->
+  keyChar = ""
+
+  # handle special keys, and normal input keys with modifiers being pressed. don't handle shiftKey alone (to
+  # avoid / being interpreted as ?
+  if (((event.metaKey || event.ctrlKey || event.altKey) && event.keyCode > 31) || (
+      # TODO(philc): some events don't have a keyidentifier. How is that possible?
+      event.keyIdentifier && event.keyIdentifier.slice(0, 2) != "U+"))
+    keyChar = KeyboardUtils.getKeyChar(event)
+    # Again, ignore just modifiers. Maybe this should replace the keyCode>31 condition.
+    if (keyChar != "")
+      modifiers = []
+
+      if (event.shiftKey)
+        keyChar = keyChar.toUpperCase()
+      if (event.metaKey)
+        modifiers.push("m")
+      if (event.ctrlKey)
+        modifiers.push("c")
+      if (event.altKey)
+        modifiers.push("a")
+
+      for i of modifiers
+        keyChar = modifiers[i] + "-" + keyChar
+
+      if (modifiers.length > 0 || keyChar.length > 1)
+        keyChar = "<" + keyChar + ">"
+
+  if (keyChar)
+    if @pushKeyToKeyQueue keyChar
+      DomUtils.suppressEvent event
+      KeydownEvents.push event
+      return @stopBubblingAndTrue
+
+  else if (KeyboardUtils.isEscape(event))
+    @clearKeyQueue()
+
+  # Added to prevent propagating this event to other listeners if it's one that'll trigger a Vimium command.
+  # The goal is to avoid the scenario where Google Instant Search uses every keydown event to dump us
+  # back into the search box. As a side effect, this should also prevent overriding by other sites.
+  #
+  # Subject to internationalization issues since we're using keyIdentifier instead of charCode (in keypress).
+  #
+  # TOOD(ilya): Revisit this. Not sure it's the absolute best approach.
+  if keyChar == "" && @isCommandKey KeyboardUtils.getKeyChar(event)
+    DomUtils.suppressPropagation(event)
+    KeydownEvents.push event
+    return @stopBubblingAndTrue
+
+  return @continueBubbling
+
+# @/this, here, is the the normal-mode Mode object.
+onKeyup = (event) ->
+  return @continueBubbling unless KeydownEvents.pop event
+  DomUtils.suppressPropagation(event)
+  @stopBubblingAndTrue
 
 root = exports ? window
 root.MappingMode = MappingMode

--- a/content_scripts/mode_passkeys.coffee
+++ b/content_scripts/mode_passkeys.coffee
@@ -1,4 +1,3 @@
-
 class PassKeysMode extends Mode
   constructor: ->
     super
@@ -13,7 +12,12 @@ class PassKeysMode extends Mode
   handleKeyChar: (event, keyChar) ->
     return @continueBubbling if event.altKey or event.ctrlKey or event.metaKey
     if keyChar and @keyQueue.length == 0 and keyChar.length == 1 and 0 <= @passKeys.indexOf keyChar
-      @stopBubblingAndTrue
+      if event.type == "keyup" and KeydownEvents.pop event
+        # This event corresponds to a keydown handled by NormalMode. We ignore it and send it onward.
+        KeydownEvents.push event
+        @continueBubbling
+      else
+        @stopBubblingAndTrue
     else
       @continueBubbling
 

--- a/content_scripts/mode_passkeys.coffee
+++ b/content_scripts/mode_passkeys.coffee
@@ -12,7 +12,7 @@ class PassKeysMode extends Mode
   # passKey, then 'gt' and '99t' will neverthless be handled by Vimium.
   handleKeyChar: (event, keyChar) ->
     return @continueBubbling if event.altKey or event.ctrlKey or event.metaKey
-    if keyChar and not @keyQueue and keyChar.length == 1 and 0 <= @passKeys.indexOf keyChar
+    if keyChar and @keyQueue.length == 0 and keyChar.length == 1 and 0 <= @passKeys.indexOf keyChar
       @stopBubblingAndTrue
     else
       @continueBubbling

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -263,7 +263,6 @@ executePageCommand = (request) ->
       # We pass the frameId from request.  That's the frame which originated the request, so that's the frame
       # which should receive the focus when the vomnibar closes.
       Utils.invokeCommandString request.command, [ request.frameId, request.registryEntry ]
-      refreshCompletionKeys request
     return
 
   # All other commands are handled in their frame (but only if Vimium is enabled).
@@ -273,8 +272,6 @@ executePageCommand = (request) ->
     Utils.invokeCommandString(request.command, [request.count])
   else
     Utils.invokeCommandString(request.command) for i in [0...request.count]
-
-  refreshCompletionKeys(request)
 
 handleShowHUDforDuration = ({ text, duration }) ->
   if DomUtils.isTopFrame()

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -137,7 +137,7 @@ class NormalMode extends Mode
       @keyQueue.push key
       bgLog "checking keyQueue: [", @keyQueue.join(""), "]"
       @keyQueue = checkKeyQueue @keyQueue
-      keyPort.postMessage {keyChar: key, keyQueue: @keyQueue, frameId}
+      handlerStack.bubbleEvent "registerKeyQueue", {keyQueue: @keyQueue}
       bgLog "new KeyQueue: " + @keyQueue.join("")
 
 # Returns true if the keys in keys1 match the first keys in keys2.
@@ -224,9 +224,6 @@ initializePreDomReady = ->
     getScrollPosition: -> scrollX: window.scrollX, scrollY: window.scrollY
     setScrollPosition: setScrollPosition
     executePageCommand: executePageCommand
-    currentKeyQueue: (request) ->
-      keyQueue = request.keyQueue
-      handlerStack.bubbleEvent "registerKeyQueue", { keyQueue: keyQueue }
     # A frame has received the focus.  We don't care here (the Vomnibar/UI-component handles this).
     frameFocused: ->
     checkEnabledAfterURLChange: checkEnabledAfterURLChange

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -130,7 +130,14 @@ class NormalMode extends Mode
     false
 
   pushKeyToKeyQueue: (key) ->
-    keyPort.postMessage {keyChar: key, keyQueue: @keyQueue, frameId}
+    if (key == "<ESC>")
+      console.log("clearing keyQueue")
+      @keyQueue = []
+    else
+      @keyQueue.push key
+      console.log("checking keyQueue: [", @keyQueue.join(""), "]")
+      keyPort.postMessage {keyChar: key, keyQueue: @keyQueue, frameId}
+      console.log("new KeyQueue: " + @keyQueue.join(""))
 
 # Only exported for tests.
 window.initializeModes = ->

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -138,22 +138,17 @@ window.initializeModes = ->
         else
           key.length
 
-      generateCompletionKeys = (keysToCheck) ->
-        splitHash = splitKeyQueue(keysToCheck || keyQueue)
-        command = splitHash.command
-        count = splitHash.count
+      splitHash = splitKeyQueue @keyQueue
+      command = splitHash.command
+      count = splitHash.count
 
-        completionKeys = singleKeyCommands.slice(0)
+      completionKeys = singleKeyCommands.slice(0)
 
-        if (getActualKeyStrokeLength(command) == 1)
-          for keys of commandKeys
-            completionKeys.push keys[1] if keys[0] == command
+      if (getActualKeyStrokeLength(command) == 1)
+        for keys of commandKeys
+          completionKeys.push keys[1] if keys[0] == command
 
-        completionKeys
-
-      currentCompletionKeys = generateCompletionKeys @keyQueue
-
-      currentCompletionKeys.indexOf(key) != -1
+      completionKeys.indexOf(key) != -1
 
   # Install the permanent modes.  The permanently-installed insert mode tracks focus/blur events, and
   # activates/deactivates itself accordingly.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -108,6 +108,8 @@ class NormalMode extends Mode
       keypress: (event) => onKeypress.call @, event
       keyup: (event) => onKeyup.call @, event
 
+    # Queue of keys typed. If keyQueue.numericPrefix is true, its 0th entry is the current command's numeric
+    # prefix.
     @keyQueue = []
     @push
       _name: "mode-#{@id}/registerKeyQueue"
@@ -128,7 +130,7 @@ class NormalMode extends Mode
     false
 
   pushKeyToKeyQueue: (key) ->
-    keyPort.postMessage {keyChar: key, frameId}
+    keyPort.postMessage {keyChar: key, keyQueue: @keyQueue, frameId}
 
 # Only exported for tests.
 window.initializeModes = ->

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -99,7 +99,7 @@ handlerStack.push
         target = target.parentElement
     true
 
-class NormalMode extends Mode
+class NormalMode extends MappingMode
   constructor: ->
     super
       name: "normal"
@@ -119,89 +119,10 @@ class NormalMode extends Mode
         else
           @continueBubbling
 
-
-    # Queue of keys typed. If keyQueue.numericPrefix is true, its 0th entry is the current command's numeric
-    # prefix.
-    @keyQueue = []
-    @push
-      _name: "mode-#{@id}/registerKeyQueue"
-      registerKeyQueue: ({keyQueue}) => @alwaysContinueBubbling => @keyQueue = keyQueue
-
   matchedKeyHandler: (command, count) ->
     chrome.runtime.sendMessage {handler: "executeCommand", command, count, frameId}
 
   getCommandKeys: -> commandKeys
-
-  isCommandKey: (key) ->
-    matched = false
-    checkKeyQueue @keyQueue.concat([key]), @getCommandKeys(), (-> matched = true), (-> matched = true)
-    matched
-
-  clearKeyQueue: ->
-    bgLog "clearing keyQueue"
-    @keyQueue = []
-
-  pushKeyToKeyQueue: (key) ->
-    @keyQueue.push key
-    bgLog "checking keyQueue: [", @keyQueue.join(""), "]"
-    matched = false
-
-    @keyQueue = checkKeyQueue @keyQueue, @getCommandKeys(), ((command, count) =>
-      @matchedKeyHandler command, count
-      matched = true
-    ), (-> matched = true)
-
-    handlerStack.bubbleEvent "registerKeyQueue", {keyQueue: @keyQueue}
-    bgLog "new KeyQueue: " + @keyQueue.join("")
-    matched
-
-# Returns true if the keys in keys1 match the first keys in keys2.
-keysPartialMatch = (keys1, keys2) ->
-  return false if keys1.length > keys2.length
-  for key, i in keys1
-    return false if key != keys2[i]
-  true
-
-simplifyNumericPrefix = (keys) ->
-  keys = keys[0..] # Make a copy of keys so the passed array isn't mutated.
-  keys.numericPrefix = /^[1-9]/.test (keys[0] or "")
-
-  if keys.numericPrefix
-    i = 1
-    i++ while i < keys.length and /^[0-9]/.test keys[i]
-    # keysToCheck[1..i] are numeric, remove them from the array and append them to the prefix.
-    keys[0] += keys.splice(1, i - 1).join ""
-
-  keys
-
-checkKeyQueue = (keysToCheck, commandKeys, successCallback, partialMatchCallback) ->
-  keys = simplifyNumericPrefix keysToCheck
-
-  if keys.numericPrefix
-    [count, command...] = keys
-    count = (parseInt count, 10) or 1
-  else
-    command = keys
-    count = 1
-
-  if command.length == 0
-    partialMatchCallback? "", count if keys.numericPrefix
-    return keysToCheck
-
-  partiallyMatchingCommands = commandKeys.filter keysPartialMatch.bind null, command
-
-  if partiallyMatchingCommands.length > 0
-    [finalCommand] = partiallyMatchingCommands.filter ({length}) -> command.length == length
-    if finalCommand
-      successCallback? command.join(""), count
-      newKeyQueue = []
-    else
-      newKeyQueue = keys
-      partialMatchCallback? command.join(""), count
-  else
-    newKeyQueue = checkKeyQueue command[1..], commandKeys, successCallback, partialMatchCallback
-
-  newKeyQueue
 
 # Only exported for tests.
 window.initializeModes = ->

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -118,9 +118,11 @@ class NormalMode extends Mode
   matchedKeyHandler: (command, count) ->
     chrome.runtime.sendMessage {handler: "executeCommand", command, count, frameId}
 
+  getCommandKeys: -> commandKeys
+
   isCommandKey: (key) ->
     matched = false
-    checkKeyQueue @keyQueue.concat([key]), (-> matched = true), (-> matched = true)
+    checkKeyQueue @keyQueue.concat([key]), @getCommandKeys(), (-> matched = true), (-> matched = true)
     matched
 
   clearKeyQueue: ->
@@ -132,7 +134,7 @@ class NormalMode extends Mode
     bgLog "checking keyQueue: [", @keyQueue.join(""), "]"
     matched = false
 
-    @keyQueue = checkKeyQueue @keyQueue, ((command, count) ->
+    @keyQueue = checkKeyQueue @keyQueue, @getCommandKeys(), ((command, count) =>
       @matchedKeyHandler command, count
       matched = true
     ), (-> matched = true)
@@ -160,7 +162,7 @@ simplifyNumericPrefix = (keys) ->
 
   keys
 
-checkKeyQueue = (keysToCheck, successCallback, partialMatchCallback) ->
+checkKeyQueue = (keysToCheck, commandKeys, successCallback, partialMatchCallback) ->
   keys = simplifyNumericPrefix keysToCheck
 
   if keys.numericPrefix
@@ -185,7 +187,7 @@ checkKeyQueue = (keysToCheck, successCallback, partialMatchCallback) ->
       newKeyQueue = keys
       partialMatchCallback? command.join(""), count
   else
-    newKeyQueue = checkKeyQueue command[1..], successCallback, partialMatchCallback
+    newKeyQueue = checkKeyQueue command[1..], commandKeys, successCallback, partialMatchCallback
 
   newKeyQueue
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -102,7 +102,6 @@ handlerStack.push
 # Only exported for tests.
 window.initializeModes = ->
   class NormalMode extends Mode
-    keyQueue: ""
     constructor: ->
       super
         name: "normal"
@@ -111,6 +110,7 @@ window.initializeModes = ->
         keypress: (event) => onKeypress.call @, event
         keyup: (event) => onKeyup.call @, event
 
+      @keyQueue = []
       @push
         _name: "mode-#{@id}/registerKeyQueue"
         registerKeyQueue: ({keyQueue}) => @alwaysContinueBubbling => @keyQueue = keyQueue
@@ -121,26 +121,11 @@ window.initializeModes = ->
 
       return true if /^[1-9]/.test(key) # Accept 1-9 to allow number prefixes.
 
-      splitKeyQueue = (queue) ->
-        match = /([1-9][0-9]*)?(.*)/.exec(queue)
-        count = parseInt(match[1], 10)
-        command = match[2]
+      command = if @keyQueue.numericPrefix then @keyQueue else @keyQueue[1..]
 
-        { count: count, command: command }
-
-      isSingleKey = (key) ->
-        namedKeyRegex = /^(<(?:[amc]-.|(?:[amc]-)?[a-z0-9]{2,5})>)(.*)$/
-        if (key.search(namedKeyRegex) == 0)
-          RegExp.$2 == ""
-        else
-          key.length == 1
-
-      splitHash = splitKeyQueue @keyQueue
-      command = splitHash.command
-
-      if (isSingleKey(command))
+      if (command.length == 1)
         for keys of commandKeys
-          return true if keys[0] == command and keys[1] == key
+          return true if keys[0] == command[0] and keys[1] == key
 
       false
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -131,13 +131,13 @@ class NormalMode extends Mode
 
   pushKeyToKeyQueue: (key) ->
     if (key == "<ESC>")
-      console.log("clearing keyQueue")
+      bgLog "clearing keyQueue"
       @keyQueue = []
     else
       @keyQueue.push key
-      console.log("checking keyQueue: [", @keyQueue.join(""), "]")
+      bgLog "checking keyQueue: [", @keyQueue.join(""), "]"
       keyPort.postMessage {keyChar: key, keyQueue: @keyQueue, frameId}
-      console.log("new KeyQueue: " + @keyQueue.join(""))
+      bgLog "new KeyQueue: " + @keyQueue.join("")
 
 # Only exported for tests.
 window.initializeModes = ->

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -117,12 +117,9 @@ window.initializeModes = ->
 
     isCommandKey: (key) ->
       for keys in commandKeys
-        return true if keys.length > 1 and keys[0] == key
+        return true if keys[0] == key
 
       return true if /^[1-9]/.test(key) # Accept 1-9 to allow number prefixes.
-
-      for keys in commandKeys
-        return true if keys.length == 1 and keys[0] == key
 
       splitKeyQueue = (queue) ->
         match = /([1-9][0-9]*)?(.*)/.exec(queue)
@@ -140,7 +137,6 @@ window.initializeModes = ->
 
       splitHash = splitKeyQueue @keyQueue
       command = splitHash.command
-      count = splitHash.count
 
       if (isSingleKey(command))
         for keys of commandKeys

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -128,19 +128,18 @@ window.initializeModes = ->
 
         { count: count, command: command }
 
-      namedKeyRegex = /^(<(?:[amc]-.|(?:[amc]-)?[a-z0-9]{2,5})>)(.*)$/
-
-      getActualKeyStrokeLength = (key) ->
+      isSingleKey = (key) ->
+        namedKeyRegex = /^(<(?:[amc]-.|(?:[amc]-)?[a-z0-9]{2,5})>)(.*)$/
         if (key.search(namedKeyRegex) == 0)
-          1 + getActualKeyStrokeLength(RegExp.$2)
+          RegExp.$2 == ""
         else
-          key.length
+          key.length == 1
 
       splitHash = splitKeyQueue @keyQueue
       command = splitHash.command
       count = splitHash.count
 
-      if (getActualKeyStrokeLength(command) == 1)
+      if (isSingleKey(command))
         for keys of commandKeys
           return true if keys[0] == command and keys[1] == key
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -103,6 +103,7 @@ handlerStack.push
 # Only exported for tests.
 window.initializeModes = ->
   class NormalMode extends Mode
+    keyQueue: ""
     constructor: ->
       super
         name: "normal"
@@ -110,6 +111,10 @@ window.initializeModes = ->
         keydown: (event) => onKeydown.call @, event
         keypress: (event) => onKeypress.call @, event
         keyup: (event) => onKeyup.call @, event
+
+      @push
+        _name: "mode-#{@id}/registerKeyQueue"
+        registerKeyQueue: ({keyQueue}) => @alwaysContinueBubbling => @keyQueue = keyQueue
 
     isCommandKey: (key) -> currentCompletionKeys.indexOf(key) != -1 or isValidFirstKey(key)
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -115,6 +115,9 @@ class NormalMode extends Mode
       _name: "mode-#{@id}/registerKeyQueue"
       registerKeyQueue: ({keyQueue}) => @alwaysContinueBubbling => @keyQueue = keyQueue
 
+  matchedKeyHandler: (command, count) ->
+    chrome.runtime.sendMessage {handler: "executeCommand", command, count, frameId}
+
   isCommandKey: (key) ->
     matched = false
     checkKeyQueue @keyQueue.concat([key]), (-> matched = true), (-> matched = true)
@@ -130,7 +133,7 @@ class NormalMode extends Mode
     matched = false
 
     @keyQueue = checkKeyQueue @keyQueue, ((command, count) ->
-      chrome.runtime.sendMessage {handler: "executeCommand", command, count, frameId}
+      @matchedKeyHandler command, count
       matched = true
     ), (-> matched = true)
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -118,10 +118,8 @@ window.initializeModes = ->
     isCommandKey: (key) ->
       return true if isValidFirstKey(key)
 
-      singleKeyCommands = []
       for keys in commandKeys
-        if (keys.length == 1)
-          singleKeyCommands.push(keys[0])
+        return true if keys.length == 1 and keys[0] == key
 
       splitKeyQueue = (queue) ->
         match = /([1-9][0-9]*)?(.*)/.exec(queue)
@@ -142,13 +140,11 @@ window.initializeModes = ->
       command = splitHash.command
       count = splitHash.count
 
-      completionKeys = singleKeyCommands.slice(0)
-
       if (getActualKeyStrokeLength(command) == 1)
         for keys of commandKeys
-          completionKeys.push keys[1] if keys[0] == command
+          return true if keys[0] == command and keys[1] == key
 
-      completionKeys.indexOf(key) != -1
+      false
 
   # Install the permanent modes.  The permanently-installed insert mode tracks focus/blur events, and
   # activates/deactivates itself accordingly.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -13,7 +13,6 @@ passKeys = null
 keyQueue = null
 # The user's operating system.
 currentCompletionKeys = ""
-validFirstKeys = ""
 commandKeys = []
 
 # We track whther the current window has the focus or not.
@@ -612,14 +611,16 @@ window.refreshCompletionKeys = (response) ->
   if (response)
     currentCompletionKeys = response.completionKeys
 
-    if (response.validFirstKeys)
-      validFirstKeys = response.validFirstKeys
     if (response.commandKeys)
       commandKeys = response.commandKeys
   else
     chrome.runtime.sendMessage({ handler: "getCompletionKeys" }, refreshCompletionKeys)
 
 isValidFirstKey = (keyChar) ->
+  validFirstKeys = {}
+  for keys in commandKeys
+    if (keys.length > 1)
+      validFirstKeys[keys[0]] = true
   validFirstKeys[keyChar] || /^[1-9]/.test(keyChar)
 
 window.handleEscapeForFindMode = ->

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -14,6 +14,7 @@ keyQueue = null
 # The user's operating system.
 currentCompletionKeys = ""
 validFirstKeys = ""
+commandKeys = []
 
 # We track whther the current window has the focus or not.
 windowIsFocused = do ->
@@ -613,6 +614,8 @@ window.refreshCompletionKeys = (response) ->
 
     if (response.validFirstKeys)
       validFirstKeys = response.validFirstKeys
+    if (response.commandKeys)
+      commandKeys = response.commandKeys
   else
     chrome.runtime.sendMessage({ handler: "getCompletionKeys" }, refreshCompletionKeys)
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -112,6 +112,8 @@ window.initializeModes = ->
         keypress: (event) => onKeypress.call @, event
         keyup: (event) => onKeyup.call @, event
 
+    isCommandKey: (key) -> currentCompletionKeys.indexOf(key) != -1 or isValidFirstKey(key)
+
   # Install the permanent modes.  The permanently-installed insert mode tracks focus/blur events, and
   # activates/deactivates itself accordingly.
   new NormalMode
@@ -500,7 +502,7 @@ onKeypress = (event) ->
     keyChar = String.fromCharCode(event.charCode)
 
     if (keyChar)
-      if currentCompletionKeys.indexOf(keyChar) != -1 or isValidFirstKey(keyChar)
+      if @isCommandKey keyChar
         DomUtils.suppressEvent(event)
         keyPort.postMessage({ keyChar:keyChar, frameId:frameId })
         return @stopBubblingAndTrue
@@ -546,7 +548,7 @@ onKeydown = (event) ->
 
   else
     if (keyChar)
-      if (currentCompletionKeys.indexOf(keyChar) != -1 or isValidFirstKey(keyChar))
+      if (@isCommandKey keyChar)
         DomUtils.suppressEvent event
         KeydownEvents.push event
         keyPort.postMessage({ keyChar:keyChar, frameId:frameId })
@@ -564,9 +566,7 @@ onKeydown = (event) ->
   # Subject to internationalization issues since we're using keyIdentifier instead of charCode (in keypress).
   #
   # TOOD(ilya): Revisit this. Not sure it's the absolute best approach.
-  if keyChar == "" &&
-     (currentCompletionKeys.indexOf(KeyboardUtils.getKeyChar(event)) != -1 ||
-      isValidFirstKey(KeyboardUtils.getKeyChar(event)))
+  if keyChar == "" && @isCommandKey KeyboardUtils.getKeyChar(event)
     DomUtils.suppressPropagation(event)
     KeydownEvents.push event
     return @stopBubblingAndTrue

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -127,6 +127,9 @@ class NormalMode extends Mode
 
     false
 
+  pushKeyToKeyQueue: (key) ->
+    keyPort.postMessage {keyChar: key, frameId}
+
 # Only exported for tests.
 window.initializeModes = ->
   # Install the permanent modes.  The permanently-installed insert mode tracks focus/blur events, and
@@ -516,10 +519,10 @@ onKeypress = (event) ->
     if (keyChar)
       if @isCommandKey keyChar
         DomUtils.suppressEvent(event)
-        keyPort.postMessage({ keyChar:keyChar, frameId:frameId })
+        @pushKeyToKeyQueue keyChar
         return @stopBubblingAndTrue
 
-      keyPort.postMessage({ keyChar:keyChar, frameId:frameId })
+      @pushKeyToKeyQueue keyChar
 
   return @continueBubbling
 
@@ -563,13 +566,13 @@ onKeydown = (event) ->
       if (@isCommandKey keyChar)
         DomUtils.suppressEvent event
         KeydownEvents.push event
-        keyPort.postMessage({ keyChar:keyChar, frameId:frameId })
+        @pushKeyToKeyQueue keyChar
         return @stopBubblingAndTrue
 
-      keyPort.postMessage({ keyChar:keyChar, frameId:frameId })
+      @pushKeyToKeyQueue keyChar
 
     else if (KeyboardUtils.isEscape(event))
-      keyPort.postMessage({ keyChar:"<ESC>", frameId:frameId })
+      @pushKeyToKeyQueue "<ESC>"
 
   # Added to prevent propagating this event to other listeners if it's one that'll trigger a Vimium command.
   # The goal is to avoid the scenario where Google Instant Search uses every keydown event to dump us

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -617,11 +617,10 @@ window.refreshCompletionKeys = (response) ->
     chrome.runtime.sendMessage({ handler: "getCompletionKeys" }, refreshCompletionKeys)
 
 isValidFirstKey = (keyChar) ->
-  validFirstKeys = {}
   for keys in commandKeys
-    if (keys.length > 1)
-      validFirstKeys[keys[0]] = true
-  validFirstKeys[keyChar] || /^[1-9]/.test(keyChar)
+    return true if keys.length > 1 and keys[0] == keyChar
+
+  /^[1-9]/.test(keyChar) # Accept 1-9 to allow number prefixes.
 
 window.handleEscapeForFindMode = ->
   document.body.classList.remove("vimiumFindMode")

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -108,6 +108,18 @@ class NormalMode extends Mode
       keypress: (event) => onKeypress.call @, event
       keyup: (event) => onKeyup.call @, event
 
+    @push
+      _name: "mode-#{@id}/escCloseHelpDialog"
+      keydown: (event) =>
+        if (isShowingHelpDialog && KeyboardUtils.isEscape(event))
+          hideHelpDialog()
+          DomUtils.suppressEvent event
+          KeydownEvents.push event
+          @stopBubblingAndTrue
+        else
+          @continueBubbling
+
+
     # Queue of keys typed. If keyQueue.numericPrefix is true, its 0th entry is the current command's numeric
     # prefix.
     @keyQueue = []
@@ -610,21 +622,14 @@ onKeydown = (event) ->
       if (modifiers.length > 0 || keyChar.length > 1)
         keyChar = "<" + keyChar + ">"
 
-  if (isShowingHelpDialog && KeyboardUtils.isEscape(event))
-    hideHelpDialog()
-    DomUtils.suppressEvent event
-    KeydownEvents.push event
-    return @stopBubblingAndTrue
+  if (keyChar)
+    if @pushKeyToKeyQueue keyChar
+      DomUtils.suppressEvent event
+      KeydownEvents.push event
+      return @stopBubblingAndTrue
 
-  else
-    if (keyChar)
-      if @pushKeyToKeyQueue keyChar
-        DomUtils.suppressEvent event
-        KeydownEvents.push event
-        return @stopBubblingAndTrue
-
-    else if (KeyboardUtils.isEscape(event))
-      @clearKeyQueue()
+  else if (KeyboardUtils.isEscape(event))
+    @clearKeyQueue()
 
   # Added to prevent propagating this event to other listeners if it's one that'll trigger a Vimium command.
   # The goal is to avoid the scenario where Google Instant Search uses every keydown event to dump us

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -570,12 +570,9 @@ onKeypress = (event) ->
     keyChar = String.fromCharCode(event.charCode)
 
     if (keyChar)
-      if @isCommandKey keyChar
+      if @pushKeyToKeyQueue keyChar
         DomUtils.suppressEvent(event)
-        @pushKeyToKeyQueue keyChar
         return @stopBubblingAndTrue
-
-      @pushKeyToKeyQueue keyChar
 
   return @continueBubbling
 
@@ -616,13 +613,10 @@ onKeydown = (event) ->
 
   else
     if (keyChar)
-      if (@isCommandKey keyChar)
+      if @pushKeyToKeyQueue keyChar
         DomUtils.suppressEvent event
         KeydownEvents.push event
-        @pushKeyToKeyQueue keyChar
         return @stopBubblingAndTrue
-
-      @pushKeyToKeyQueue keyChar
 
     else if (KeyboardUtils.isEscape(event))
       @clearKeyQueue()

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -104,9 +104,6 @@ class NormalMode extends MappingMode
     super
       name: "normal"
       indicator: false # There is no mode indicator in normal mode.
-      keydown: (event) => onKeydown.call @, event
-      keypress: (event) => onKeypress.call @, event
-      keyup: (event) => onKeyup.call @, event
 
     @push
       _name: "mode-#{@id}/escCloseHelpDialog"
@@ -491,86 +488,6 @@ KeydownEvents =
 handlerStack.push
   _name: "KeydownEvents-cleanup"
   blur: (event) -> KeydownEvents.clear() if event.target == window; true
-
-#
-# Sends everything except i & ESC to the handler in background_page. i & ESC are special because they control
-# insert mode which is local state to the page. The key will be are either a single ascii letter or a
-# key-modifier pair, e.g. <c-a> for control a.
-#
-# Note that some keys will only register keydown events and not keystroke events, e.g. ESC.
-#
-# @/this, here, is the the normal-mode Mode object.
-onKeypress = (event) ->
-  keyChar = ""
-
-  # Ignore modifier keys by themselves.
-  if (event.keyCode > 31)
-    keyChar = String.fromCharCode(event.charCode)
-
-    if (keyChar)
-      if @pushKeyToKeyQueue keyChar
-        DomUtils.suppressEvent(event)
-        return @stopBubblingAndTrue
-
-  return @continueBubbling
-
-# @/this, here, is the the normal-mode Mode object.
-onKeydown = (event) ->
-  keyChar = ""
-
-  # handle special keys, and normal input keys with modifiers being pressed. don't handle shiftKey alone (to
-  # avoid / being interpreted as ?
-  if (((event.metaKey || event.ctrlKey || event.altKey) && event.keyCode > 31) || (
-      # TODO(philc): some events don't have a keyidentifier. How is that possible?
-      event.keyIdentifier && event.keyIdentifier.slice(0, 2) != "U+"))
-    keyChar = KeyboardUtils.getKeyChar(event)
-    # Again, ignore just modifiers. Maybe this should replace the keyCode>31 condition.
-    if (keyChar != "")
-      modifiers = []
-
-      if (event.shiftKey)
-        keyChar = keyChar.toUpperCase()
-      if (event.metaKey)
-        modifiers.push("m")
-      if (event.ctrlKey)
-        modifiers.push("c")
-      if (event.altKey)
-        modifiers.push("a")
-
-      for i of modifiers
-        keyChar = modifiers[i] + "-" + keyChar
-
-      if (modifiers.length > 0 || keyChar.length > 1)
-        keyChar = "<" + keyChar + ">"
-
-  if (keyChar)
-    if @pushKeyToKeyQueue keyChar
-      DomUtils.suppressEvent event
-      KeydownEvents.push event
-      return @stopBubblingAndTrue
-
-  else if (KeyboardUtils.isEscape(event))
-    @clearKeyQueue()
-
-  # Added to prevent propagating this event to other listeners if it's one that'll trigger a Vimium command.
-  # The goal is to avoid the scenario where Google Instant Search uses every keydown event to dump us
-  # back into the search box. As a side effect, this should also prevent overriding by other sites.
-  #
-  # Subject to internationalization issues since we're using keyIdentifier instead of charCode (in keypress).
-  #
-  # TOOD(ilya): Revisit this. Not sure it's the absolute best approach.
-  if keyChar == "" && @isCommandKey KeyboardUtils.getKeyChar(event)
-    DomUtils.suppressPropagation(event)
-    KeydownEvents.push event
-    return @stopBubblingAndTrue
-
-  return @continueBubbling
-
-# @/this, here, is the the normal-mode Mode object.
-onKeyup = (event) ->
-  return @continueBubbling unless KeydownEvents.pop event
-  DomUtils.suppressPropagation(event)
-  @stopBubblingAndTrue
 
 # Checks if Vimium should be enabled or not in this frame.  As a side effect, it also informs the background
 # page whether this frame has the focus, allowing the background page to track the active frame's URL.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -951,6 +951,7 @@ window.onbeforeunload = ->
 root = exports ? window
 root.handlerStack = handlerStack
 root.NormalMode = NormalMode
+root.KeydownEvents = KeydownEvents
 root.frameId = frameId
 root.windowIsFocused = windowIsFocused
 root.bgLog = bgLog

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -99,36 +99,36 @@ handlerStack.push
         target = target.parentElement
     true
 
+class NormalMode extends Mode
+  constructor: ->
+    super
+      name: "normal"
+      indicator: false # There is no mode indicator in normal mode.
+      keydown: (event) => onKeydown.call @, event
+      keypress: (event) => onKeypress.call @, event
+      keyup: (event) => onKeyup.call @, event
+
+    @keyQueue = []
+    @push
+      _name: "mode-#{@id}/registerKeyQueue"
+      registerKeyQueue: ({keyQueue}) => @alwaysContinueBubbling => @keyQueue = keyQueue
+
+  isCommandKey: (key) ->
+    for keys in commandKeys
+      return true if keys[0] == key
+
+    return true if /^[1-9]/.test(key) # Accept 1-9 to allow number prefixes.
+
+    command = if @keyQueue.numericPrefix then @keyQueue else @keyQueue[1..]
+
+    if (command.length == 1)
+      for keys of commandKeys
+        return true if keys[0] == command[0] and keys[1] == key
+
+    false
+
 # Only exported for tests.
 window.initializeModes = ->
-  class NormalMode extends Mode
-    constructor: ->
-      super
-        name: "normal"
-        indicator: false # There is no mode indicator in normal mode.
-        keydown: (event) => onKeydown.call @, event
-        keypress: (event) => onKeypress.call @, event
-        keyup: (event) => onKeyup.call @, event
-
-      @keyQueue = []
-      @push
-        _name: "mode-#{@id}/registerKeyQueue"
-        registerKeyQueue: ({keyQueue}) => @alwaysContinueBubbling => @keyQueue = keyQueue
-
-    isCommandKey: (key) ->
-      for keys in commandKeys
-        return true if keys[0] == key
-
-      return true if /^[1-9]/.test(key) # Accept 1-9 to allow number prefixes.
-
-      command = if @keyQueue.numericPrefix then @keyQueue else @keyQueue[1..]
-
-      if (command.length == 1)
-        for keys of commandKeys
-          return true if keys[0] == command[0] and keys[1] == key
-
-      false
-
   # Install the permanent modes.  The permanently-installed insert mode tracks focus/blur events, and
   # activates/deactivates itself accordingly.
   new NormalMode
@@ -891,6 +891,7 @@ window.onbeforeunload = ->
 
 root = exports ? window
 root.handlerStack = handlerStack
+root.NormalMode = NormalMode
 root.frameId = frameId
 root.windowIsFocused = windowIsFocused
 root.bgLog = bgLog

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -129,16 +129,16 @@ class NormalMode extends Mode
 
     false
 
+  clearKeyQueue: ->
+    bgLog "clearing keyQueue"
+    @keyQueue = []
+
   pushKeyToKeyQueue: (key) ->
-    if (key == "<ESC>")
-      bgLog "clearing keyQueue"
-      @keyQueue = []
-    else
-      @keyQueue.push key
-      bgLog "checking keyQueue: [", @keyQueue.join(""), "]"
-      @keyQueue = checkKeyQueue @keyQueue
-      handlerStack.bubbleEvent "registerKeyQueue", {keyQueue: @keyQueue}
-      bgLog "new KeyQueue: " + @keyQueue.join("")
+    @keyQueue.push key
+    bgLog "checking keyQueue: [", @keyQueue.join(""), "]"
+    @keyQueue = checkKeyQueue @keyQueue
+    handlerStack.bubbleEvent "registerKeyQueue", {keyQueue: @keyQueue}
+    bgLog "new KeyQueue: " + @keyQueue.join("")
 
 # Returns true if the keys in keys1 match the first keys in keys2.
 keysPartialMatch = (keys1, keys2) ->
@@ -628,7 +628,7 @@ onKeydown = (event) ->
       @pushKeyToKeyQueue keyChar
 
     else if (KeyboardUtils.isEscape(event))
-      @pushKeyToKeyQueue "<ESC>"
+      @clearKeyQueue()
 
   # Added to prevent propagating this event to other listeners if it's one that'll trigger a Vimium command.
   # The goal is to avoid the scenario where Google Instant Search uses every keydown event to dump us

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -116,7 +116,10 @@ window.initializeModes = ->
         registerKeyQueue: ({keyQueue}) => @alwaysContinueBubbling => @keyQueue = keyQueue
 
     isCommandKey: (key) ->
-      return true if isValidFirstKey(key)
+      for keys in commandKeys
+        return true if keys.length > 1 and keys[0] == key
+
+      return true if /^[1-9]/.test(key) # Accept 1-9 to allow number prefixes.
 
       for keys in commandKeys
         return true if keys.length == 1 and keys[0] == key
@@ -645,12 +648,6 @@ window.refreshCompletionKeys = (response) ->
       commandKeys = response.commandKeys
   else
     chrome.runtime.sendMessage({ handler: "getCompletionKeys" }, refreshCompletionKeys)
-
-isValidFirstKey = (keyChar) ->
-  for keys in commandKeys
-    return true if keys.length > 1 and keys[0] == keyChar
-
-  /^[1-9]/.test(keyChar) # Accept 1-9 to allow number prefixes.
 
 window.handleEscapeForFindMode = ->
   document.body.classList.remove("vimiumFindMode")

--- a/manifest.json
+++ b/manifest.json
@@ -48,6 +48,7 @@
              "content_scripts/scroller.js",
              "content_scripts/marks.js",
              "content_scripts/mode.js",
+             "content_scripts/mode_mapping.js",
              "content_scripts/mode_insert.js",
              "content_scripts/mode_passkeys.js",
              "content_scripts/mode_find.js",

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -27,7 +27,7 @@ initializeModeState = ->
   initializeModes()
   # We use "m" as the only mapped key, "p" as a passkey, and "u" as an unmapped key.
   refreshCompletionKeys
-    completionKeys: "mp"
+    commandKeys: [["m"], ["p"]]
   handlerStack.bubbleEvent "registerStateChange",
     enabled: true
     passKeys: "p"

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -32,7 +32,7 @@ initializeModeState = ->
     enabled: true
     passKeys: "p"
   handlerStack.bubbleEvent "registerKeyQueue",
-    keyQueue: ""
+    keyQueue: []
 
 # Tell Settings that it's been loaded.
 Settings.isLoaded = true
@@ -372,7 +372,7 @@ context "Normal mode",
     assert.equal pageKeyboardEventCount, 3
 
   should "suppress passKeys with a non-empty keyQueue", ->
-    handlerStack.bubbleEvent "registerKeyQueue", keyQueue: "p"
+    handlerStack.bubbleEvent "registerKeyQueue", keyQueue: ["p"]
     sendKeyboardEvent "p"
     assert.equal pageKeyboardEventCount, 0
 
@@ -500,9 +500,9 @@ context "Mode utilities",
 
   should "register the keyQueue", ->
     test = new Mode trackState: true
-    handlerStack.bubbleEvent "registerKeyQueue", keyQueue: "hello"
+    handlerStack.bubbleEvent "registerKeyQueue", keyQueue: "hello".split ""
 
-    assert.isTrue test.keyQueue == "hello"
+    assert.isTrue test.keyQueue.join("") == "hello"
 
 context "PostFindMode",
   setup ->

--- a/tests/dom_tests/dom_tests.html
+++ b/tests/dom_tests/dom_tests.html
@@ -42,6 +42,7 @@
     <script type="text/javascript" src="../../content_scripts/vomnibar.js"></script>
     <script type="text/javascript" src="../../content_scripts/scroller.js"></script>
     <script type="text/javascript" src="../../content_scripts/mode.js"></script>
+    <script type="text/javascript" src="../../content_scripts/mode_mapping.js"></script>
     <script type="text/javascript" src="../../content_scripts/mode_passkeys.js"></script>
     <script type="text/javascript" src="../../content_scripts/mode_insert.js"></script>
     <script type="text/javascript" src="../../content_scripts/mode_find.js"></script>


### PR DESCRIPTION
This PR
* creates a new, generic class `MappingMode` for handling mappable commands and numeric prefixes
* moves the bulk of (easily re-usable) normal mode key handling mode out of `vimium_frontend.coffee` and into this class
* moves the key checking code from the background page into the the class
  - this resolves some race conditions
  - fixes an passkey issue we were testing for, but where Shoulda.js' lack of asynchronous testing made the test pass incorrectly (da419de and 98e7095 for info)
  - we're not messaging the background as much
* gives each `NormalMode` its own key queue
  - switching tab/window with the mouse/a window manager command could cause weirdness before (eg. `g` *switch tab* `y` *switch back* `y` would run `yy` and pass the second `y` to the page)
* uses a single implementation to do all normal mode key handling logic (ie. instead of a frontend one and a more complex background one)
  - because of this, `0` will no longer be leaked to the page in number prefixes
* gives the handler which hides the help dialog its own function, since it's not a part of the mode's main logic.


Consequences of this:
* gives us support for mappings of more than 2 keys
* fixes #1545 
* modularisation

This is also a good starting point for #1188, #1469 (and in general removing a lot of duplicate key handling code from visual etc. modes) and several other issues.

Every commit in this PR should compile, pass all tests (apart from da419de), and work correctly. Each commit is a single simple step, so it should be possible to review this commit by commit or in blocks of commits too.