### PR TITLE
CSS overrides for Vomnibar + optional overlay behind it

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -44,5 +44,6 @@ Contributors:
   Shiyong Chen <billbill290@gmail.com> (github: UncleBill)
   Utkarsh Upadhyay <musically.ut@gmail.com) (github: musically-ut)
   Michael Salihi <admin@prestance-informatique.fr> (github: PrestanceDesign)
+  Bez Hermoso <bezalelhermoso@gmail.com) (github: bezhermoso)
 
 Feel free to add real names in addition to GitHub usernames.

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -405,6 +405,15 @@ chrome.tabs.onUpdated.addListener (tabId, changeInfo, tab) ->
     code: Settings.get("userDefinedLinkHintCss")
     runAt: "document_start"
   chrome.tabs.insertCSS tabId, cssConf, -> chrome.runtime.lastError
+
+chrome.tabs.onUpdated.addListener (tabId, changeInfo, tab) ->
+  return unless changeInfo.status == "loading" # only do this once per URL change
+  cssConf =
+    allFrames: true
+    code: Settings.get("userDefinedVomnibarOverlayCss")
+    runAt: "document_start"
+  chrome.tabs.insertCSS tabId, cssConf, -> chrome.runtime.lastError
+  updateOpenTabs(tab) if changeInfo.url?
   updateOpenTabs(tab) if changeInfo.url?
 
 chrome.tabs.onAttached.addListener (tabId, attachedInfo) ->

--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -13,7 +13,7 @@ HUD =
   # it doesn't sit on top of horizontal scrollbars like Chrome's HUD does.
 
   init: ->
-    @hudUI = new UIComponent "pages/hud.html", "vimiumHUDFrame", ({data}) =>
+    @hudUI = new UIComponent "pages/hud.html", "vimiumHUDFrame", false, ({data}) =>
       this[data.name]? data
     @tween = new Tween "iframe.vimiumHUDFrame.vimiumUIComponentVisible", @hudUI.shadowDOM
 

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -21,6 +21,7 @@ class UIComponent
     UIComponent::styleSheetGetter ?= new AsyncDataFetcher @fetchFileContents "content_scripts/vimium.css"
     @styleSheetGetter.use (styles) -> styleSheet.innerHTML = styles
 
+
     @className = className
     @iframeElement = DomUtils.createElement "iframe"
     extend @iframeElement,

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -102,7 +102,8 @@ class UIComponent
     unless @overlay?
       @overlay = document.createElement 'div'
       @overlay.className = 'vomnibarBackgroundOverlay'
-      document.body.appendChild @overlay
+      document.body.insertBefore(@overlay, document.body.firstChild)
+      #document.body.appendChild @overlay
     else
       @overlay.style.display = "block"
 

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -5,8 +5,12 @@ class UIComponent
   options: null
   shadowDOM: null
   styleSheetGetter: null
+  overlayEnabled: false
+  overlay: null
 
-  constructor: (iframeUrl, className, @handleMessage) ->
+  constructor: (iframeUrl, className, overlayEnabled, @handleMessage) ->
+    @overlayEnabled = overlayEnabled
+
     styleSheet = DomUtils.createElement "style"
     styleSheet.type = "text/css"
     # Default to everything hidden while the stylesheet loads.
@@ -17,6 +21,7 @@ class UIComponent
     UIComponent::styleSheetGetter ?= new AsyncDataFetcher @fetchFileContents "content_scripts/vimium.css"
     @styleSheetGetter.use (styles) -> styleSheet.innerHTML = styles
 
+    @className = className
     @iframeElement = DomUtils.createElement "iframe"
     extend @iframeElement,
       className: className
@@ -68,6 +73,7 @@ class UIComponent
       @iframeElement.focus()
 
   show: (message) ->
+    @showOverlay() if @overlayEnabled
     @postMessage message, =>
       @iframeElement.classList.remove "vimiumUIComponentHidden"
       @iframeElement.classList.add "vimiumUIComponentVisible"
@@ -82,6 +88,7 @@ class UIComponent
       @showing = true
 
   hide: (focusWindow = true)->
