### PR TITLE
Make <label>s clickable with LinkHints

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -214,6 +214,8 @@ class LinkHintsMode
                              (element.readOnly and DomUtils.isSelectable element))
       when "button", "select"
         isClickable ||= not element.disabled
+      when "label"
+        isClickable ||= element.control?
 
     # Elements with tabindex are sometimes useful, but usually not. We can treat them as second class
     # citizens when it improves UX, so take special note of them.

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -215,7 +215,7 @@ class LinkHintsMode
       when "button", "select"
         isClickable ||= not element.disabled
       when "label"
-        isClickable ||= element.control?
+        isClickable ||= element.control? and (@getVisibleClickable element.control).length == 0
 
     # Elements with tabindex are sometimes useful, but usually not. We can treat them as second class
     # citizens when it improves UX, so take special note of them.

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -243,8 +243,8 @@ context "Filtered link hints",
       hintMarkers = getHintMarkers()
       hintMarkers = getHintMarkers().map (marker) -> marker.textContent.toLowerCase()
       # We don't know the actual hint numbers which will be assigned, so we replace them with "N".
-      hintMarkers = hintMarkers.map (str) -> str.replace /^[1-5]/, "N"
-      assert.equal 5, hintMarkers.length
+      hintMarkers = hintMarkers.map (str) -> str.replace /^[0-9]+/, "N"
+      assert.equal 7, hintMarkers.length
       assert.isTrue "N" in hintMarkers
       assert.isTrue "N" in hintMarkers
       assert.isTrue "N: a label" in hintMarkers

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -244,7 +244,7 @@ context "Filtered link hints",
       hintMarkers = getHintMarkers().map (marker) -> marker.textContent.toLowerCase()
       # We don't know the actual hint numbers which will be assigned, so we replace them with "N".
       hintMarkers = hintMarkers.map (str) -> str.replace /^[0-9]+/, "N"
-      assert.equal 7, hintMarkers.length
+      assert.equal 5, hintMarkers.length
       assert.isTrue "N" in hintMarkers
       assert.isTrue "N" in hintMarkers
       assert.isTrue "N: a label" in hintMarkers


### PR DESCRIPTION
This fixes #1783.

Edit: Updated to only show hints for `<label>`s whose corresponding element doesn't have a hint itself, to avoid lots of duplicated hints where `<label>` wraps the element.

Edit 2: [JSFiddle](http://jsfiddle.net/mhwa9zep/1/) for testing all the cases.