### PR TITLE
Add <count> prefix for g0 and g$.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Release Notes
 -------------
 Updates since 1.52 (not yet released)
 
+- `g0` and `g$` now accept count prefixes; so `2g0` selects the second tab, and so on.
 - Bug fixes:
     - Fix `moveTabLeft` and `moveTabRight` for pinned tabs (#1814 and #1815).
 

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -309,8 +309,8 @@ commandDescriptions =
   # Manipulating tabs
   nextTab: ["Go one tab right", { background: true, passCountToFunction: true }]
   previousTab: ["Go one tab left", { background: true, passCountToFunction: true }]
-  firstTab: ["Go to the first tab", { background: true }]
-  lastTab: ["Go to the last tab", { background: true }]
+  firstTab: ["Go to the first tab", { background: true, passCountToFunction: true }]
+  lastTab: ["Go to the last tab", { background: true, passCountToFunction: true }]
 
   createTab: ["Create new tab", { background: true, repeatLimit: 20 }]
   duplicateTab: ["Duplicate current tab", { background: true, repeatLimit: 20 }]

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -267,8 +267,8 @@ BackgroundCommands =
       chrome.windows.create {tabId: tab.id, incognito: tab.incognito}
   nextTab: (count) -> selectTab "next", count
   previousTab: (count) -> selectTab "previous", count
-  firstTab: -> selectTab "first"
-  lastTab: -> selectTab "last"
+  firstTab: (count) -> selectTab "first", count
+  lastTab: (count) -> selectTab "last", count
   removeTab: (callback) ->
     chrome.tabs.getSelected(null, (tab) ->
       chrome.tabs.remove(tab.id)
@@ -349,15 +349,13 @@ selectTab = (direction, count = 1) ->
       toSelect =
         switch direction
           when "next"
-            currentTab.index + count
+            Math.min tabs.length - 1, currentTab.index + count
           when "previous"
-            currentTab.index - count
+            Math.max 0, currentTab.index - count
           when "first"
-            0
+            Math.min tabs.length - 1, count - 1
           when "last"
-            tabs.length - 1
-      # Bring toSelect into the range [0,tabs.length).
-      toSelect = (toSelect + tabs.length * Math.abs count) % tabs.length
+            Math.max 0, tabs.length - count
       chrome.tabs.update tabs[toSelect].id, selected: true
 
 updateOpenTabs = (tab, deleteFrames = false) ->


### PR DESCRIPTION
`2g0` takes you to the second tab.
`2g$` takes you to the second last tab.

This gives us `gt`/`gT` for relative tab selection and `g0`/`g$` for absolute tab selection.

`<count>` previously had no special meaning for `g0` and `g$`, and it's not clear it could have any other meaning than that implemented here.

Fixes #1298 (kind of).