### PR TITLE
Fix Vimium on XML pages

### DIFF
--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -96,7 +96,7 @@ class Tween
   styleElement: null
 
   constructor: (@cssSelector, insertionPoint = document.documentElement) ->
-    @styleElement = document.createElement "style"
+    @styleElement = DomUtils.createElement "style"
 
     unless @styleElement.style
       # We're in an XML document, so we shouldn't inject any elements. See the comment in UIComponent.

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -127,7 +127,7 @@ class LinkHintsMode
   # Creates a link marker for the given link.
   #
   createMarkerFor: (link) ->
-    marker = document.createElement("div")
+    marker = DomUtils.createElement("div")
     marker.className = "vimiumReset internalVimiumHintMarker vimiumHintMarker"
     marker.clickableItem = link.element
 

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -6,28 +6,17 @@ class UIComponent
   shadowDOM: null
 
   constructor: (iframeUrl, className, @handleMessage) ->
-    styleSheet = document.createElement "style"
-
-    unless styleSheet.style
-      # If this is an XML document, nothing we do here works:
-      # * <style> elements show their contents inline,
-      # * <iframe> elements don't load any content,
-      # * document.createElement generates elements that have style == null and ignore CSS.
-      # If this is the case we don't want to pollute the DOM to no or negative effect.  So we bail
-      # immediately, and disable all externally-called methods.
-      @postMessage = @activate = @show = @hide = ->
-        console.log "This vimium feature is disabled because it is incompatible with this page."
-      return
+    styleSheet = DomUtils.createElement "style"
 
     styleSheet.type = "text/css"
     # Default to everything hidden while the stylesheet loads.
     styleSheet.innerHTML = "@import url(\"#{chrome.runtime.getURL("content_scripts/vimium.css")}\");"
 
-    @iframeElement = document.createElement "iframe"
+    @iframeElement = DomUtils.createElement "iframe"
     extend @iframeElement,
       className: className
       seamless: "seamless"
-    shadowWrapper = document.createElement "div"
+    shadowWrapper = DomUtils.createElement "div"
     # PhantomJS doesn't support createShadowRoot, so guard against its non-existance.
     @shadowDOM = shadowWrapper.createShadowRoot?() ? shadowWrapper
     @shadowDOM.appendChild styleSheet

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -276,17 +276,16 @@ setScrollPosition = ({ scrollX, scrollY }) ->
 #
 window.focusThisFrame = do ->
   # Create a shadow DOM wrapping the frame so the page's styles don't interfere with ours.
-  highlightedFrameElement = document.createElement "div"
+  highlightedFrameElement = DomUtils.createElement "div"
   # PhantomJS doesn't support createShadowRoot, so guard against its non-existance.
   _shadowDOM = highlightedFrameElement.createShadowRoot?() ? highlightedFrameElement
 
   # Inject stylesheet.
-  _styleSheet = document.createElement "style"
-  if _styleSheet.style?
-    _styleSheet.innerHTML = "@import url(\"#{chrome.runtime.getURL("content_scripts/vimium.css")}\");"
-    _shadowDOM.appendChild _styleSheet
+  _styleSheet = DomUtils.createElement "style"
+  _styleSheet.innerHTML = "@import url(\"#{chrome.runtime.getURL("content_scripts/vimium.css")}\");"
+  _shadowDOM.appendChild _styleSheet
 
-  _frameEl = document.createElement "div"
+  _frameEl = DomUtils.createElement "div"
   _frameEl.className = "vimiumReset vimiumHighlightedFrame"
   _shadowDOM.appendChild _frameEl
 
@@ -405,7 +404,7 @@ extend window,
           Math.min(count, visibleInputs.length) - 1
 
       hints = for tuple in visibleInputs
-        hint = document.createElement "div"
+        hint = DomUtils.createElement "div"
         hint.className = "vimiumReset internalVimiumInputHint vimiumInputHint"
 
         # minus 1 for the border
@@ -775,7 +774,7 @@ window.enterFindMode = ->
 window.showHelpDialog = (html, fid) ->
   return if (isShowingHelpDialog || !document.body || fid != frameId)
   isShowingHelpDialog = true
-  container = document.createElement("div")
+  container = DomUtils.createElement("div")
   container.id = "vimiumHelpDialogContainer"
   container.className = "vimiumReset"
 
@@ -861,7 +860,7 @@ CursorHider =
     # See #1345 and #1348.
     return unless Utils.haveChromeVersion "39.0.2171.71"
 
-    @cursorHideStyle = document.createElement("style")
+    @cursorHideStyle = DomUtils.createElement("style")
     @cursorHideStyle.innerHTML = """
       body * {pointer-events: none !important; cursor: none !important;}
       body, html {cursor: none !important;}

--- a/lib/clipboard.coffee
+++ b/lib/clipboard.coffee
@@ -1,6 +1,6 @@
 Clipboard =
   _createTextArea: ->
-    textArea = document.createElement("textarea")
+    textArea = DomUtils.createElement("textarea")
     textArea.style.position = "absolute"
     textArea.style.left = "-100%"
     textArea

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -8,12 +8,22 @@ DomUtils =
     else
       func()
 
+  createElement: (tagName) ->
+    element = document.createElement tagName
+    if element.style
+      # The document namespace provides (X)HTML elements, so we can use them directly.
+      element
+    else
+      # The document namespace doesn't give (X)HTML elements, so we create them with the correct namespace
+      # manually.
+      document.createElementNS "http://www.w3.org/1999/xhtml", tagName
+
   #
   # Adds a list of elements to a page.
   # Note that adding these nodes all at once (via the parent div) is significantly faster than one-by-one.
   #
   addElementList: (els, overlayOptions) ->
-    parent = document.createElement("div")
+    parent = DomUtils.createElement("div")
     parent.id = overlayOptions.id if overlayOptions.id?
     parent.className = overlayOptions.className if overlayOptions.className?
     parent.appendChild(el) for el in els
@@ -236,7 +246,7 @@ DomUtils =
 
   # momentarily flash a rectangular border to give user some visual feedback
   flashRect: (rect) ->
-    flashEl = document.createElement("div")
+    flashEl = DomUtils.createElement("div")
     flashEl.id = "vimiumFlash"
     flashEl.className = "vimiumReset"
     flashEl.style.left = rect.left + window.scrollX + "px"
@@ -297,7 +307,7 @@ DomUtils =
       'letterSpacing', 'wordSpacing' ]
 
     (element, position) ->
-      div = document.createElement "div"
+      div = DomUtils.createElement "div"
       div.id = "vimium-input-textarea-caret-position-mirror-div"
       document.body.appendChild div
 
@@ -315,7 +325,7 @@ DomUtils =
       if element.nodeName.toLowerCase() == "input"
         div.textContent = div.textContent.replace /\s/g, "\u00a0"
 
-      span = document.createElement "span"
+      span = DomUtils.createElement "span"
       span.textContent = element.value.substring(position) || "."
       div.appendChild span
 

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -21,7 +21,7 @@ Utils =
 
   # Creates a single DOM element from :html
   createElementFromHtml: (html) ->
-    tmp = document.createElement("div")
+    tmp = DomUtils.createElement("div")
     tmp.innerHTML = html
     tmp.firstChild
 


### PR DESCRIPTION
This implements @gdh1995's idea from #1796, using `document.createElementNS` for XML documents and remove the now redundant XML-specific codepaths.

Tested as working correctly [here](http://qz.com/feed/), the example from #1640.