+    @hideOverlay()
     @refocusSourceFrame @options?.sourceFrameId if focusWindow
     window.removeEventListener "focus", @onFocus if @onFocus
     @onFocus = null
@@ -90,6 +97,17 @@ class UIComponent
     @options = null
     @showing = false
 
+  showOverlay: ->
+    unless @overlay?
+      @overlay = document.createElement 'div'
+      @overlay.className = 'vomnibarBackgroundOverlay'
+      document.body.appendChild @overlay
+    else
+      @overlay.style.display = "block"
+
+  hideOverlay: ->
+    if @overlay?
+      @overlay.style.display = "none"
   # Refocus the frame from which the UI component was opened.  This may be different from the current frame.
   # After hiding the UI component, Chrome refocuses the containing frame. To avoid a race condition, we need
   # to wait until that frame first receives the focus, before then focusing the frame which should now have

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -304,6 +304,16 @@ body.vimiumFindMode ::selection {
   background: #ff9632;
 }
 
+div.vomnibarBackgroundOverlay {
+  position: fixed;
+  top: 0px;
+  bottom: 0px;
+  right: 0px;
+  left: 0px;
+  background-color: rgba(255, 255, 255, 0.8);
+  z-index: 9999;
+}
+
 /* Vomnibar Frame CSS */
 
 iframe.vomnibarFrame {

--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -22,6 +22,7 @@ Vomnibar =
           else
               console.log "Vimium configuration error: unused flag: #{option}."
 
+      options.userDefinedStyles = Settings.get("userDefinedVomnibarCss")
       callback? options
 
   # sourceFrameId here (and below) is the ID of the frame from which this request originates, which may be different

--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -3,6 +3,7 @@
 #
 Vomnibar =
   vomnibarUI: null
+  overlay: null
 
   # Parse any additional options from the command's registry entry.  Currently, this only includes a flag of
   # the form "keyword=X", for direct activation of a custom search engine.
@@ -61,7 +62,7 @@ Vomnibar =
 
   init: ->
     unless @vomnibarUI?
-      @vomnibarUI = new UIComponent "pages/vomnibar.html", "vomnibarFrame", (event) =>
+      @vomnibarUI = new UIComponent "pages/vomnibar.html", "vomnibarFrame", true, (event) =>
         @vomnibarUI.hide() if event.data == "hide"
       # Whenever the window receives the focus, we tell the Vomnibar UI that it has been hidden (regardless of
       # whether it was previously visible).

--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -63,7 +63,7 @@ Vomnibar =
 
   init: ->
     unless @vomnibarUI?
-      @vomnibarUI = new UIComponent "pages/vomnibar.html", "vomnibarFrame", true, (event) =>
+      @vomnibarUI = new UIComponent "pages/vomnibar.html", "vomnibarFrame", true && Settings.get("overlayBehindVomnibar"), (event) =>
         @vomnibarUI.hide() if event.data == "hide"
       # Whenever the window receives the focus, we tell the Vomnibar UI that it has been hidden (regardless of
       # whether it was previously visible).

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -102,7 +102,9 @@ Settings =
     linkHintNumbers: "0123456789"
     filterLinkHints: false
     hideHud: false
-    userDefinedVomnibarCss: ".vomnibar {}"
+    userDefinedVomnibarCss: "#vomnibar {}"
+    userDefinedVomnibarOverlayCss: ".vomnibarBackgroundOverlay {}"
+    overlayBehindVomnibar: false
     userDefinedLinkHintCss:
       """
       div > .vimiumHintMarker {

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -102,6 +102,7 @@ Settings =
     linkHintNumbers: "0123456789"
     filterLinkHints: false
     hideHud: false
+    userDefinedVomnibarCss: ".vomnibar {}"
     userDefinedLinkHintCss:
       """
       div > .vimiumHintMarker {

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -198,6 +198,7 @@ Options =
   searchEngines: TextOption
   searchUrl: NonEmptyTextOption
   userDefinedLinkHintCss: TextOption
+  userDefinedVomnibarCss: TextOption
 
 initOptionsPage = ->
   onUpdated = ->

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -199,6 +199,8 @@ Options =
   searchUrl: NonEmptyTextOption
   userDefinedLinkHintCss: TextOption
   userDefinedVomnibarCss: TextOption
+  overlayBehindVomnibar: CheckBoxOption
+  userDefinedVomnibarOverlayCss: TextOption
 
 initOptionsPage = ->
   onUpdated = ->

--- a/pages/options.css
+++ b/pages/options.css
@@ -112,7 +112,7 @@ input#scrollStepSize {
   margin-right: 3px;
   padding-left: 3px;
 }
-textarea#userDefinedLinkHintCss, textarea#keyMappings, textarea#searchEngines {
+textarea#userDefinedLinkHintCss, textarea#keyMappings, textarea#searchEngines, textarea#userDefinedVomnibarCss {
   width: 100%;;
   min-height: 140px;
   white-space: nowrap;

--- a/pages/options.css
+++ b/pages/options.css
@@ -112,7 +112,7 @@ input#scrollStepSize {
   margin-right: 3px;
   padding-left: 3px;
 }
