### PR TITLE
For filtered hints, wait for <Enter> before activating link

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -367,7 +367,7 @@ class LinkHintsMode
     if linksMatched.length == 0
       @deactivateMode()
     else if linksMatched.length == 1
-      @activateLink linksMatched[0], keyResult.delay ? 0
+      @activateLink linksMatched[0], keyResult.delay ? 0, keyResult.waitForEnter and Settings.get "waitForEnterForFilteredHints"
     else
       @hideMarker marker for marker in hintMarkers
       @showMarker matched, @markerMatcher.hintKeystrokeQueue.length for matched in linksMatched
@@ -375,7 +375,7 @@ class LinkHintsMode
   #
   # When only one link hint remains, this function activates it in the appropriate way.
   #
-  activateLink: (matchedLink, delay = 0) ->
+  activateLink: (matchedLink, delay = 0, waitForEnter = false) ->
     clickEl = matchedLink.clickableItem
     if (DomUtils.isSelectable(clickEl))
       DomUtils.simulateSelect(clickEl)
@@ -384,12 +384,18 @@ class LinkHintsMode
       # TODO figure out which other input elements should not receive focus
       if (clickEl.nodeName.toLowerCase() == "input" and clickEl.type not in ["button", "submit"])
         clickEl.focus()
-      DomUtils.flashRect(matchedLink.rect)
-      @linkActivator(clickEl)
-      if @mode is OPEN_WITH_QUEUE
-        @deactivateMode delay, -> LinkHints.activateModeWithQueue()
-      else
-        @deactivateMode delay
+
+      linkActivator = =>
+        @linkActivator(clickEl)
+        LinkHints.activateModeWithQueue() if @mode is OPEN_WITH_QUEUE
+
+      delay = 0 if waitForEnter
+      @deactivateMode delay, =>
+        if waitForEnter
+          new WaitForEnter matchedLink.rect, linkActivator
+        else
+          DomUtils.flashRect matchedLink.rect
+          linkActivator()
 
   #
   # Shows the marker, highlighting matchingCharCount characters.
@@ -571,7 +577,7 @@ class FilterHints
     @activeHintMarker = linksMatched[tabCount]
     @activeHintMarker?.classList.add "vimiumActiveHintMarker"
 
-    { linksMatched: linksMatched, delay: delay }
+    { linksMatched: linksMatched, delay: delay, waitForEnter: 0 < delay }
 
   pushKeyChar: (keyChar, keydownKeyChar) ->
     # For filtered hints, we *always* use the keyChar value from keypress, because there is no obvious and
@@ -658,6 +664,26 @@ class TypingProtector extends Mode
       keypress: handler
 
     @onExit callback
+
+class WaitForEnter extends Mode
+  constructor: (rect, callback) ->
+    super
+      name: "hint/wait-for-enter"
+      suppressAllKeyboardEvents: true
+      exitOnEscape: true
+      indicator: "Hit <Enter> to proceed..."
+
+    @push
+      keydown: (event) =>
+        if event.keyCode == keyCodes.enter
+          @exit()
+          callback()
+          DomUtils.suppressEvent event
+        else
+          true
+
+    flashEl = DomUtils.addFlashRect rect
+    @onExit -> DomUtils.removeElement flashEl
 
 root = exports ? window
 root.LinkHints = LinkHints

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -375,8 +375,8 @@ class LinkHintsMode
   #
   # When only one link hint remains, this function activates it in the appropriate way.
   #
-  activateLink: (matchedLink, delay = 0, waitForEnter = false) ->
-    clickEl = matchedLink.clickableItem
+  activateLink: (@matchedLink, delay = 0, waitForEnter = false) ->
+    clickEl = @matchedLink.clickableItem
     if (DomUtils.isSelectable(clickEl))
       DomUtils.simulateSelect(clickEl)
       @deactivateMode delay
@@ -392,9 +392,9 @@ class LinkHintsMode
       delay = 0 if waitForEnter
       @deactivateMode delay, =>
         if waitForEnter
-          new WaitForEnter matchedLink.rect, linkActivator
+          new WaitForEnter @matchedLink.rect, linkActivator
         else
-          DomUtils.flashRect matchedLink.rect
+          DomUtils.flashRect @matchedLink.rect
           linkActivator()
 
   #
