### PR TITLE
Show as many short hint markers as possible

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -441,7 +441,7 @@ class AlphabetHints
     # Short hints are the number of hints we can possibly show which are (digitsNeeded - 1) digits in length.
     shortHintCount = Math.floor(
       (Math.pow(@linkHintCharacters.length, digitsNeeded) - linkCount) /
-      @linkHintCharacters.length)
+      (@linkHintCharacters.length - 1))
     longHintCount = linkCount - shortHintCount
 
     hintStrings = []

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -149,18 +149,16 @@ context "Alphabetical link hints",
     document.getElementById("test-div").innerHTML = ""
 
   should "label the hints correctly", ->
-    # TODO(philc): This test verifies the current behavior, but the current behavior is incorrect.
-    # The output here should be something like aa, ab, b.
     hintMarkers = getHintMarkers()
-    expectedHints = ["aa", "ba", "ab"]
+    expectedHints = ["a", "bb", "ba"]
     for hint, i in expectedHints
       assert.equal hint, hintMarkers[i].hintString
 
   should "narrow the hints", ->
     hintMarkers = getHintMarkers()
-    sendKeyboardEvent "A"
-    assert.equal "none", hintMarkers[1].style.display
-    assert.equal "", hintMarkers[0].style.display
+    sendKeyboardEvent "B"
+    assert.equal "none", hintMarkers[0].style.display
+    assert.equal "", hintMarkers[1].style.display
 
 context "Filtered link hints",
   # Note.  In all of these tests, the order of the elements returned by getHintMarkers() may be different from


### PR DESCRIPTION
The previous formula was sub-optimal; this updates the formula to get the maximum number of short hints that we can.

Explanation from the commit messge:

```
Let linkCount be the number of links,
    characterCount be the number of characters.

Let digitsNeeded be such that
  characterCount^digitsNeeded >= linkCount > characterCount^(digitsNeeded - 1),
  as in the code.

Let longLen = characterCount^(digitsNeeded - 1),
    shortLen = characterCount^(digitsNeeded - 2),
  such that they represent the number of hints a letter can prefix,
  depending on whether they are used for short or long hint strings.

Then the maximum number of links we can show hints for, when shortCount
is the number of short hint prefixes, is

maxCount = shortCount * shortLen + (hintCharacters - shortCount) * longLen
         = shortCount * (shortLen - longLen) + hintCharacters^digitsNeeded

We want that linkCount <= maxCount, so

linkCount <= shortCount * (shortLen - longLen) + hintCharacters^digitsNeeded

shortCount * (longLen - shortLen) <= hintCharacters^digitsNeeded - linkCount
shortCount * shortLen * (characterCount - 1) <= hintCharacters^digitsNeeded - linkCount
shortCount * shortLen <= (hintCharacters^digitsNeeded - linkCount) / (characterCount - 1)

Since (shortCount * shortLen) is the largest number of short hints we
can show, we get that shortHintCount can be as in the code.
```