### PR TITLE
For Ctrl-[, also require NOT Alt

### DIFF
--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -53,7 +53,7 @@ KeyboardUtils =
 
   isEscape: (event) ->
     # c-[ is mapped to ESC in Vim by default.
-    (event.keyCode == @keyCodes.ESC) || (event.ctrlKey && @getKeyChar(event) == '[')
+    (event.keyCode == @keyCodes.ESC) || (event.ctrlKey && @getKeyChar(event) == '[' and not event.metaKey)
 
   # TODO. This is probably a poor way of detecting printable characters.  However, it shouldn't incorrectly
   # identify any of chrome's own keyboard shortcuts as printable.


### PR DESCRIPTION
See #1906.

It is not obvious that this is in fact correct.  In particular, it's not clear how `Ctrl-[` should work on Mac keyboards.

Anyone with a Mac know what the right thing to do is?