### PR TITLE
Suppress trailing key events (after link hints).

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -69,6 +69,7 @@ class LinkHintsMode
       indicator: false
       passInitialKeyupEvents: true
       suppressAllKeyboardEvents: true
+      suppressTrailingKeyEvents: true
       exitOnEscape: true
       exitOnClick: true
       exitOnScroll: true

--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -144,6 +144,25 @@ class Mode
         keyup: (event) =>
           if KeyboardUtils.isPrintable event then @stopBubblingAndFalse else @stopBubblingAndTrue
 
+    # if @options.suppressTrailingKeyEvents is set, then we suppress all key events until a subsquent
+    # (non-repeat) keydown or keypress.  In particular, the intention is to catch keyup events for keys which
+    # we have handled, but which otherwise might trigger page actions (if the page is listening for keyup
+    # events).
+    if @options.suppressTrailingKeyEvents
+      @onExit ->
+        handler = (event) ->
+          if event.repeat
+            false # Suppress event.
+          else
+            keyEventSuppressor.exit()
+            true # Do not suppress event.
+
+        keyEventSuppressor = new Mode
+          name: "suppress-trailing-key-events"
+          keydown: handler
+          keypress: handler
+          keyup: -> handlerStack.stopBubblingAndFalse
+
     Mode.modes.push @
     @setIndicator()
     @logModes()

--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -41,6 +41,7 @@ class Mode
     @handlers = []
     @exitHandlers = []
     @modeIsActive = true
+    @modeIsExiting = false
     @name = @options.name || "anonymous"
 
     @count = ++count
@@ -189,8 +190,10 @@ class Mode
   exit: ->
     if @modeIsActive
       @log "deactivate:", @id
-      handler() for handler in @exitHandlers
-      handlerStack.remove handlerId for handlerId in @handlers
+      unless @modeIsExiting
+        @modeIsExiting = true
+        handler() for handler in @exitHandlers
+        handlerStack.remove handlerId for handlerId in @handlers
       Mode.modes = Mode.modes.filter (mode) => mode != @
       @modeIsActive = false
       @setIndicator()

--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -144,10 +144,10 @@ class Mode
         keyup: (event) =>
           if KeyboardUtils.isPrintable event then @stopBubblingAndFalse else @stopBubblingAndTrue
 
-    # if @options.suppressTrailingKeyEvents is set, then we suppress all key events until a subsquent
-    # (non-repeat) keydown or keypress.  In particular, the intention is to catch keyup events for keys which
-    # we have handled, but which otherwise might trigger page actions (if the page is listening for keyup
-    # events).
+    # if @options.suppressTrailingKeyEvents is set, then  -- on exit -- we suppress all key events until a
+    # subsquent (non-repeat) keydown or keypress.  In particular, the intention is to catch keyup events for
+    # keys which we have handled, but which otherwise might trigger page actions (if the page is listening for
+    # keyup events).
     if @options.suppressTrailingKeyEvents
       @onExit ->
         handler = (event) ->

--- a/lib/handler_stack.coffee
+++ b/lib/handler_stack.coffee
@@ -48,7 +48,7 @@ class HandlerStack
         result = handler[type].call @, event
         @logResult eventNumber, type, event, handler, result if @debug
         if not result
-          DomUtils.suppressEvent event  if @isChromeEvent event
+          DomUtils.suppressEvent event if @isChromeEvent event
           return false
         return true if result == @stopBubblingAndTrue
         return false if result == @stopBubblingAndFalse


### PR DESCRIPTION
This ensures that -- on leaving link hints mode -- we consume any trailing keyup events (and don't let the underlying page see them).

Fixes #1844; possibly.

Additional notes:

- There are other places where we seem to be leaking keyup events.

- A separate bug... It looks like we're calling `exit()` on link-hints
  mode twice.