### PR TITLE
Make the sort used for filetered link hints stable.

### DIFF
--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -185,18 +185,21 @@ context "Filtered link hints",
 
     should "label the hints", ->
       hintMarkers = getHintMarkers()
-      for i in [0...4]
-        assert.equal (i + 1).toString(), hintMarkers[i].textContent.toLowerCase()
+      expectedMarkers = [1..4].map (m) -> m.toString()
+      actualMarkers = [0...4].map (i) -> hintMarkers[i].textContent.toLowerCase()
+      assert.equal expectedMarkers.length, actualMarkers.length
+      for marker in expectedMarkers
+        assert.isTrue marker in actualMarkers
 
     should "narrow the hints", ->
       hintMarkers = getHintMarkers()
       sendKeyboardEvent "T"
       sendKeyboardEvent "R"
       assert.equal "none", hintMarkers[0].style.display
-      assert.equal "1", hintMarkers[1].hintString
+      assert.equal "3", hintMarkers[1].hintString
       assert.equal "", hintMarkers[1].style.display
       sendKeyboardEvent "A"
-      assert.equal "2", hintMarkers[3].hintString
+      assert.equal "1", hintMarkers[3].hintString
 
   context "Image hints",
 


### PR DESCRIPTION
JavaScript's sort function is not stable; this PR makes the sort used for filtered link hints stable.

There are two reasons for doing this:

- High-scoring hints are more likely to keep the same hint string as the user continues typing. (Currently, the hints assigned change based on the vaguaries of the non-stable sort.)

- For equal-scoring hints, we retain the visit-child-before-parent ordering (which is used to NOT match a parent's text if we have already matched that text in a child).

And, as a result of all of that, the UX is more predictable and hence better.

Edit:

A specific use case where this improves things is on Reddit and using filtered link hints to select one of the "comments" links.  In this case, after typing "com", there are still lots of matches.  With this PR, the hints assigned don't change (so much) as the user continues typing "ment".