### PR TITLE
Fix endless scrolling problem (#1911)

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -309,6 +309,9 @@ class LinkHintsMode
             if event.keyCode == keyCode
               handlerStack.remove()
               @setOpenLinkMode previousMode if @isActive
+          blur: (event) =>
+            handlerStack.remove()
+            @setOpenLinkMode previousMode if @isActive
 
     else if event.keyCode in [ keyCodes.backspace, keyCodes.deleteKey ]
       if @markerMatcher.popKeyChar()


### PR DESCRIPTION
Link hints mode would, if the user held shift and then left the tab,
wait endlessly for a shift keyup, preventing other keyups from taking
effect.