### PR TITLE
Properly check whether the selection is visible in the current viewport

### DIFF
--- a/content_scripts/mode_visual_edit.coffee
+++ b/content_scripts/mode_visual_edit.coffee
@@ -484,8 +484,11 @@ class VisualMode extends Movement
         @extendByOneCharacter(forward) or @extendByOneCharacter backward
       else
         if @selection.type in [ "Caret", "Range" ]
-          elementWithFocus = DomUtils.getElementWithFocus @selection, @getDirection() == backward
-          if DomUtils.getVisibleClientRect elementWithFocus
+          selectionRect = @selection.getRangeAt(0).getBoundingClientRect()
+          selectionRect = Rect.intersect selectionRect, (Rect.create 0, 0, window.innerWidth,
+              window.innerHeight)
+          if selectionRect.height >= 0 and selectionRect.width >= 0
+            # The selection is visible in the current viewport.
             if @selection.type == "Caret"
               # The caret is in the viewport. Make make it visible.
               @extendByOneCharacter(forward) or @extendByOneCharacter backward

--- a/lib/rect.coffee
+++ b/lib/rect.coffee
@@ -78,5 +78,9 @@ Rect =
       return false if rect1[property] != rect2[property]
     true
 
+  intersect: (rect1, rect2) ->
+    @create (Math.max rect1.left, rect2.left), (Math.max rect1.top, rect2.top),
+        (Math.min rect1.right, rect2.right), (Math.min rect1.bottom, rect2.bottom)
+
 root = exports ? window
 root.Rect = Rect


### PR DESCRIPTION
This fixes the issue menioned in PR #1864, by using `Range.getBoundingClientRect`.

For more accurate results, it might be worth instead doing

```coffee
visibleSelectionRects = (@selection.getRangeAt(0).getClientRects().map (rect) ->
  Rect.intersect rect, (Rect.create 0, 0, window.innerWidth,
    window.innerHeight)
).filter (rect) -> rect.height >= 0 and selectionRect.width >= 0
if visibleSelectionRects.length > 0
...
```

which will mean that Visual Mode will fall back to Caret Mode if and only if there is no selection visible in the viewport.

Edit: I've also pushed a branch ([`visual-mode-range-getClientRects`](https://github.com/mrmr1993/vimium/tree/visual-mode-range-getClientRects)) with a version containing this instead.