-textarea#userDefinedLinkHintCss, textarea#keyMappings, textarea#searchEngines, textarea#userDefinedVomnibarCss {
+textarea#userDefinedLinkHintCss, textarea#keyMappings, textarea#searchEngines, textarea#userDefinedVomnibarCss, textarea#userDefinedVomnibarOverlayCss {
   width: 100%;;
   min-height: 140px;
   white-space: nowrap;

--- a/pages/options.html
+++ b/pages/options.html
@@ -234,6 +234,20 @@ b: http://b.com/?q=%s description
               <div class="nonEmptyTextOption">
             </td>
           </tr>
+          <tr>
+            <td class="caption">CSS for Vomnibar</td>
+            <td verticalAlign="top">
+              <div class="help">
+                <div class="example">
+                  Additional CSS to style the Vomnibar<br/><br/>
+                  These styles are used in addition to and take precedence over Vimium's
+                  default styles.
+                </div>
+              </div>
+              <textarea id="userDefinedVomnibarCss" class="code" type="text"></textarea>
+              <div class="nonEmptyTextOption">
+            </td>
+          </tr>
 
           <!-- Vimium Labs -->
           <!--

--- a/pages/options.html
+++ b/pages/options.html
@@ -248,6 +248,29 @@ b: http://b.com/?q=%s description
               <div class="nonEmptyTextOption">
             </td>
           </tr>
+          <tr>
+            <td class="caption"></td>
+            <td verticalAlign="top" class="booleanOption">
+              <label>
+                <input id="overlayBehindVomnibar" type="checkbox"/>
+                Overlay behind Vomnibar
+              </label>
+            </td>
+          </tr>
+          <tr>
+            <td class="caption">CSS for Vomnibar overlay</td>
+            <td verticalAlign="top">
+              <div class="help">
+                <div class="example">
+                  Additional CSS to style the overlay behind Vomnibar<br/><br/>
+                  These styles are used in addition to and take precedence over Vimium's
+                  default styles.
+                </div>
+              </div>
+              <textarea id="userDefinedVomnibarOverlayCss" class="code" type="text"></textarea>
+              <div class="nonEmptyTextOption">
+            </td>
+          </tr>
 
           <!-- Vimium Labs -->
           <!--

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -18,11 +18,13 @@ Vomnibar =
       newTab: false
       selectFirst: false
       keyword: null
+      userDefinedStyles: ""
+
     extend options, userOptions
     extend options, refreshInterval: if options.completer == "omni" then 150 else 0
 
     completer = @getCompleter options.completer
-    @vomnibarUI ?= new VomnibarUI()
+    @vomnibarUI ?= new VomnibarUI(options.userDefinedStyles)
     completer.refresh @vomnibarUI
     @vomnibarUI.setInitialSelectionValue if options.selectFirst then 0 else -1
     @vomnibarUI.setCompleter completer
@@ -36,7 +38,8 @@ Vomnibar =
   onHidden: -> @vomnibarUI?.onHidden()
 
 class VomnibarUI
-  constructor: ->
+  constructor: (userDefinedStyles) ->
+    @userDefinedStyles = userDefinedStyles
     @refreshInterval = 0
     @postHideCallback = null
     @initDom()
@@ -245,6 +248,12 @@ class VomnibarUI
     @input.focus()
 
   initDom: ->
