### PR TITLE
Bound count for H and L by history length.

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -325,8 +325,8 @@ extend window,
 
 extend window,
   reload: -> window.location.reload()
-  goBack: (count) -> history.go(-count)
-  goForward: (count) -> history.go(count)
+  goBack: (count) -> history.go Math.max -count, -(history.length - 1)
+  goForward: (count) -> history.go Math.min count, history.length - 1
 
   goUp: (count) ->
     url = window.location.href


### PR DESCRIPTION
Bound the count for H and L by history.length - 1.  Going further back or forward than this is always silently discarded.

This means that, in certain circumstances, you can say 1000H to go back to the first history page and 1000L to go forward to the end of the history.

(However, this doesn't work unless you're starting at the beginning or end of the history.  The history API doesn't expose where in the history we currently are.)

Fixes #1691, kind of.