### PR TITLE
Enable edit mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Release Notes
 -------------
 Next version (not yet released)
 
+- Edit mode for text inputs (including GMail): `gv` (beta feature).
 - Bug fixes:
     - Fix endless scrolling (#1911).
 

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -98,7 +98,7 @@ Commands =
       "enterInsertMode",
       "enterVisualMode",
       "enterVisualLineMode",
-      # "enterEditMode",
+      "enterEditMode",
       "focusInput",
       "LinkHints.activateMode",
       "LinkHints.activateModeToOpenInNewTab",
@@ -187,7 +187,7 @@ defaultKeyMappings =
   "i": "enterInsertMode"
   "v": "enterVisualMode"
   "V": "enterVisualLineMode"
-  # "gv": "enterEditMode"
+  "gv": "enterEditMode"
 
   "H": "goBack"
   "L": "goForward"
@@ -279,7 +279,7 @@ commandDescriptions =
   enterInsertMode: ["Enter insert mode", { noRepeat: true }]
   enterVisualMode: ["Enter visual mode", { noRepeat: true }]
   enterVisualLineMode: ["Enter visual line mode", { noRepeat: true }]
-  # enterEditMode: ["Enter vim-like edit mode (not yet implemented)", { noRepeat: true }]
+  enterEditMode: ["Enter vim-like edit mode (beta feature)", { noRepeat: true }]
 
   focusInput: ["Focus the first text box on the page. Cycle between them using tab",
     { passCountToFunction: true }]

--- a/content_scripts/mode_visual_edit.coffee
+++ b/content_scripts/mode_visual_edit.coffee
@@ -554,6 +554,10 @@ class VisualMode extends Movement
       if document.activeElement and DomUtils.isEditable document.activeElement
         document.activeElement.blur() unless event?.type == "click"
 
+    if @options.parentMode
+      # E.g. when exiting visual mode under edit mode, we no longer want the selection.
+      @collapseSelectionToFocus()
+
     super event, target
     if @yankedText?
       unless @options.noCopyToClipboard


### PR DESCRIPTION
This re-enables edit-mode (`gv`).  The code for this has been present in `master` for quite some time, but has been disabled.

I propose we polish this a bit, and the consider it as signature feature for the next release.