+
+    styles = DomUtils.createElement "style"
+    styles.type = "text/css"
+    styles.innerHTML = @userDefinedStyles
+    document.getElementsByTagName("head")[0].appendChild styles
+
     @box = document.getElementById("vomnibar")
 
     @input = @box.querySelector("input")

--- a/pages/vomnibar.css
+++ b/pages/vomnibar.css
@@ -9,19 +9,19 @@
 #vomnibar {
   display: block;
   position: fixed;
-  width: calc(100% - 120px); /* adjusted to keep border radius and box-shadow visible*/
+  width: calc(100% - 20px); /* adjusted to keep border radius and box-shadow visible*/
   /*min-width: 400px;
   top: 70px;
   left: 50%;*/
-  top: 40px;
-  left: 40px;
+  top: 8px;
+  left: 8px;
   /*margin: 0 0 0 -40%;*/
   font-family: sans-serif;
 
   background: #F1F1F1;
   text-align: left;
   border-radius: 4px;
-  box-shadow: 0px 25px 50px rgba(0, 0, 0, 0.5);
+  box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.8);
   border: 1px solid #aaa;
   /* One less than hint markers and the help dialog. */
   z-index: 2147483646;
@@ -35,10 +35,9 @@
   margin-bottom: 0;
   padding: 4px;
   background-color: white;
-  /*border-radius: 3px;*/
-  border: none;
-  border-bottom: 1px solid #ccc;
-  /*box-shadow: #444 0px 0px 1px;*/
+  border-radius: 3px;
+  border: 1px solid #E8E8E8;
+  box-shadow: #444 0px 0px 1px;
   width: 100%;
   outline: none;
   box-sizing: border-box;
@@ -47,7 +46,7 @@
 #vomnibar .vomnibarSearchArea {
   display: block;
   padding: 10px;
-  background-color: #FFFFFF;
+  background-color: #F1F1F1;
   border-radius: 4px 4px 0 0;
   border-bottom: 1px solid #C6C9CE;
 }

--- a/pages/vomnibar.css
+++ b/pages/vomnibar.css
@@ -9,19 +9,19 @@
 #vomnibar {
   display: block;
   position: fixed;
-  width: calc(100% - 20px); /* adjusted to keep border radius and box-shadow visible*/
+  width: calc(100% - 120px); /* adjusted to keep border radius and box-shadow visible*/
   /*min-width: 400px;
   top: 70px;
   left: 50%;*/
-  top: 8px;
-  left: 8px;
+  top: 40px;
+  left: 40px;
   /*margin: 0 0 0 -40%;*/
   font-family: sans-serif;
 
   background: #F1F1F1;
   text-align: left;
   border-radius: 4px;
-  box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.8);
+  box-shadow: 0px 25px 50px rgba(0, 0, 0, 0.5);
   border: 1px solid #aaa;
   /* One less than hint markers and the help dialog. */
   z-index: 2147483646;
@@ -35,9 +35,10 @@
   margin-bottom: 0;
   padding: 4px;
   background-color: white;
-  border-radius: 3px;
-  border: 1px solid #E8E8E8;
-  box-shadow: #444 0px 0px 1px;
+  /*border-radius: 3px;*/
+  border: none;
+  border-bottom: 1px solid #ccc;
+  /*box-shadow: #444 0px 0px 1px;*/
   width: 100%;
   outline: none;
   box-sizing: border-box;
@@ -46,7 +47,7 @@
 #vomnibar .vomnibarSearchArea {
   display: block;
   padding: 10px;
-  background-color: #F1F1F1;
+  background-color: #FFFFFF;
   border-radius: 4px 4px 0 0;
   border-bottom: 1px solid #C6C9CE;
 }


### PR DESCRIPTION
Nothing particularly game-changing -- just added a white translucent overlay behind the Vomnibar to increase visibility. Also softened the shadow up a bit (mimicks OS X Spotlight bar closely).

![vimium omnibar focus](https://cloud.githubusercontent.com/assets/1437428/11044877/43d51152-86d9-11e5-8a15-77adf4d96689.gif)

I understand that this change is purely aesthetic. Just putting it in here in case people are interested.
