### PR TITLE
Don't decode javascript URIs on Chrome 46.0.2467.2 and later

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -144,7 +144,8 @@ Utils =
     if Utils.hasChromePrefix string
       string
     else if Utils.hasJavascriptPrefix string
-      Utils.decodeURIByParts string
+      # In Chrome versions older than 46.0.2467.2, encoded javascript URIs weren't handled correctly by.
+      if Utils.haveChromeVersion "46.0.2467.2" then string else Utils.decodeURIByParts string
     else if Utils.isUrl string
       Utils.createFullUrl string
     else
@@ -176,7 +177,7 @@ Utils =
 
   # True if the current Chrome version is at least the required version.
   haveChromeVersion: (required) ->
-    chromeVersion = navigator.appVersion.match(/Chrome\/(.*?) /)?[1]
+    chromeVersion = navigator.appVersion.match(/Chrom(e|ium)\/(.*?) /)?[2]
     chromeVersion and 0 <= Utils.compareVersions chromeVersion, required
 
   # Zip two (or more) arrays:

--- a/tests/unit_tests/test_chrome_stubs.coffee
+++ b/tests/unit_tests/test_chrome_stubs.coffee
@@ -8,6 +8,9 @@
 exports.window = {}
 exports.localStorage = {}
 
+global.navigator =
+  appVersion: "5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.85 Safari/537.36"
+
 global.document =
   createElement: -> {}
   addEventListener: ->


### PR DESCRIPTION
The fix for the [Chromium issue 483000](https://code.google.com/p/chromium/issues/detail?id=483000) landed in version 46.0.2467.2, so it is no longer necessary for #1611.

Currently, in that version and later, javascript URIs will be decoded twice &mdash; once by us and once by Chrome when opening the URL &mdash; which will break some bookmarklets.