### PR TITLE
Don't show UIComponent <iframe>s while vimium.css loads

### DIFF
--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -9,7 +9,10 @@ class UIComponent
     styleSheet = DomUtils.createElement "style"
     styleSheet.type = "text/css"
     # Default to everything hidden while the stylesheet loads.
-    styleSheet.innerHTML = "@import url(\"#{chrome.runtime.getURL("content_scripts/vimium.css")}\");"
+    styleSheet.innerHTML = """
+      @import url("#{chrome.runtime.getURL("content_scripts/vimium.css")}");
+      iframe {display: none;}
+    """
 
     @iframeElement = DomUtils.createElement "iframe"
     extend @iframeElement,


### PR DESCRIPTION
This fixes #1817 by hiding the Vomnibar and HUD when our stylesheet isn't loaded.

This has the effect that `b`/`B`/`o`/`O`/etc. appear to do nothing, but require a click on the new tab page to continue using Vimium normally.