### PR TITLE
Link hints context-menu mode

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -106,6 +106,7 @@ Commands =
       "LinkHints.activateModeWithQueue",
       "LinkHints.activateModeToDownloadLink",
       "LinkHints.activateModeToOpenIncognito",
+      "LinkHints.activateModeForMenu",
       "goPrevious",
       "goNext",
       "nextFrame",
@@ -199,6 +200,7 @@ defaultKeyMappings =
   "f":     "LinkHints.activateMode"
   "F":     "LinkHints.activateModeToOpenInNewTab"
   "<a-f>": "LinkHints.activateModeWithQueue"
+  "gm": "LinkHints.activateModeForMenu"
 
   "/": "enterFindMode"
   "n": "performFind"
@@ -290,6 +292,7 @@ commandDescriptions =
   "LinkHints.activateModeWithQueue": ["Open multiple links in a new tab", { noRepeat: true }]
   "LinkHints.activateModeToOpenIncognito": ["Open a link in incognito window", { noRepeat: true }]
   "LinkHints.activateModeToDownloadLink": ["Download link url", { noRepeat: true }]
+  "LinkHints.activateModeForMenu": ["Open a link's context menu", { noRepeat: true }]
 
   enterFindMode: ["Enter find mode", { noRepeat: true }]
   performFind: ["Cycle forward to the next find match"]

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -187,7 +187,7 @@ getCompletionKeysRequest = (request, keysToCheck = "") ->
   completionKeys: generateCompletionKeys(keysToCheck)
   validFirstKeys: validFirstKeys
 
-openUrlInNewWindow = (request, callback = (->)) ->
+openUrlInNewWindow = (request, sender, callback = (->)) ->
   chrome.tabs.query { active: true, currentWindow: true }, (tabs) ->
     chrome.windows.create { url: request.url, incognito: tabs[0].incognito }, callback
 

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -187,6 +187,10 @@ getCompletionKeysRequest = (request, keysToCheck = "") ->
   completionKeys: generateCompletionKeys(keysToCheck)
   validFirstKeys: validFirstKeys
 
+openUrlInNewWindow = (request, callback = (->)) ->
+  chrome.tabs.query { active: true, currentWindow: true }, (tabs) ->
+    chrome.windows.create { url: request.url, incognito: tabs[0].incognito }, callback
+
 TabOperations =
   # Opens the url in the current tab.
   openUrlInCurrentTab: (request, callback = (->)) ->
@@ -653,6 +657,7 @@ sendRequestHandlers =
   openUrlInNewTab: TabOperations.openUrlInNewTab
   openUrlInIncognito: TabOperations.openUrlInIncognito
   openUrlInCurrentTab: TabOperations.openUrlInCurrentTab
+  openUrlInNewWindow: openUrlInNewWindow
   openOptionsPageInNewTab: openOptionsPageInNewTab
   registerFrame: registerFrame
   unregisterFrame: unregisterFrame

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -736,14 +736,6 @@ class ContextMenuMode extends Mode
       hoverMode.onExit -> DomUtils.simulateUnhover link
       DomUtils.simulateHover link
 
-    menuEntries = [
-      openCurrentTab, openNewTab, openBackground, openNewWindow, openIncognito
-      "hr"
-      yankURL, yankLinkText
-      "hr"
-      hover, downloadLink
-    ]
-
     clientRect = DomUtils.getVisibleClientRect link
 
     # We flash and hold the link while the menu is active.
@@ -753,20 +745,26 @@ class ContextMenuMode extends Mode
     menuElement = DomUtils.createElement "div"
     menuElement.className = "vimiumReset vimiumHintContextMenu"
 
