### PR TITLE
Alt modifier on Enter in vomnibar opens in new tab

### DIFF
--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -125,7 +125,7 @@ class VomnibarUI
     return true unless action # pass through
 
     openInNewTab = @forceNewTab ||
-      (event.shiftKey || event.ctrlKey || KeyboardUtils.isPrimaryModifierKey(event))
+      (event.shiftKey || event.ctrlKey || event.altKey || KeyboardUtils.isPrimaryModifierKey(event))
     if (action == "dismiss")
       @hide()
     else if action in [ "tab", "down" ]


### PR DESCRIPTION
`<Alt-Enter>` in Vomnibar opens in a new tab, as suggested in #1804.

What do you think, @mrmr1993?  On the one hand, there's no reason to be non-chrome-like here.  On the other hand, we're wasting a lot of bindings.

(Interestingly, it seems Chrome treats `Ctrl-Enter` as "I'm feeling lucky...".)