@@ -425,7 +425,7 @@ class LinkHintsMode
     if delay
       # Install a mode to block keyboard events if the user is still typing.  The intention is to prevent the
       # user from inadvertently launching Vimium commands when typing the link text.
-      new TypingProtector delay, ->
+      new TypingProtector delay, @matchedLink?.rect, ->
         deactivate()
         callback?()
     else
@@ -650,12 +650,12 @@ spanWrap = (hintString) ->
 
 # Suppress all keyboard events until the user stops typing for sufficiently long.
 class TypingProtector extends Mode
-  constructor: (delay, callback) ->
+  constructor: (delay, rect, callback) ->
     @timer = Utils.setTimeout delay, => @exit()
 
     handler = (event) =>
       clearTimeout @timer
-      @timer = Utils.setTimeout 150, => @exit()
+      @timer = Utils.setTimeout delay, => @exit()
 
     super
       name: "hint/typing-protector"
@@ -663,7 +663,14 @@ class TypingProtector extends Mode
       keydown: handler
       keypress: handler
 
+    if rect
+      # We keep a "flash" overlay active while the user is typing; this provides visual feeback that something
+      # has been selected.
+      flashEl = DomUtils.addFlashRect rect
+      @onExit -> DomUtils.removeElement flashEl
+
     @onExit callback
+
 
 class WaitForEnter extends Mode
   constructor: (rect, callback) ->

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -262,8 +262,7 @@ DomUtils =
       # but Webkit will. Dispatching a click on an input box does not seem to focus it; we do that separately
       element.dispatchEvent(mouseEvent)
 
-  # momentarily flash a rectangular border to give user some visual feedback
-  flashRect: (rect) ->
+  addFlashRect: (rect) ->
     flashEl = @createElement "div"
     flashEl.id = "vimiumFlash"
     flashEl.className = "vimiumReset"
@@ -271,7 +270,12 @@ DomUtils =
     flashEl.style.top = rect.top  + window.scrollY  + "px"
     flashEl.style.width = rect.width + "px"
     flashEl.style.height = rect.height + "px"
-    document.documentElement.appendChild(flashEl)
+    document.documentElement.appendChild flashEl
+    flashEl
+
+  # momentarily flash a rectangular border to give user some visual feedback
+  flashRect: (rect) ->
+    flashEl = @addFlashRect rect
     setTimeout((-> DomUtils.removeElement flashEl), 400)
 
   suppressPropagation: (event) ->

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -170,7 +170,7 @@ Settings =
     newTabUrl: "chrome://newtab"
     grabBackFocus: false
     regexFindMode: false
-    waitForEnterForFilteredHints: false
+    waitForEnterForFilteredHints: false # Note: this defaults to true for new users; see below.
 
     settingsVersion: Utils.getCurrentVersion()
     helpDialog_showAdvancedCommands: false
@@ -181,6 +181,15 @@ Settings.init()
 
 # Perform migration from old settings versions, if this is the background page.
 if Utils.isBackgroundPage()
+
+  if not Settings.get "settingsVersion"
+    # This is a new install.  For some settings, we retain a legacy default behaviour for existing users but
+    # use a non-default behaviour for new users.
+
+    # For waitForEnterForFilteredHints, we (smblott) think that "true" gives a better UX; see #1950.  However,
+    # forcing the change on existing users would be unnecessarily disruptive.  So, only new users default to
+    # "true".
+    Settings.set "waitForEnterForFilteredHints", true
 
   # We use settingsVersion to coordinate any necessary schema changes.
   Settings.set("settingsVersion", Utils.getCurrentVersion())

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -170,6 +170,7 @@ Settings =
     newTabUrl: "chrome://newtab"
     grabBackFocus: false
     regexFindMode: false
+    waitForEnterForFilteredHints: true # Once properly implmented, this will default to false.
 
     settingsVersion: Utils.getCurrentVersion()
     helpDialog_showAdvancedCommands: false

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -170,7 +170,7 @@ Settings =
     newTabUrl: "chrome://newtab"
     grabBackFocus: false
     regexFindMode: false
-    waitForEnterForFilteredHints: true # Once properly implmented, this will default to false.
+    waitForEnterForFilteredHints: false
 
     settingsVersion: Utils.getCurrentVersion()
     helpDialog_showAdvancedCommands: false

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -184,6 +184,7 @@ class ExclusionRulesOnPopupOption extends ExclusionRulesOption
 Options =
   exclusionRules: ExclusionRulesOption
   filterLinkHints: CheckBoxOption
