### PR TITLE
Disable position-at-end in text areas.

### DIFF
--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -223,15 +223,16 @@ DomUtils =
       handlerStack.bubbleEvent "click", target: element
     else
       element.focus()
-      # If the cursor is at the start of the element's contents, send it to the end. Motivation:
-      # * the end is a more useful place to focus than the start,
-      # * this way preserves the last used position (except when it's at the beginning), so the user can
-      #   'resume where they left off'.
-      # NOTE(mrmr1993): Some elements throw an error when we try to access their selection properties, so
-      # wrap this with a try.
-      try
-        if element.selectionStart == 0 and element.selectionEnd == 0
-          element.setSelectionRange element.value.length, element.value.length
+      if element.tagName.toLowerCase() != "textarea"
+        # If the cursor is at the start of the (non-textarea) element's contents, send it to the end. Motivation:
+        # * the end is a more useful place to focus than the start,
+        # * this way preserves the last used position (except when it's at the beginning), so the user can
+        #   'resume where they left off'.
+        # NOTE(mrmr1993): Some elements throw an error when we try to access their selection properties, so
+        # wrap this with a try.
+        try
+          if element.selectionStart == 0 and element.selectionEnd == 0
+            element.setSelectionRange element.value.length, element.value.length
 
 
 


### PR DESCRIPTION
When we `simulateSelect` an input and the selection is at the start, we move it to the end.  This works well for single-line inputs.  However, the UX is *bad* for multiline inputs (such as text areas), and doubly so if the end of the input happens to be out of the viewport.

This commit simply disables the repositioning of the selection within text areas.