### PR TITLE
use keyCode only to distinguish a key event in KeydownEvents

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -461,26 +461,20 @@ extend window,
 # Track which keydown events we have handled, so that we can subsequently suppress the corresponding keyup
 # event.
 KeydownEvents =
-  handledEvents: {}
-
-  stringify: (event) ->
-    JSON.stringify
-      metaKey: event.metaKey
-      altKey: event.altKey
-      ctrlKey: event.ctrlKey
-      keyIdentifier: event.keyIdentifier
-      keyCode: event.keyCode
+  handledEvents: new Uint8Array(256)
 
   push: (event) ->
-    @handledEvents[@stringify event] = true
+    @handledEvents[event.keyCode] = 1
 
   # Yields truthy or falsy depending upon whether a corresponding keydown event is present (and removes that
   # event).
   pop: (event) ->
-    detailString = @stringify event
-    value = @handledEvents[detailString]
-    delete @handledEvents[detailString]
-    value
+    keyCode = event.keyCode
+    if @handledEvents[keyCode]
+      @handledEvents[keyCode] = 0
+      true
+    else
+      false
 
 #
 # Sends everything except i & ESC to the handler in background_page. i & ESC are special because they control


### PR DESCRIPTION
There's no need to distinguish a key using `keyIdentifier`, `ctrlKey` and so on, since:
* Whenever we press a key and release it, the `keyCode` stays the same.
* Most different keys on one keyboard has different `keyCode`.