### PR TITLE
fix bugs in KeydownEvents so that correct keyup events will be handled

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -463,13 +463,7 @@ extend window,
 KeydownEvents =
   handledEvents: {}
 
-  stringify: (event) ->
-    JSON.stringify
-      metaKey: event.metaKey
-      altKey: event.altKey
-      ctrlKey: event.ctrlKey
-      keyIdentifier: event.keyIdentifier
-      keyCode: event.keyCode
+  stringify: (event) -> event.keyCode
 
   push: (event) ->
     @handledEvents[@stringify event] = true
@@ -481,6 +475,12 @@ KeydownEvents =
     value = @handledEvents[detailString]
     delete @handledEvents[detailString]
     value
+
+  clear: -> @handledEvents = {}
+
+handlerStack.push
+  _name: "KeydownEvents-cleanup"
+  blur: (event) -> KeydownEvents.clear() if event.target == window; true
 
 #
 # Sends everything except i & ESC to the handler in background_page. i & ESC are special because they control


### PR DESCRIPTION
In this PR, `KeydownEvents` uses only `keyCode` to match events, and will clean left keydown records when `window` loses its focus (e.g. another tab becomes selected).

 Then,
> the following sequence: `<ctrl>` keydown, `<c-a>` keydown, `<ctrl>` keyup, `a` keyup

will be handled correctly, and no irrelevant keyup event will be matched.

This is better than PR #1779 , since `handledEvents` is still `{}`.