### PR TITLE
Fix scrolling for webpages using web components

### DIFF
--- a/content_scripts/scroller.coffee
+++ b/content_scripts/scroller.coffee
@@ -81,7 +81,7 @@ doesScroll = (element, direction, amount, factor) ->
 findScrollableElement = (element, direction, amount, factor) ->
   while element != document.body and
     not (doesScroll(element, direction, amount, factor) and shouldScroll(element, direction))
-      element = element.parentElement || document.body
+      element = (DomUtils.getContainingElement element) ? document.body
   element
 
 # On some pages, document.body is not scrollable.  Here, we search the document for the largest visible
@@ -220,7 +220,12 @@ Scroller =
   init: ->
     handlerStack.push
       _name: 'scroller/active-element'
-      DOMActivate: (event) -> handlerStack.alwaysContinueBubbling -> activatedElement = event.target
+      DOMActivate: (event) -> handlerStack.alwaysContinueBubbling ->
+        # If event.path is present, the true event taget (potentially inside a Shadow DOM inside
+        # event.target) can be found as its first element.
+        # NOTE(mrmr1993): event.path has been renamed to event.deepPath in the spec, but this change is not
+        # yet implemented by Chrome.
+        activatedElement = event.deepPath?[0] ? event.path?[0] ? event.target
     CoreScroller.init()
 
   # scroll the active element in :direction by :amount * :factor.

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -370,5 +370,11 @@ DomUtils =
           text
       texts.join " "
 
+  # Get the element in the DOM hierachy that contains `element`.
+  # If the element is rendered in a shadow DOM via a <content> element, the <content> element will be
+  # returned, so the shadow DOM is traversed rather than passed over.
+  getContainingElement: (element) ->
+    element.getDestinationInsertionPoints()[0] or element.parentElement
+
 root = exports ? window
 root.DomUtils = DomUtils


### PR DESCRIPTION
This changes the implementation of `Scroller` to
* track focus changes (via `DOMActivate`) to elements inside Shadow DOMs, and
* step into Shadow DOMs when we want the ancestor of an element rendered in a `<content>`.

This fixes the main issue behind #1795, making scrolling work on the Google Play Music website ([link](https://play.google.com/music/listen#/now)) once the appropriate element has been clicked.