+  waitForEnterForFilteredHints: CheckBoxOption
   hideHud: CheckBoxOption
   keyMappings: TextOption
   linkHintCharacters: NonEmptyTextOption
@@ -206,14 +207,16 @@ initOptionsPage = ->
 
   # Display either "linkHintNumbers" or "linkHintCharacters", depending upon "filterLinkHints".
   maintainLinkHintsView = ->
-    hide = (el) -> el.parentNode.parentNode.style.display = "none"
-    show = (el) -> el.parentNode.parentNode.style.display = "table-row"
+    hide = (el) -> el.style.display = "none"
+    show = (el) -> el.style.display = "table-row"
     if $("filterLinkHints").checked
-      hide $("linkHintCharacters")
-      show $("linkHintNumbers")
+      hide $("linkHintCharactersContainer")
+      show $("linkHintNumbersContainer")
+      show $("waitForEnterForFilteredHintsContainer")
     else
-      show $("linkHintCharacters")
-      hide $("linkHintNumbers")
+      show $("linkHintCharactersContainer")
+      hide $("linkHintNumbersContainer")
+      hide $("waitForEnterForFilteredHintsContainer")
 
   maintainAdvancedOptions = ->
     if bgSettings.get "optionsPage_showAdvancedOptions"

--- a/pages/options.html
+++ b/pages/options.html
@@ -82,7 +82,7 @@ b: http://b.com/?q=%s description
               <input id="scrollStepSize" type="number" />px
             </td>
           </tr>
-          <tr>
+          <tr id="linkHintCharactersContainer">
             <td class="caption">Characters used<br/> for link hints</td>
             <td verticalAlign="top">
                 <div class="help">
@@ -94,7 +94,7 @@ b: http://b.com/?q=%s description
                 <div class="nonEmptyTextOption">
             </td>
           </tr>
-          <tr>
+          <tr id="linkHintNumbersContainer">
             <td class="caption">Numbers used<br/> for link hints</td>
             <td verticalAlign="top">
                 <div class="help">
@@ -126,6 +126,21 @@ b: http://b.com/?q=%s description
               <label>
                 <input id="filterLinkHints" type="checkbox"/>
                 Use the link's name and numbers for link-hint filtering
+              </label>
+            </td>
+          </tr>
+          <tr id="waitForEnterForFilteredHintsContainer">
+            <td class="caption"></td>
+            <td verticalAlign="top" class="booleanOption">
+              <div class="help">
+                <div class="example">
+                  You activate the link with <tt>Enter</tt>, <em>always</em>; so you never accidentally type Vimium
+                  commands.
+                </div>
+              </div>
+              <label>
+                <input id="waitForEnterForFilteredHints" type="checkbox"/>
+                Require <tt>Enter</tt> for filtered hints
               </label>
             </td>
           </tr>

--- a/pages/options.html
+++ b/pages/options.html
@@ -140,7 +140,7 @@ b: http://b.com/?q=%s description
               </div>
               <label>
                 <input id="waitForEnterForFilteredHints" type="checkbox"/>
-                Require <tt>Enter</tt> for filtered hints
+                Require <tt>Enter</tt> when filtering hints
               </label>
             </td>
           </tr>


### PR DESCRIPTION
This affects filtered hints only.

There's a usability issue with filtered hints which has bothered me for some time.

The link is activated:

- when the user types the hint text
- when the user hits `<Enter>`, or `<Tab><Enter>`
- or when only one link remains

The latter case is problematic.  We add a delay in case the user is still typing.  But that delay could be too long, or too short.  Who knows.  In practice, I find myself typing a couple of characters then hitting `<Enter>` or `<Tab><Enter>` just to *avoid* having the link automatically activated.

The idea here is to get rid of the race condition in the latter case.  If a hint is triggered because the user typed the link text, then:

- highlight the link (using the same blue "flash" as we use currently),
- but wait until the user types `<Enter>` before actually activating the link (consuming any other characters typed).

With this approach, typing a few characters from the link then hitting `<Enter>` nearly always gets it right.

When the link is highlighted, it looks like this...

![snapshot](https://cloud.githubusercontent.com/assets/2641335/12678052/b47ac9ec-c694-11e5-8724-2904b90ca02b.png)

Because this would be a change to the established behaviour, it would probably (and unfortunately) require a new option.