### PR TITLE
Link hints with count

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -270,7 +270,7 @@ commandDescriptions =
   toggleViewSource: ["View page source", { noRepeat: true }]
 
   copyCurrentUrl: ["Copy the current URL to the clipboard", { noRepeat: true }]
-  "LinkHints.activateModeToCopyLinkUrl": ["Copy a link URL to the clipboard", { noRepeat: true }]
+  "LinkHints.activateModeToCopyLinkUrl": ["Copy a link URL to the clipboard", { passCountToFunction: true }]
   openCopiedUrlInCurrentTab: ["Open the clipboard's URL in the current tab", { background: true }]
   openCopiedUrlInNewTab: ["Open the clipboard's URL in a new tab", { background: true, repeatLimit: 20 }]
 
@@ -281,12 +281,12 @@ commandDescriptions =
   focusInput: ["Focus the first text box on the page. Cycle between them using tab",
     { passCountToFunction: true }]
 
-  "LinkHints.activateMode": ["Open a link in the current tab", { noRepeat: true }]
-  "LinkHints.activateModeToOpenInNewTab": ["Open a link in a new tab", { noRepeat: true }]
-  "LinkHints.activateModeToOpenInNewForegroundTab": ["Open a link in a new tab & switch to it", { noRepeat: true }]
+  "LinkHints.activateMode": ["Open a link in the current tab", { passCountToFunction: true }]
+  "LinkHints.activateModeToOpenInNewTab": ["Open a link in a new tab", { passCountToFunction: true }]
+  "LinkHints.activateModeToOpenInNewForegroundTab": ["Open a link in a new tab & switch to it", { passCountToFunction: true }]
   "LinkHints.activateModeWithQueue": ["Open multiple links in a new tab", { noRepeat: true }]
-  "LinkHints.activateModeToOpenIncognito": ["Open a link in incognito window", { noRepeat: true }]
-  "LinkHints.activateModeToDownloadLink": ["Download link url", { noRepeat: true }]
+  "LinkHints.activateModeToOpenIncognito": ["Open a link in incognito window", { passCountToFunction: true }]
+  "LinkHints.activateModeToDownloadLink": ["Download link url", { passCountToFunction: true }]
 
   enterFindMode: ["Enter find mode", { noRepeat: true }]
   performFind: ["Cycle forward to the next find match"]

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -22,8 +22,8 @@ LinkHints =
   activateMode: (count = 1, mode = OPEN_IN_CURRENT_TAB) ->
     if 0 < count
       new LinkHintsMode mode, (event = null) ->
-        # Escape and Backspace are the two ways in which hints mode can exit following which we do no restart
-        # hints mode.
+        # This is called which LinkHintsMode exits.  Escape and Backspace are the two ways in which hints mode
+        # can exit following which we do not restart hints mode.
         return if event?.type == "keydown" and KeyboardUtils.isEscape event
         return if event?.type == "keydown" and event.keyCode in [ keyCodes.backspace, keyCodes.deleteKey ]
         LinkHints.activateMode count-1, mode

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -19,14 +19,16 @@ OPEN_INCOGNITO = name: "incognito"
 DOWNLOAD_LINK_URL = name: "download"
 
 LinkHints =
-  activateMode: (mode = OPEN_IN_CURRENT_TAB) -> new LinkHintsMode mode
+  activateMode: (count = 1, mode = OPEN_IN_CURRENT_TAB) ->
+    if 0 < count
+      new LinkHintsMode mode, -> LinkHints.activateMode count-1, mode
 
-  activateModeToOpenInNewTab: -> @activateMode OPEN_IN_NEW_BG_TAB
-  activateModeToOpenInNewForegroundTab: -> @activateMode OPEN_IN_NEW_FG_TAB
-  activateModeToCopyLinkUrl: -> @activateMode COPY_LINK_URL
-  activateModeWithQueue: -> @activateMode OPEN_WITH_QUEUE
-  activateModeToOpenIncognito: -> @activateMode OPEN_INCOGNITO
-  activateModeToDownloadLink: -> @activateMode DOWNLOAD_LINK_URL
+  activateModeToOpenInNewTab: (count) -> @activateMode count, OPEN_IN_NEW_BG_TAB
+  activateModeToOpenInNewForegroundTab: (count) -> @activateMode count, OPEN_IN_NEW_FG_TAB
+  activateModeToCopyLinkUrl: (count) -> @activateMode count, COPY_LINK_URL
+  activateModeWithQueue: -> @activateMode 1, OPEN_WITH_QUEUE
+  activateModeToOpenIncognito: (count) -> @activateMode count, OPEN_INCOGNITO
+  activateModeToDownloadLink: (count) -> @activateMode count, DOWNLOAD_LINK_URL
 
 class LinkHintsMode
   hintMarkerContainingDiv: null
@@ -43,7 +45,7 @@ class LinkHintsMode
   # A count of the number of Tab presses since the last non-Tab keyboard event.
   tabCount: 0
 
-  constructor: (mode = OPEN_IN_CURRENT_TAB) ->
+  constructor: (mode = OPEN_IN_CURRENT_TAB, onExit = (->)) ->
     # we need documentElement to be ready in order to append links
     return unless document.documentElement
     @isActive = true
@@ -80,6 +82,7 @@ class LinkHintsMode
 
     @hintMode.onExit =>
       @deactivateMode() if @isActive
+    @hintMode.onExit onExit
 
     @setOpenLinkMode mode
 

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -21,7 +21,9 @@ DOWNLOAD_LINK_URL = name: "download"
 LinkHints =
   activateMode: (count = 1, mode = OPEN_IN_CURRENT_TAB) ->
     if 0 < count
-      new LinkHintsMode mode, -> LinkHints.activateMode count-1, mode
+      new LinkHintsMode mode, (event = null) ->
+        unless event?.type == "keydown" and KeyboardUtils.isEscape event
+          LinkHints.activateMode count-1, mode
 
   activateModeToOpenInNewTab: (count) -> @activateMode count, OPEN_IN_NEW_BG_TAB
   activateModeToOpenInNewForegroundTab: (count) -> @activateMode count, OPEN_IN_NEW_FG_TAB

--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -187,12 +187,12 @@ class Mode
   onExit: (handler) ->
     @exitHandlers.push handler
 
-  exit: ->
+  exit: (args...) ->
     if @modeIsActive
       @log "deactivate:", @id
       unless @modeIsExiting
         @modeIsExiting = true
-        handler() for handler in @exitHandlers
+        handler args... for handler in @exitHandlers
         handlerStack.remove handlerId for handlerId in @handlers
       Mode.modes = Mode.modes.filter (mode) => mode != @
       @modeIsActive = false


### PR DESCRIPTION
Use a count with link hints.
    
Pass a count to link-hint commands, and the link-hint mode is started that many times (except "with queue").

This resolves the same issue as #1291.  However, all of the `count` handling is outside of the `LinkHints` class, which simplifies things somewhat.

Fixes #1289.
Closes #1291.