### PR TITLE
Enter visual mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist
 jscoverage.json
 tags
 .cake_task_cache
+.idea/
+*.iml

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -280,7 +280,6 @@ DomUtils =
     event.initTextEvent "textInput", true, true, null, text
     element.dispatchEvent event
 
-  # Adapted from: http://roysharon.com/blog/37.
   # This finds the element containing the selection focus.
   getElementWithFocus: (selection, backwards) ->
     selection.anchorNode;

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -283,16 +283,7 @@ DomUtils =
   # Adapted from: http://roysharon.com/blog/37.
   # This finds the element containing the selection focus.
   getElementWithFocus: (selection, backwards) ->
-    r = t = selection.getRangeAt 0
-    if selection.type == "Range"
-      r = t.cloneRange()
-      r.collapse backwards
-    t = r.startContainer
-    t = t.childNodes[r.startOffset] if t.nodeType == 1
-    o = t
-    o = o.previousSibling while o and o.nodeType != 1
-    t = o || t?.parentNode
-    t
+    selection.anchorNode;
 
   # This calculates the caret coordinates within an input element.  It is used by edit mode to calculate the
   # caret position for scrolling.  It creates a hidden div contain a mirror of element, and all of the text


### PR DESCRIPTION
I had a problem with entering visual mode in this specific case:
If searched the page for a string. The string got highlighted. I pressed "v" to enter visual mode, but then the message "no usable selection, switching to caret mode" appeared. 
I tried to figure out what happened and it appeared that the html of that specific text was like this:
```
<p>
Lorum<br>
Ipsum<br>
Dolor
</p>
```
(where the selected text was "Ipsum").

In the original code of getSelectedElement it, for some reason, returned the element that is before the selected element (`<br>` in this case). Of course selecting just the `<br>` isn't useful so it switched to caret mode. 

I replaced the method's contents by just returning the anchorNode of the selected text. It now works perfectly!