### PR TITLE
Fix visual indicator for `focusInput()`.

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -385,9 +385,8 @@ extend window,
       visibleInputs =
         for i in [0...resultSet.snapshotLength] by 1
           element = resultSet.snapshotItem i
-          rect = DomUtils.getVisibleClientRect element, true
-          continue if rect == null
-          { element: element, rect: rect }
+          continue unless DomUtils.getVisibleClientRect element, true
+          { element, rect: DomUtils.getBoundingClientRect element }
 
       if visibleInputs.length == 0
         HUD.showForDuration("There are no inputs to focus.", 1000)

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -386,7 +386,7 @@ extend window,
         for i in [0...resultSet.snapshotLength] by 1
           element = resultSet.snapshotItem i
           continue unless DomUtils.getVisibleClientRect element, true
-          { element, rect: DomUtils.getBoundingClientRect element }
+          { element, rect: Rect.copy element.getBoundingClientRect() }
 
       if visibleInputs.length == 0
         HUD.showForDuration("There are no inputs to focus.", 1000)

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -116,6 +116,18 @@ DomUtils =
     null
 
   #
+  # Returns the smallest rectangle which encloses element.  Assumes that there is at least one rectangle.
+  #
+  getBoundingClientRect: (element) ->
+    [clientRect, rects...] = element.getClientRects()
+    for rect in rects
+      clientRect.top = Math.min clientRect.top, rect.top
+      clientRect.bottom = Math.max clientRect.bottom, rect.bottom
+      clientRect.left = Math.min clientRect.left, rect.left
+      clientRect.right = Math.max clientRect.right, rect.right
+    extend clientRect, width: clientRect.right - clientRect.left, height: clientRect.bottom - clientRect.top
+
+  #
   # Bounds the rect by the current viewport dimensions. If the rect is offscreen or has a height or width < 3
   # then null is returned instead of a rect.
   #

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -116,18 +116,6 @@ DomUtils =
     null
 
   #
-  # Returns the smallest rectangle which encloses element.  Assumes that there is at least one rectangle.
-  #
-  getBoundingClientRect: (element) ->
-    [clientRect, rects...] = element.getClientRects()
-    for rect in rects
-      clientRect.top = Math.min clientRect.top, rect.top
-      clientRect.bottom = Math.max clientRect.bottom, rect.bottom
-      clientRect.left = Math.min clientRect.left, rect.left
-      clientRect.right = Math.max clientRect.right, rect.right
-    extend clientRect, width: clientRect.right - clientRect.left, height: clientRect.bottom - clientRect.top
-
-  #
   # Bounds the rect by the current viewport dimensions. If the rect is offscreen or has a height or width < 3
   # then null is returned instead of a rect.
   #


### PR DESCRIPTION
Currently, if an input is only partially in the view port, then the page may scroll when it is focused and the overlays for `focusInput()` are wonky.  See #1257.

Here, we draw the overlay around the *entire* input, instead of just around the visible part.  Being partially visible therefore is no longer relevant.

@mrmr1993... Does this look correct to you?

Fixes #1257.
Closes #1258.