### PR TITLE
Use version 0.11 of node's path; new version 0.12 breaks the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js: 0.10
 before_install:
   - "npm install -g coffee-script"
-  - "npm install path"
+  - "npm install path@0.11"
   - "npm install util"
   - "cake build"
 script: "cake test"


### PR DESCRIPTION
This fixes the Travis build, which is failing since the path module was updated to 0.12.