### PR TITLE
Copy link text support

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -91,6 +91,7 @@ Commands =
       "toggleViewSource",
       "copyCurrentUrl",
       "LinkHints.activateModeToCopyLinkUrl",
+      "LinkHints.activateModeToCopyLinkText",
       "openCopiedUrlInCurrentTab",
       "openCopiedUrlInNewTab",
       "goUp",
@@ -209,6 +210,7 @@ defaultKeyMappings =
 
   "yy": "copyCurrentUrl"
   "yf": "LinkHints.activateModeToCopyLinkUrl"
+  "yl": "LinkHints.activateModeToCopyLinkText"
 
   "p": "openCopiedUrlInCurrentTab"
   "P": "openCopiedUrlInNewTab"
@@ -273,6 +275,7 @@ commandDescriptions =
 
   copyCurrentUrl: ["Copy the current URL to the clipboard", { noRepeat: true }]
   "LinkHints.activateModeToCopyLinkUrl": ["Copy a link URL to the clipboard", { noRepeat: true }]
+  "LinkHints.activateModeToCopyLinkText": ["Copy a link text to the clipboard", { noRepeat: true }]
   openCopiedUrlInCurrentTab: ["Open the clipboard's URL in the current tab", { background: true }]
   openCopiedUrlInNewTab: ["Open the clipboard's URL in a new tab", { background: true, repeatLimit: 20 }]
 


### PR DESCRIPTION
Since I often wished to copy the link text I implemented it maybe it is of interest for other users too. I'm not too familiar with coffee script so if there are any flaws please let me know. I mainly adopted the `CopyLinkUrl` procedure. Besides existence of the text it additionally checks if the trimmed text is nonempty.

At the moment the command is bind to `yl`