### PR TITLE
Add a logging page...

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -13,7 +13,7 @@ Commands =
   #    command passed to it. This is used to implement e.g. "closing of 3 tabs".
   addCommand: (command, description, options) ->
     if command of @availableCommands
-      console.log(command, "is already defined! Check commands.coffee for duplicates.")
+      logMessage? "#{command} is already defined! Check commands.coffee for duplicates."
       return
 
     options ||= {}
@@ -26,7 +26,7 @@ Commands =
 
   mapKeyToCommand: ({ key, command, options }) ->
     unless @availableCommands[command]
-      console.log command, "doesn't exist!"
+      logMessage? "#{command} doesn't exist!"
       return
 
     options ?= []
@@ -55,13 +55,13 @@ Commands =
             [ _, key, command, options... ] = tokens
             if command? and @availableCommands[command]
               key = @normalizeKey key
-              console.log "Mapping", key, "to", command
+              logMessage? "Mapping #{key} to #{command}"
               @mapKeyToCommand { key, command, options }
 
           when "unmap"
             if tokens.length == 2
               key = @normalizeKey tokens[1]
-              console.log "Unmapping", key
+              logMessage? "Unmapping #{key}"
               delete @keyToCommandRegistry[key]
 
           when "unmapAll"

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -96,6 +96,11 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) ->
   # Ensure the sendResponse callback is freed.
   return false)
 
+logMessage = (message) ->
+  for viewWindow in chrome.extension.getViews {type: "tab"}
+    if viewWindow.location.pathname == "/pages/logging.html"
+      viewWindow.document.getElementById("log-text").value += "#{(new Date()).toISOString()}: #{message}\n"
+
 #
 # Used by the content scripts to get their full URL. This is needed for URLs like "view-source:http:# .."
 # because window.location doesn't know anything about the Chrome-specific "view-source:".
@@ -513,12 +518,12 @@ splitKeyQueue = (queue) ->
 handleKeyDown = (request, port) ->
   key = request.keyChar
   if (key == "<ESC>")
-    console.log("clearing keyQueue")
+    logMessage "clearing keyQueue"
     keyQueue = ""
   else
-    console.log("checking keyQueue: [", keyQueue + key, "]")
+    logMessage "checking keyQueue: [#{keyQueue + key}]"
     keyQueue = checkKeyQueue(keyQueue + key, port.sender.tab.id, request.frameId)
-    console.log("new KeyQueue: " + keyQueue)
+    logMessage "new KeyQueue: #{keyQueue}"
   # Tell the content script whether there are keys in the queue.
   # FIXME: There is a race condition here.  The behaviour in the content script depends upon whether this message gets
   # back there before or after the next keystroke.

--- a/pages/logging.html
+++ b/pages/logging.html
@@ -1,0 +1,37 @@
+<html>
+  <head>
+    <title>Vimium Options</title>
+    <script src="content_script_loader.js"></script>
+    <style type="text/css">
+      body {
+        font: 14px "DejaVu Sans", "Arial", sans-serif;
+        color: #303942;
+        margin: 0 auto;
+      }
+      div#wrapper {
+        margin: 0px 35px;
+        width: calc(100% - 70px);
+      }
+      header {
+        font-size: 18px;
+        font-weight: normal;
+        border-bottom: 1px solid #eee;
+        padding: 20px 0 15px 0;
+        width: 100%;
+      }
+      #log-text {
+        width: 100%;
+        height: 80%;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="wrapper">
+      <header>Vimium Log</header>
+      <br />
+      <textarea id="log-text" readonly></textarea>
+      <br />
+    </div>
+  </body>
+</html>

--- a/tests/unit_tests/test_chrome_stubs.coffee
+++ b/tests/unit_tests/test_chrome_stubs.coffee
@@ -17,6 +17,7 @@ global.document =
 
 exports.chrome =
   runtime:
+    getURL: ->
     getManifest: () ->
       version: "1.2.3"
     onConnect:


### PR DESCRIPTION
This tweaks @mrmr1993's logging ideas discussed in #1629:

- Do not generate log entries from the logging page itself.
- Use the logger for *all* logging (including from `commands.coffee`, and from `bgLog`).

Edit... also:
- Echo the logging URL to the console on start up.

@mrmr1993's original idea is 91fb337.

Fixes #1629.