### PR TITLE
Prevent perpetual scroll.

### DIFF
--- a/content_scripts/scroller.coffee
+++ b/content_scripts/scroller.coffee
@@ -136,6 +136,9 @@ CoreScroller =
         handlerStack.alwaysContinueBubbling =>
           @keyIsDown = false
           @time += 1
+      blur: =>
+        handlerStack.alwaysContinueBubbling =>
+          @time += 1 if event.target == window
 
   # Return true if CoreScroller would not initiate a new scroll right now.
   wouldNotInitiateScroll: -> @lastEvent?.repeat and Settings.get "smoothScroll"


### PR DESCRIPTION
If we miss the `keyup` event while a smooth scroll is active (because the focus changes), then we scroll forever.  This stops scrolling on blur.

Fixes #1788.