### PR TITLE
Emit mouseout for the last link when clicking a new link with link hints

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -93,6 +93,7 @@ class LinkHintsMode
       else
         @hintMode.setIndicator "Open multiple links in new tabs."
       @linkActivator = (link) ->
+        @unhoverLast link
         # When "clicking" on a link, dispatch the event with the appropriate meta key (CMD on Mac, CTRL on
         # windows) to open it in a new tab if necessary.
         DomUtils.simulateClick link,
@@ -117,10 +118,13 @@ class LinkHintsMode
     else if @mode is DOWNLOAD_LINK_URL
       @hintMode.setIndicator "Download link URL."
       @linkActivator = (link) ->
+        @unhoverLast link
         DomUtils.simulateClick link, altKey: true, ctrlKey: false, metaKey: false
     else # OPEN_IN_CURRENT_TAB
       @hintMode.setIndicator "Open link in current tab."
-      @linkActivator = (link) -> DomUtils.simulateClick.bind(DomUtils, link)()
+      @linkActivator = (link) ->
+        @unhoverLast link
+        DomUtils.simulateClick link
 
   #
   # Creates a link marker for the given link.
@@ -376,6 +380,12 @@ class LinkHintsMode
         @deactivateMode delay, -> LinkHints.activateModeWithQueue()
       else
         @deactivateMode delay
+
+  unhoverLast: do ->
+    lastHoveredElement = null
+    (element) ->
+      DomUtils.simulateUnhover lastHoveredElement if lastHoveredElement?
+      lastHoveredElement = element
 
   #
   # Shows the marker, highlighting matchingCharCount characters.

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -93,7 +93,6 @@ class LinkHintsMode
       else
         @hintMode.setIndicator "Open multiple links in new tabs."
       @linkActivator = (link) ->
-        @unhoverLast link
         # When "clicking" on a link, dispatch the event with the appropriate meta key (CMD on Mac, CTRL on
         # windows) to open it in a new tab if necessary.
         DomUtils.simulateClick link,
@@ -118,13 +117,10 @@ class LinkHintsMode
     else if @mode is DOWNLOAD_LINK_URL
       @hintMode.setIndicator "Download link URL."
       @linkActivator = (link) ->
-        @unhoverLast link
         DomUtils.simulateClick link, altKey: true, ctrlKey: false, metaKey: false
     else # OPEN_IN_CURRENT_TAB
       @hintMode.setIndicator "Open link in current tab."
-      @linkActivator = (link) ->
-        @unhoverLast link
-        DomUtils.simulateClick link
+      @linkActivator = DomUtils.simulateClick.bind DomUtils
 
   #
   # Creates a link marker for the given link.
@@ -380,12 +376,6 @@ class LinkHintsMode
         @deactivateMode delay, -> LinkHints.activateModeWithQueue()
       else
         @deactivateMode delay
-
-  unhoverLast: do ->
-    lastHoveredElement = null
-    (element) ->
-      DomUtils.simulateUnhover lastHoveredElement if lastHoveredElement?
-      lastHoveredElement = element
 
   #
   # Shows the marker, highlighting matchingCharCount characters.

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -234,19 +234,20 @@ DomUtils =
           if element.selectionStart == 0 and element.selectionEnd == 0
             element.setSelectionRange element.value.length, element.value.length
 
-
+  simulateUnhover: (element, modifiers) -> @simulateMouseEvent "mouseout", element, modifiers
 
   simulateClick: (element, modifiers) ->
-    modifiers ||= {}
-
     eventSequence = ["mouseover", "mousedown", "mouseup", "click"]
     for event in eventSequence
-      mouseEvent = document.createEvent("MouseEvents")
-      mouseEvent.initMouseEvent(event, true, true, window, 1, 0, 0, 0, 0, modifiers.ctrlKey, modifiers.altKey,
-      modifiers.shiftKey, modifiers.metaKey, 0, null)
-      # Debugging note: Firefox will not execute the element's default action if we dispatch this click event,
-      # but Webkit will. Dispatching a click on an input box does not seem to focus it; we do that separately
-      element.dispatchEvent(mouseEvent)
+      @simulateMouseEvent event, element, modifiers
+
+  simulateMouseEvent: (event, element, modifiers = {}) ->
+    mouseEvent = document.createEvent("MouseEvents")
+    mouseEvent.initMouseEvent(event, true, true, window, 1, 0, 0, 0, 0, modifiers.ctrlKey, modifiers.altKey,
+    modifiers.shiftKey, modifiers.metaKey, 0, null)
+    # Debugging note: Firefox will not execute the element's default action if we dispatch this click event,
+    # but Webkit will. Dispatching a click on an input box does not seem to focus it; we do that separately
+    element.dispatchEvent(mouseEvent)
 
   # momentarily flash a rectangular border to give user some visual feedback
   flashRect: (rect) ->

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -241,13 +241,26 @@ DomUtils =
     for event in eventSequence
       @simulateMouseEvent event, element, modifiers
 
-  simulateMouseEvent: (event, element, modifiers = {}) ->
-    mouseEvent = document.createEvent("MouseEvents")
-    mouseEvent.initMouseEvent(event, true, true, window, 1, 0, 0, 0, 0, modifiers.ctrlKey, modifiers.altKey,
-    modifiers.shiftKey, modifiers.metaKey, 0, null)
-    # Debugging note: Firefox will not execute the element's default action if we dispatch this click event,
-    # but Webkit will. Dispatching a click on an input box does not seem to focus it; we do that separately
-    element.dispatchEvent(mouseEvent)
+  simulateMouseEvent: do ->
+    lastHoveredElement = undefined
+    (event, element, modifiers = {}) ->
+
+      if event == "mouseout"
+        element ?= lastHoveredElement # Allow unhovering the last hovered element by passing undefined.
+        lastHoveredElement = undefined
+        return unless element?
+
+      else if event == "mouseover"
+        # Simulate moving the mouse off the previous element first, as if we were a real mouse.
+        @simulateMouseEvent "mouseout", undefined, modifiers
+        lastHoveredElement = element
+
+      mouseEvent = document.createEvent("MouseEvents")
+      mouseEvent.initMouseEvent(event, true, true, window, 1, 0, 0, 0, 0, modifiers.ctrlKey, modifiers.altKey,
+      modifiers.shiftKey, modifiers.metaKey, 0, null)
+      # Debugging note: Firefox will not execute the element's default action if we dispatch this click event,
+      # but Webkit will. Dispatching a click on an input box does not seem to focus it; we do that separately
+      element.dispatchEvent(mouseEvent)
 
   # momentarily flash a rectangular border to give user some visual feedback
   flashRect: (rect) ->


### PR DESCRIPTION
This is the unobjectionable part of #1032, intended to fix #1189.

Whenever a new link is clicked with `DomUtils.simulateClick` in `LinkHints`, the previous element to have been clicked is sent a `mouseout` event. This greatly improves usability of some websites with hover effects (eg. [an IMDb grid view page](http://www.imdb.com/list/ls000004180/?start=1&view=grid&sort=listorian:asc&defaults=1&scb=0.23077548970468342), where opening one of the films in a new tab shows a hover pop-up).