-    htmls =
-      for entry in menuEntries
-        if entry == "hr"
-          "<hr class=\"vimiumHintContextMenuHR\"/>"
-        else if entry.requireLink and not link.href?
-          # If there's no href, then don't include menu entries which require one.
-          ""
-        else if entry.requireLinkText and not link.text?.trim().length
-          # If there's no link text, then don't include menu entries which require it.
-          ""
-        else
-          "<li><span class=\"vimiumHintContextMenuText\">#{entry.text}</span>
-           <span class=\"vimiumHintContextMenuKey\"n>#{entry.key}</span></li>"
-    menuElement.innerHTML = "<ul>#{htmls.join ""}</ul>"
+    openMenuEntries = [openCurrentTab, openNewTab, openBackground, openNewWindow, openIncognito]
+    yankMenuEntries = [yankURL, yankLinkText]
+    otherMenuEntries = [hover, downloadLink]
+
+    menuEntries =
+      for group in [openMenuEntries, yankMenuEntries, otherMenuEntries]
+        for entry in group
+          if entry.requireLink and not link.href?
+            # If there's no href, then don't include menu entries which require one.
+            ""
+          else if entry.requireLinkText and not link.text?.trim().length
+            # If there's no link text, then don't include menu entries which require it.
+            ""
+          else
+            "<li><span class=\"vimiumHintContextMenuText\">#{entry.text}</span>
+             <span class=\"vimiumHintContextMenuKey\"n>#{entry.key}</span></li>"
+
+    menuGroupHTMLs = (group.join "" for group in menuEntries)
+    menuHTML = menuGroupHTMLs.join "<hr class=\"vimiumHintContextMenuHR\"/>"
+    menuElement.innerHTML = "<ul>#{menuHTML}</ul>"
 
     # FIXME(smblott) It would be better to wait until the menu has been rendered and only *then* (once we know
     # the actual width and height) calculate the position.

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -759,11 +759,13 @@ class ContextMenuMode extends Mode
             # If there's no link text, then don't include menu entries which require it.
             ""
           else
-            "<li><span class=\"vimiumHintContextMenuText\">#{entry.text}</span>
-             <span class=\"vimiumHintContextMenuKey\"n>#{entry.key}</span></li>"
+            "<li><span class=\"vimiumHintContextMenuItem\">
+              <span class=\"vimiumHintContextMenuKey\"n>#{entry.key}</span>
+              <span class=\"vimiumHintContextMenuText\">#{entry.text}</span>
+             </span></li>"
 
     menuGroupHTMLs = (group.join "" for group in menuEntries)
-    menuHTML = menuGroupHTMLs.join "<hr class=\"vimiumHintContextMenuHR\"/>"
+    menuHTML = menuGroupHTMLs.join "<li><hr class=\"vimiumHintContextMenuHR\"/></li>"
     menuElement.innerHTML = "<ul>#{menuHTML}</ul>"
 
     # FIXME(smblott) It would be better to wait until the menu has been rendered and only *then* (once we know

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -375,7 +375,6 @@ class LinkHintsMode
       # TODO figure out which other input elements should not receive focus
       if (clickEl.nodeName.toLowerCase() == "input" and clickEl.type not in ["button", "submit"])
         clickEl.focus()
-
       DomUtils.flashRect(matchedLink.rect) unless @mode is CONTEXT_MENU
       @linkActivator(clickEl)
       if @mode is OPEN_WITH_QUEUE
@@ -686,9 +685,8 @@ class TypingProtector extends Mode
 
 class ContextMenuMode extends Mode
   # TODO:
-  #   - ensure menu is wholy within viewport
-  #   - implement arrow and <Enter> to select menu item (optional)
   #   - internationalization (key mapping)
+  #   - with queue?
   constructor: (link) ->
     super
       name: "hint/context-menu"

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -768,8 +768,10 @@ class ContextMenuMode extends Mode
            <span class=\"vimiumHintContextMenuKey\"n>#{entry.key}</span></li>"
     menuElement.innerHTML = "<ul>#{htmls.join ""}</ul>"
 
