### PR TITLE
Load UIComponent stylesheet via XMLHttpRequest, use background as needed

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -668,6 +668,7 @@ sendRequestHandlers =
   setIcon: setIcon
   sendMessageToFrames: sendMessageToFrames
   log: bgLog
+  fetchFileContents: (request, sender) -> fetchFileContents request.fileName
 
 # We always remove chrome.storage.local/findModeRawQueryListIncognito on startup.
 chrome.storage.local.remove "findModeRawQueryListIncognito"


### PR DESCRIPTION
This fixes #1817 (properly this time), making the Vomnibar and HUD work on NTP for Chrome 47.

We try to load styles via `XMLHttpRequest`, and if that fails we use `fetchFileContents` in the background page to do the `XMLHttpRequest` for us.

@smblott-github I think this is the silver bullet you wanted over in #1831.