### PR TITLE
Fix indentation so that `openerTabId` takes effect

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -202,7 +202,7 @@ TabOperations =
         index: tab.index + 1
         selected: true
         windowId: tab.windowId
-      openerTabId: tab.id
+        openerTabId: tab.id
       callback = (->) unless typeof callback == "function"
       chrome.tabs.create tabConfig, callback
 


### PR DESCRIPTION
An indentation mistake prevents every new tab opened via `TabOperations.openUrlInNewTab` from remembering its opener tab. This patch fixes that.