-    left = Math.min clientRect.left + window.scrollX + 50, window.innerWidth - 250
-    top = Math.min clientRect.top  + window.scrollY  + 0, window.innerHeight - 130
+    # FIXME(smblott) It would be better to wait until the menu has been rendered and only *then* (once we know
+    # the actual width and height) calculate the position.
+    left = Math.min clientRect.left + window.scrollX + 50, window.scrollX + window.innerWidth - 230
+    top = Math.min clientRect.top + window.scrollY, window.scrollY + window.innerHeight - 300
 
     menuElement.style.left = left + "px"
     menuElement.style.top = top + "px"

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -94,6 +94,54 @@ div > .vimiumActiveHintMarker span {
   color: #A07555 !important;
 }
 
+div.vimiumHintContextMenu {
+  position: absolute;
+  display: block;
+  top: -1px;
+  left: -1px;
+  white-space: nowrap;
+  overflow: hidden;
+  padding: 1px 3px 0px 3px;
+  background: #dcdcdc;
+  border: solid 0px #dcdcdc;
+  border-radius: 0px;
+  box-shadow: 0px 3px 7px 0px rgba(0, 0, 0, 0.3);
+  width: 200px;
+  padding-top: 10px;
+}
+
+div.vimiumHintContextMenu > ul {
+  list-style-type: none;
+  list-style: none;
+  padding-left: 10px;
+  padding-right: 10px;
+  padding-top: 0px;
+  padding-bottom: 7px;
+}
+
+div.vimiumHintContextMenu > ul > li {
+  color: #000000;
+  font-family: Helvetica, Arial, sans-serif;
+  font-weight: normal;
+  font-size: 14px;
+  padding-top: 7px;
+  padding-bottom: 0px;
+}
+
+.vimiumHintContextMenuKey {
+  float: right;
+  color: #888888;
+  width: 10px;
+  text-align: center;
+}
+
+.vimiumHintContextMenuHR {
+  width: 100%;
+  border-top: 1px solid #777777;
+  margin-top: 12px;
+  padding-bottom: 0px;
+}
+
 /* Input hints CSS */
 
 div.internalVimiumInputHint {

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -94,6 +94,10 @@ div > .vimiumActiveHintMarker span {
   color: #A07555 !important;
 }
 
+#vimiumContextMenu {
+  z-index: 2147483647;
+}
+
 div.vimiumHintContextMenu {
   position: absolute;
   display: block;

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -111,16 +111,14 @@ div.vimiumHintContextMenu {
   border-radius: 0px;
   box-shadow: 0px 3px 7px 0px rgba(0, 0, 0, 0.3);
   width: 200px;
-  padding-top: 10px;
 }
 
 div.vimiumHintContextMenu > ul {
   list-style-type: none;
   list-style: none;
-  padding-left: 10px;
-  padding-right: 10px;
-  padding-top: 0px;
-  padding-bottom: 7px;
+  padding-left: 5px;
+  padding-right: 5px;
+  margin-bottom: 0px;
 }
 
 div.vimiumHintContextMenu > ul > li {
@@ -128,8 +126,11 @@ div.vimiumHintContextMenu > ul > li {
   font-family: Helvetica, Arial, sans-serif;
   font-weight: normal;
   font-size: 14px;
-  padding-top: 7px;
-  padding-bottom: 0px;
+}
+
+div.vimiumHintContextMenu > ul, div.vimiumHintContextMenu > ul > li {
+  padding-top: 3px;
+  padding-bottom: 3px;
 }
 
 .vimiumHintContextMenuKey {
@@ -141,8 +142,9 @@ div.vimiumHintContextMenu > ul > li {
 
 .vimiumHintContextMenuHR {
   width: 100%;
-  border-top: 1px solid #777777;
-  margin-top: 12px;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  padding-top: 0px;
   padding-bottom: 0px;
 }
 

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -116,9 +116,9 @@ div.vimiumHintContextMenu {
 div.vimiumHintContextMenu > ul {
   list-style-type: none;
   list-style: none;
+  margin-bottom: 0px;
   padding-left: 5px;
   padding-right: 5px;
-  margin-bottom: 0px;
 }
 
 div.vimiumHintContextMenu > ul > li {
@@ -134,10 +134,11 @@ div.vimiumHintContextMenu > ul, div.vimiumHintContextMenu > ul > li {
 }
 
 .vimiumHintContextMenuKey {
-  float: right;
-  color: #888888;
-  width: 10px;
-  text-align: center;
+  color:#2f508e; /* Matches blue of help page. */
+  float: left;
+  width: 20px;
+  font-weight: bold;
+  font-size: 15px;
 }
 
 .vimiumHintContextMenuHR {

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -234,21 +234,27 @@ DomUtils =
           element.setSelectionRange element.value.length, element.value.length
 
 
+  # From @mrmr1993: https://github.com/philc/vimium/pull/1032.
+  simulateHover: (element, modifiers) ->
+    @simulateMouseEvent("mouseover", element, modifiers)
+
+  simulateUnhover: (element, modifiers) ->
+    @simulateMouseEvent("mouseout", element, modifiers)
 
   simulateClick: (element, modifiers) ->
-    modifiers ||= {}
-
     eventSequence = ["mouseover", "mousedown", "mouseup", "click"]
-    for event in eventSequence
-      mouseEvent = document.createEvent("MouseEvents")
-      mouseEvent.initMouseEvent(event, true, true, window, 1, 0, 0, 0, 0, modifiers.ctrlKey, modifiers.altKey,
-      modifiers.shiftKey, modifiers.metaKey, 0, null)
-      # Debugging note: Firefox will not execute the element's default action if we dispatch this click event,
-      # but Webkit will. Dispatching a click on an input box does not seem to focus it; we do that separately
-      element.dispatchEvent(mouseEvent)
+    @simulateMouseEvent event, element, modifiers for event in eventSequence
 
-  # momentarily flash a rectangular border to give user some visual feedback
-  flashRect: (rect) ->
+  simulateMouseEvent: (event, element, modifiers) ->
+    modifiers ||= {}
+    mouseEvent = document.createEvent("MouseEvents")
+    mouseEvent.initMouseEvent(event, true, true, window, 1, 0, 0, 0, 0, modifiers.ctrlKey, modifiers.altKey,
+    modifiers.shiftKey, modifiers.metaKey, 0, null)
+    # Debugging note: Firefox will not execute the element's default action if we dispatch this click event,
+    # but Webkit will. Dispatching a click on an input box does not seem to focus it; we do that separately
+    element.dispatchEvent(mouseEvent)
+
+  addFlashRect: (rect) ->
     flashEl = @createElement "div"
     flashEl.id = "vimiumFlash"
     flashEl.className = "vimiumReset"
@@ -256,7 +262,12 @@ DomUtils =
     flashEl.style.top = rect.top  + window.scrollY  + "px"
     flashEl.style.width = rect.width + "px"
     flashEl.style.height = rect.height + "px"
-    document.documentElement.appendChild(flashEl)
+    document.documentElement.appendChild flashEl
+    flashEl
+
+  # momentarily flash a rectangular border to give user some visual feedback
+  flashRect: (rect) ->
+    flashEl = @addFlashRect rect
     setTimeout((-> DomUtils.removeElement flashEl), 400)
 
   suppressPropagation: (event) ->


### PR DESCRIPTION
This implements @philc's idea from #1312, a link-hints mode which activates a menu.

We get a lot of a requests for new link-hints modes.  Each new mode requires a new command, and we arguably already have too many commands.  The idea here is that - for less common modes - we can add a new menu operation instead.

Details:
- Default binding: `gm`.
- This PR also adds a hover option (borrowed from @mrmr1993's #1032).
- And it adds a "yank-link-text" option (borrowed from @svgsponer's #1947).

Currently, it looks like this...

![snapshot](https://cloud.githubusercontent.com/assets/2641335/12644774/4c4b8a64-c5bd-11e5-8f6a-2560de1d3cb8.png)

To do:
- internationalisation?
- with queue

Fixes #1312.
Replaces #1032.
Replaces #1947.