### PR TITLE
Refactor help dialog code

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -144,13 +144,18 @@ root.helpDialogHtml = (showUnboundCommands, showCommandNames, customTitle) ->
     command = Commands.keyToCommandRegistry[key].command
     commandsToKey[command] = (commandsToKey[command] || []).concat(key)
 
-  dialogHtml = fetchFileContents("pages/help_dialog.html")
+  replacementStrings =
+    version: currentVersion
+    title: customTitle || "Help"
+
   for group of Commands.commandGroups
-    dialogHtml = dialogHtml.replace("{{#{group}}}",
+    replacementStrings[group] =
         helpDialogHtmlForCommandGroup(group, commandsToKey, Commands.availableCommands,
-                                      showUnboundCommands, showCommandNames))
-  dialogHtml = dialogHtml.replace("{{version}}", currentVersion)
-  dialogHtml = dialogHtml.replace("{{title}}", customTitle || "Help")
+                                      showUnboundCommands, showCommandNames)
+
+  dialogHtml = fetchFileContents("pages/help_dialog.html")
+  for placeholder, replacementString of replacementStrings
+    dialogHtml = dialogHtml.replace "{{#{placeholder}}}", replacementString
   dialogHtml
 
 #

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -155,7 +155,7 @@ root.helpDialogHtml = (showUnboundCommands, showCommandNames, customTitle) ->
 
   dialogHtml = fetchFileContents("pages/help_dialog.html")
   for placeholder, replacementString of replacementStrings
-    dialogHtml = dialogHtml.replace "{{#{placeholder}}}", replacementString
+    dialogHtml = dialogHtml.replace "<span id=\"help-dialog-#{placeholder}\"></span>", replacementString
   dialogHtml
 
 #

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -153,10 +153,7 @@ root.helpDialogHtml = (showUnboundCommands, showCommandNames, customTitle) ->
         helpDialogHtmlForCommandGroup(group, commandsToKey, Commands.availableCommands,
                                       showUnboundCommands, showCommandNames)
 
-  dialogHtml = fetchFileContents("pages/help_dialog.html")
-  for placeholder, replacementString of replacementStrings
-    dialogHtml = dialogHtml.replace "<span id=\"help-dialog-#{placeholder}\"></span>", replacementString
-  dialogHtml
+  replacementStrings
 
 #
 # Generates HTML for a given set of commands. commandGroups are defined in commands.js

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -203,7 +203,8 @@ div#vimiumHelpDialog td.vimiumHelpSectionTitle {
 }
 div#vimiumHelpDialog div.commandName { font-family:"courier new"; }
 /* Advanced commands are hidden by default until you show them. */
-div#vimiumHelpDialog div.advanced { display: none; }
+div#vimiumHelpDialog tr.advanced { display: none; }
+div#vimiumHelpDialog.showAdvanced tr.advanced { display: table-row; }
 div#vimiumHelpDialog div.advanced td:nth-of-type(3) { color: #555; }
 div#vimiumHelpDialog a.closeButton {
   position:absolute;

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -61,6 +61,14 @@ tr.vimiumReset {
   z-index: 2147483648;
 }
 
+thead.vimiumReset, tbody.vimiumReset {
+  display: table-header-group;
+}
+
+tbody.vimiumReset {
+  display: table-row-group;
+}
+
 /* Linkhints CSS */
 
 div.internalVimiumHintMarker {

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -138,7 +138,7 @@ div#vimiumHelpDialog {
   border-radius:6px;
   padding:8px 12px;
   width:640px;
-  max-height: 85%;
+  max-height: calc(100% - 80px);
   left:50%;
   /* This needs to be 1/2 width to horizontally center the help dialog */
   margin-left:-320px;

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -796,6 +796,11 @@ VimiumHelpDialog =
     # Simulating a click on the help dialog makes it the active element for scrolling.
     DomUtils.simulateClick document.getElementById "vimiumHelpDialog"
 
+  hide: ->
+    helpDialog = document.getElementById("vimiumHelpDialogContainer")
+    if (helpDialog)
+      helpDialog.parentNode.removeChild(helpDialog)
+
   #
   # Advanced commands are hidden by default so they don't overwhelm new and casual users.
   #
@@ -821,11 +826,8 @@ window.showHelpDialog = (html, fid) ->
 
 hideHelpDialog = (clickEvent) ->
   isShowingHelpDialog = false
-  helpDialog = document.getElementById("vimiumHelpDialogContainer")
-  if (helpDialog)
-    helpDialog.parentNode.removeChild(helpDialog)
-  if (clickEvent)
-    clickEvent.preventDefault()
+  VimiumHelpDialog.hide()
+  clickEvent?.preventDefault()
 
 toggleHelpDialog = (html, fid) ->
   if (isShowingHelpDialog)

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -137,7 +137,7 @@ initializePreDomReady = ->
 
   requestHandlers =
     showHUDforDuration: handleShowHUDforDuration
-    toggleHelpDialog: (request) -> toggleHelpDialog(request.dialogHtml, request.frameId)
+    toggleHelpDialog: (request) -> if frameId == request.frameId then toggleHelpDialog request.dialogHtml
     focusFrame: (request) -> if (frameId == request.frameId) then focusThisFrame request
     refreshCompletionKeys: refreshCompletionKeys
     getScrollPosition: -> scrollX: window.scrollX, scrollY: window.scrollY
@@ -832,8 +832,7 @@ window.HelpDialog =
     addOrRemove = if visible then "add" else "remove"
     HelpDialog.dialogElement.classList[addOrRemove] "showAdvanced"
 
-toggleHelpDialog = (html, fid) ->
-  return unless fid == frameId
+toggleHelpDialog = (html) ->
   if HelpDialog.showing
     HelpDialog.hide()
   else

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -768,6 +768,33 @@ window.enterFindMode = ->
   Marks.setPreviousPosition()
   new FindMode()
 
+VimiumHelpDialog =
+  # This setting is pulled out of local storage. It's false by default.
+  getShowAdvancedCommands: -> Settings.get("helpDialog_showAdvancedCommands")
+
+  init: () ->
+    this.dialogElement = document.getElementById("vimiumHelpDialog")
+    this.dialogElement.getElementsByClassName("toggleAdvancedCommands")[0].addEventListener("click",
+      VimiumHelpDialog.toggleAdvancedCommands, false)
+    this.dialogElement.style.maxHeight = window.innerHeight - 80
+    this.showAdvancedCommands(this.getShowAdvancedCommands())
+
+  #
+  # Advanced commands are hidden by default so they don't overwhelm new and casual users.
+  #
+  toggleAdvancedCommands: (event) ->
+    event.preventDefault()
+    showAdvanced = VimiumHelpDialog.getShowAdvancedCommands()
+    VimiumHelpDialog.showAdvancedCommands(!showAdvanced)
+    Settings.set("helpDialog_showAdvancedCommands", !showAdvanced)
+
+  showAdvancedCommands: (visible) ->
+    VimiumHelpDialog.dialogElement.getElementsByClassName("toggleAdvancedCommands")[0].innerHTML =
+      if visible then "Hide advanced commands" else "Show advanced commands"
+    advancedEls = VimiumHelpDialog.dialogElement.getElementsByClassName("advanced")
+    for el in advancedEls
+      el.style.display = if visible then "table-row" else "none"
+
 window.showHelpDialog = (html, fid) ->
   return if (isShowingHelpDialog || !document.body || fid != frameId)
   isShowingHelpDialog = true
@@ -779,33 +806,6 @@ window.showHelpDialog = (html, fid) ->
 
   container.innerHTML = html
   container.getElementsByClassName("closeButton")[0].addEventListener("click", hideHelpDialog, false)
-
-  VimiumHelpDialog =
-    # This setting is pulled out of local storage. It's false by default.
-    getShowAdvancedCommands: -> Settings.get("helpDialog_showAdvancedCommands")
-
-    init: () ->
-      this.dialogElement = document.getElementById("vimiumHelpDialog")
-      this.dialogElement.getElementsByClassName("toggleAdvancedCommands")[0].addEventListener("click",
-        VimiumHelpDialog.toggleAdvancedCommands, false)
-      this.dialogElement.style.maxHeight = window.innerHeight - 80
-      this.showAdvancedCommands(this.getShowAdvancedCommands())
-
-    #
-    # Advanced commands are hidden by default so they don't overwhelm new and casual users.
-    #
-    toggleAdvancedCommands: (event) ->
-      event.preventDefault()
-      showAdvanced = VimiumHelpDialog.getShowAdvancedCommands()
-      VimiumHelpDialog.showAdvancedCommands(!showAdvanced)
-      Settings.set("helpDialog_showAdvancedCommands", !showAdvanced)
-
-    showAdvancedCommands: (visible) ->
-      VimiumHelpDialog.dialogElement.getElementsByClassName("toggleAdvancedCommands")[0].innerHTML =
-        if visible then "Hide advanced commands" else "Show advanced commands"
-      advancedEls = VimiumHelpDialog.dialogElement.getElementsByClassName("advanced")
-      for el in advancedEls
-        el.style.display = if visible then "table-row" else "none"
 
   VimiumHelpDialog.init()
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -794,7 +794,10 @@ VimiumHelpDialog =
       @dialogElement.getElementsByClassName("toggleAdvancedCommands")[0].addEventListener("click",
         VimiumHelpDialog.toggleAdvancedCommands, false)
 
+  isReady: -> document.body? and @container?
+
   show: (html) ->
+    isShowingHelpDialog = true
     for placeholder, htmlString of html
       @dialogElement.querySelector("#help-dialog-#{placeholder}").innerHTML = htmlString
 
@@ -805,6 +808,7 @@ VimiumHelpDialog =
     DomUtils.simulateClick document.getElementById "vimiumHelpDialog"
 
   hide: ->
+    isShowingHelpDialog = false
     @container?.parentNode?.removeChild @container
 
   #
@@ -819,26 +823,25 @@ VimiumHelpDialog =
   showAdvancedCommands: (visible) ->
     VimiumHelpDialog.dialogElement.getElementsByClassName("toggleAdvancedCommands")[0].innerHTML =
       if visible then "Hide advanced commands" else "Show advanced commands"
-    advancedEls = VimiumHelpDialog.dialogElement.getElementsByClassName("advanced")
-    for el in advancedEls
-      el.style.display = if visible then "table-row" else "none"
 
-window.showHelpDialog = (html, fid) ->
-  return if (isShowingHelpDialog || !document.body || fid != frameId)
-  isShowingHelpDialog = true
+    # Add/remove the showAdvanced class to show/hide advanced commands.
+    addOrRemove = if visible then "add" else "remove"
+    VimiumHelpDialog.dialogElement.classList[addOrRemove] "showAdvanced"
 
+window.showHelpDialog = (html) ->
+  return if isShowingHelpDialog or !VimiumHelpDialog.isReady()
   VimiumHelpDialog.show html
 
 hideHelpDialog = (clickEvent) ->
-  isShowingHelpDialog = false
   VimiumHelpDialog.hide()
   clickEvent?.preventDefault()
 
 toggleHelpDialog = (html, fid) ->
-  if (isShowingHelpDialog)
+  return unless fid == frameId
+  if isShowingHelpDialog
     hideHelpDialog()
   else
-    showHelpDialog(html, fid)
+    showHelpDialog html
 
 initializePreDomReady()
 DomUtils.documentReady initializeOnDomReady

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -772,6 +772,21 @@ VimiumHelpDialog =
   # This setting is pulled out of local storage. It's false by default.
   getShowAdvancedCommands: -> Settings.get("helpDialog_showAdvancedCommands")
 
+  init: (html) ->
+    container = DomUtils.createElement "div"
+    container.id = "vimiumHelpDialogContainer"
+    container.className = "vimiumReset"
+
+    document.body.appendChild(container)
+
+    container.innerHTML = html
+    container.getElementsByClassName("closeButton")[0].addEventListener("click", hideHelpDialog, false)
+    container.getElementsByClassName("optionsPage")[0].addEventListener("click", (clickEvent) ->
+        clickEvent.preventDefault()
+        chrome.runtime.sendMessage({handler: "openOptionsPageInNewTab"})
+      false)
+
+
   show: ->
     @dialogElement = document.getElementById("vimiumHelpDialog")
     @dialogElement.getElementsByClassName("toggleAdvancedCommands")[0].addEventListener("click",
@@ -797,21 +812,9 @@ VimiumHelpDialog =
 window.showHelpDialog = (html, fid) ->
   return if (isShowingHelpDialog || !document.body || fid != frameId)
   isShowingHelpDialog = true
-  container = DomUtils.createElement "div"
-  container.id = "vimiumHelpDialogContainer"
-  container.className = "vimiumReset"
 
-  document.body.appendChild(container)
-
-  container.innerHTML = html
-  container.getElementsByClassName("closeButton")[0].addEventListener("click", hideHelpDialog, false)
-
+  VimiumHelpDialog.init html
   VimiumHelpDialog.show()
-
-  container.getElementsByClassName("optionsPage")[0].addEventListener("click", (clickEvent) ->
-      clickEvent.preventDefault()
-      chrome.runtime.sendMessage({handler: "openOptionsPageInNewTab"})
-    false)
 
   # Simulating a click on the help dialog makes it the active element for scrolling.
   DomUtils.simulateClick document.getElementById "vimiumHelpDialog"

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -793,6 +793,9 @@ VimiumHelpDialog =
       VimiumHelpDialog.toggleAdvancedCommands, false)
     @showAdvancedCommands(@getShowAdvancedCommands())
 
+    # Simulating a click on the help dialog makes it the active element for scrolling.
+    DomUtils.simulateClick document.getElementById "vimiumHelpDialog"
+
   #
   # Advanced commands are hidden by default so they don't overwhelm new and casual users.
   #
@@ -815,9 +818,6 @@ window.showHelpDialog = (html, fid) ->
 
   VimiumHelpDialog.init html
   VimiumHelpDialog.show()
-
-  # Simulating a click on the help dialog makes it the active element for scrolling.
-  DomUtils.simulateClick document.getElementById "vimiumHelpDialog"
 
 hideHelpDialog = (clickEvent) ->
   isShowingHelpDialog = false

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -769,26 +769,29 @@ window.enterFindMode = ->
   new FindMode()
 
 VimiumHelpDialog =
+  container: null
+  dialogElement: null
+
   # This setting is pulled out of local storage. It's false by default.
   getShowAdvancedCommands: -> Settings.get("helpDialog_showAdvancedCommands")
 
-  init: (html) ->
-    container = DomUtils.createElement "div"
-    container.id = "vimiumHelpDialogContainer"
-    container.className = "vimiumReset"
+  init: ->
+    unless @container?
+      @container = DomUtils.createElement "div"
+      @container.id = "vimiumHelpDialogContainer"
+      @container.className = "vimiumReset"
 
-    document.body.appendChild(container)
+  show: (html) ->
+    document.body.appendChild @container
 
-    container.innerHTML = html
-    container.getElementsByClassName("closeButton")[0].addEventListener("click", hideHelpDialog, false)
-    container.getElementsByClassName("optionsPage")[0].addEventListener("click", (clickEvent) ->
+    @container.innerHTML = html
+    @container.getElementsByClassName("closeButton")[0].addEventListener("click", hideHelpDialog, false)
+    @container.getElementsByClassName("optionsPage")[0].addEventListener("click", (clickEvent) ->
         clickEvent.preventDefault()
         chrome.runtime.sendMessage({handler: "openOptionsPageInNewTab"})
       false)
 
-
-  show: ->
-    @dialogElement = document.getElementById("vimiumHelpDialog")
+    @dialogElement = @container.querySelector "#VimiumHelpDialog"
     @dialogElement.getElementsByClassName("toggleAdvancedCommands")[0].addEventListener("click",
       VimiumHelpDialog.toggleAdvancedCommands, false)
     @showAdvancedCommands(@getShowAdvancedCommands())
@@ -797,9 +800,7 @@ VimiumHelpDialog =
     DomUtils.simulateClick document.getElementById "vimiumHelpDialog"
 
   hide: ->
-    helpDialog = document.getElementById("vimiumHelpDialogContainer")
-    if (helpDialog)
-      helpDialog.parentNode.removeChild(helpDialog)
+    @container?.parentNode?.removeChild @container
 
   #
   # Advanced commands are hidden by default so they don't overwhelm new and casual users.
@@ -821,8 +822,8 @@ window.showHelpDialog = (html, fid) ->
   return if (isShowingHelpDialog || !document.body || fid != frameId)
   isShowingHelpDialog = true
 
-  VimiumHelpDialog.init html
-  VimiumHelpDialog.show()
+  VimiumHelpDialog.init()
+  VimiumHelpDialog.show html
 
 hideHelpDialog = (clickEvent) ->
   isShowingHelpDialog = false

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -137,7 +137,7 @@ initializePreDomReady = ->
 
   requestHandlers =
     showHUDforDuration: handleShowHUDforDuration
-    toggleHelpDialog: (request) -> if frameId == request.frameId then toggleHelpDialog request.dialogHtml
+    toggleHelpDialog: (request) -> if frameId == request.frameId then HelpDialog.toggle request.dialogHtml
     focusFrame: (request) -> if (frameId == request.frameId) then focusThisFrame request
     refreshCompletionKeys: refreshCompletionKeys
     getScrollPosition: -> scrollX: window.scrollX, scrollY: window.scrollY
@@ -815,6 +815,9 @@ window.HelpDialog =
     HelpDialog.showing = false
     @container?.parentNode?.removeChild @container
 
+  toggle: (html) ->
+    if @showing then @hide() else @show html
+
   #
   # Advanced commands are hidden by default so they don't overwhelm new and casual users.
   #
@@ -831,12 +834,6 @@ window.HelpDialog =
     # Add/remove the showAdvanced class to show/hide advanced commands.
     addOrRemove = if visible then "add" else "remove"
     HelpDialog.dialogElement.classList[addOrRemove] "showAdvanced"
-
-toggleHelpDialog = (html) ->
-  if HelpDialog.showing
-    HelpDialog.hide()
-  else
-    HelpDialog.show html
 
 initializePreDomReady()
 DomUtils.documentReady initializeOnDomReady

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -5,7 +5,6 @@
 # "domReady".
 #
 
-isShowingHelpDialog = false
 keyPort = null
 isEnabledForUrl = true
 isIncognitoMode = chrome.extension.inIncognitoContext
@@ -533,7 +532,7 @@ onKeydown = (event) ->
       if (modifiers.length > 0 || keyChar.length > 1)
         keyChar = "<" + keyChar + ">"
 
-  if (isShowingHelpDialog && KeyboardUtils.isEscape(event))
+  if (HelpDialog.showing && KeyboardUtils.isEscape(event))
     HelpDialog.hide()
     DomUtils.suppressEvent event
     KeydownEvents.push event
@@ -772,6 +771,7 @@ window.enterFindMode = ->
 window.HelpDialog =
   container: null
   dialogElement: null
+  showing: false
 
   # This setting is pulled out of local storage. It's false by default.
   getShowAdvancedCommands: -> Settings.get("helpDialog_showAdvancedCommands")
@@ -800,8 +800,8 @@ window.HelpDialog =
   isReady: -> document.body? and @container?
 
   show: (html) ->
-    return if isShowingHelpDialog or !@isReady()
-    isShowingHelpDialog = true
+    return if HelpDialog.showing or !@isReady()
+    HelpDialog.showing = true
     for placeholder, htmlString of html
       @dialogElement.querySelector("#help-dialog-#{placeholder}").innerHTML = htmlString
 
@@ -812,7 +812,7 @@ window.HelpDialog =
     DomUtils.simulateClick document.getElementById "vimiumHelpDialog"
 
   hide: ->
-    isShowingHelpDialog = false
+    HelpDialog.showing = false
     @container?.parentNode?.removeChild @container
 
   #
@@ -834,7 +834,7 @@ window.HelpDialog =
 
 toggleHelpDialog = (html, fid) ->
   return unless fid == frameId
-  if isShowingHelpDialog
+  if HelpDialog.showing
     HelpDialog.hide()
   else
     HelpDialog.show html

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -534,7 +534,7 @@ onKeydown = (event) ->
         keyChar = "<" + keyChar + ">"
 
   if (isShowingHelpDialog && KeyboardUtils.isEscape(event))
-    hideHelpDialog()
+    VimiumHelpDialog.hide()
     DomUtils.suppressEvent event
     KeydownEvents.push event
     return @stopBubblingAndTrue
@@ -769,7 +769,7 @@ window.enterFindMode = ->
   Marks.setPreviousPosition()
   new FindMode()
 
-VimiumHelpDialog =
+window.VimiumHelpDialog =
   container: null
   dialogElement: null
 
@@ -786,7 +786,10 @@ VimiumHelpDialog =
 
       @dialogElement = @container.querySelector "#vimiumHelpDialog"
 
-      @dialogElement.getElementsByClassName("closeButton")[0].addEventListener("click", hideHelpDialog, false)
+      @dialogElement.getElementsByClassName("closeButton")[0].addEventListener("click", (clickEvent) =>
+          clickEvent.preventDefault()
+          @hide()
+        false)
       @dialogElement.getElementsByClassName("optionsPage")[0].addEventListener("click", (clickEvent) ->
           clickEvent.preventDefault()
           chrome.runtime.sendMessage({handler: "openOptionsPageInNewTab"})
@@ -797,6 +800,7 @@ VimiumHelpDialog =
   isReady: -> document.body? and @container?
 
   show: (html) ->
+    return if isShowingHelpDialog or !@isReady()
     isShowingHelpDialog = true
     for placeholder, htmlString of html
       @dialogElement.querySelector("#help-dialog-#{placeholder}").innerHTML = htmlString
@@ -828,20 +832,12 @@ VimiumHelpDialog =
     addOrRemove = if visible then "add" else "remove"
     VimiumHelpDialog.dialogElement.classList[addOrRemove] "showAdvanced"
 
-window.showHelpDialog = (html) ->
-  return if isShowingHelpDialog or !VimiumHelpDialog.isReady()
-  VimiumHelpDialog.show html
-
-hideHelpDialog = (clickEvent) ->
-  VimiumHelpDialog.hide()
-  clickEvent?.preventDefault()
-
 toggleHelpDialog = (html, fid) ->
   return unless fid == frameId
   if isShowingHelpDialog
-    hideHelpDialog()
+    VimiumHelpDialog.hide()
   else
-    showHelpDialog html
+    VimiumHelpDialog.show html
 
 initializePreDomReady()
 DomUtils.documentReady initializeOnDomReady

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -220,7 +220,7 @@ initializeOnDomReady = ->
   # We only initialize the vomnibar in the tab's main frame, because it's only ever opened there.
   Vomnibar.init() if DomUtils.isTopFrame()
   HUD.init()
-  VimiumHelpDialog.init()
+  HelpDialog.init()
 
 registerFrame = ->
   # Don't register frameset containers; focusing them is no use.
@@ -534,7 +534,7 @@ onKeydown = (event) ->
         keyChar = "<" + keyChar + ">"
 
   if (isShowingHelpDialog && KeyboardUtils.isEscape(event))
-    VimiumHelpDialog.hide()
+    HelpDialog.hide()
     DomUtils.suppressEvent event
     KeydownEvents.push event
     return @stopBubblingAndTrue
@@ -769,7 +769,7 @@ window.enterFindMode = ->
   Marks.setPreviousPosition()
   new FindMode()
 
-window.VimiumHelpDialog =
+window.HelpDialog =
   container: null
   dialogElement: null
 
@@ -795,7 +795,7 @@ window.VimiumHelpDialog =
           chrome.runtime.sendMessage({handler: "openOptionsPageInNewTab"})
         false)
       @dialogElement.getElementsByClassName("toggleAdvancedCommands")[0].addEventListener("click",
-        VimiumHelpDialog.toggleAdvancedCommands, false)
+        HelpDialog.toggleAdvancedCommands, false)
 
   isReady: -> document.body? and @container?
 
@@ -820,24 +820,24 @@ window.VimiumHelpDialog =
   #
   toggleAdvancedCommands: (event) ->
     event.preventDefault()
-    showAdvanced = VimiumHelpDialog.getShowAdvancedCommands()
-    VimiumHelpDialog.showAdvancedCommands(!showAdvanced)
+    showAdvanced = HelpDialog.getShowAdvancedCommands()
+    HelpDialog.showAdvancedCommands(!showAdvanced)
     Settings.set("helpDialog_showAdvancedCommands", !showAdvanced)
 
   showAdvancedCommands: (visible) ->
-    VimiumHelpDialog.dialogElement.getElementsByClassName("toggleAdvancedCommands")[0].innerHTML =
+    HelpDialog.dialogElement.getElementsByClassName("toggleAdvancedCommands")[0].innerHTML =
       if visible then "Hide advanced commands" else "Show advanced commands"
 
     # Add/remove the showAdvanced class to show/hide advanced commands.
     addOrRemove = if visible then "add" else "remove"
-    VimiumHelpDialog.dialogElement.classList[addOrRemove] "showAdvanced"
+    HelpDialog.dialogElement.classList[addOrRemove] "showAdvanced"
 
 toggleHelpDialog = (html, fid) ->
   return unless fid == frameId
   if isShowingHelpDialog
-    VimiumHelpDialog.hide()
+    HelpDialog.hide()
   else
-    VimiumHelpDialog.show html
+    HelpDialog.show html
 
 initializePreDomReady()
 DomUtils.documentReady initializeOnDomReady

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -772,12 +772,11 @@ VimiumHelpDialog =
   # This setting is pulled out of local storage. It's false by default.
   getShowAdvancedCommands: -> Settings.get("helpDialog_showAdvancedCommands")
 
-  init: () ->
-    this.dialogElement = document.getElementById("vimiumHelpDialog")
-    this.dialogElement.getElementsByClassName("toggleAdvancedCommands")[0].addEventListener("click",
+  show: ->
+    @dialogElement = document.getElementById("vimiumHelpDialog")
+    @dialogElement.getElementsByClassName("toggleAdvancedCommands")[0].addEventListener("click",
       VimiumHelpDialog.toggleAdvancedCommands, false)
-    this.dialogElement.style.maxHeight = window.innerHeight - 80
-    this.showAdvancedCommands(this.getShowAdvancedCommands())
+    @showAdvancedCommands(@getShowAdvancedCommands())
 
   #
   # Advanced commands are hidden by default so they don't overwhelm new and casual users.
@@ -807,7 +806,7 @@ window.showHelpDialog = (html, fid) ->
   container.innerHTML = html
   container.getElementsByClassName("closeButton")[0].addEventListener("click", hideHelpDialog, false)
 
-  VimiumHelpDialog.init()
+  VimiumHelpDialog.show()
 
   container.getElementsByClassName("optionsPage")[0].addEventListener("click", (clickEvent) ->
       clickEvent.preventDefault()

--- a/pages/help_dialog.html
+++ b/pages/help_dialog.html
@@ -9,12 +9,12 @@
   <a class="vimiumReset optionsPage" href="#">Options</a>
   <a class="vimiumReset wikiPage" href="https://github.com/philc/vimium/wiki" target="_blank">Wiki</a>
   <a class="vimiumReset closeButton" href="#">&times;</a>
-  <div id="vimiumTitle" class="vimiumReset"><span class="vimiumReset" style="color:#2f508e">Vim</span>ium {{title}}</div>
+  <div id="vimiumTitle" class="vimiumReset"><span class="vimiumReset" style="color:#2f508e">Vim</span>ium <span id="help-dialog-title"></span></div>
   <div class="vimiumReset vimiumColumn">
     <table class="vimiumReset">
       <tbody class="vimiumReset">
       <tr class="vimiumReset" ><td class="vimiumReset"></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Navigating the page</td></tr>
-      {{pageNavigation}}
+      <span id="help-dialog-pageNavigation"></span>
       </tbody>
     </table>
   </div>
@@ -22,15 +22,15 @@
     <table class="vimiumReset" >
       <tbody class="vimiumReset">
       <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Using the vomnibar</td></tr>
-      {{vomnibarCommands}}
+      <span id="help-dialog-vomnibarCommands"></span>
       <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Using find</td></tr>
-      {{findCommands}}
+      <span id="help-dialog-findCommands"></span>
       <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Navigating history</td></tr>
-      {{historyNavigation}}
+      <span id="help-dialog-historyNavigation"></span>
       <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Manipulating tabs</td></tr>
-      {{tabManipulation}}
+      <span id="help-dialog-tabManipulation"></span>
       <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Miscellaneous</td></tr>
-      {{misc}}
+      <span id="help-dialog-misc"></span>
       </tbody>
     </table>
   </div>
@@ -48,7 +48,7 @@
       Found a bug? <a class="vimiumReset" href="http://github.com/philc/vimium/issues">Report it here</a>.
     </div>
     <div class="vimiumReset vimiumColumn" style="text-align:right">
-      <span class="vimiumReset">Version {{version}}</span><br/>
+      <span class="vimiumReset">Version <span id="help-dialog-version"></span></span><br/>
       <a href="https://github.com/philc/vimium#release-notes" class="vimiumReset">What's new?</a>
     </div>
   </div>

--- a/pages/help_dialog.html
+++ b/pages/help_dialog.html
@@ -12,26 +12,35 @@
   <div id="vimiumTitle" class="vimiumReset"><span class="vimiumReset" style="color:#2f508e">Vim</span>ium <span id="help-dialog-title"></span></div>
   <div class="vimiumReset vimiumColumn">
     <table class="vimiumReset">
-      <tbody class="vimiumReset">
-      <tr class="vimiumReset" ><td class="vimiumReset"></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Navigating the page</td></tr>
-      <span id="help-dialog-pageNavigation"></span>
+      <thead class="vimiumReset">
+        <tr class="vimiumReset" ><td class="vimiumReset"></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Navigating the page</td></tr>
+      </thead>
+      <tbody id="help-dialog-pageNavigation" class="vimiumReset">
       </tbody>
     </table>
   </div>
   <div class="vimiumReset vimiumColumn">
     <table class="vimiumReset" >
-      <tbody class="vimiumReset">
+      <thead class="vimiumReset">
       <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Using the vomnibar</td></tr>
-      <span id="help-dialog-vomnibarCommands"></span>
+      </thead>
+      <tbody class="vimiumReset" id="help-dialog-vomnibarCommands"></tbody>
+      <thead class="vimiumReset">
       <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Using find</td></tr>
-      <span id="help-dialog-findCommands"></span>
+      </thead>
+      <tbody class="vimiumReset" id="help-dialog-findCommands"></tbody>
+      <thead class="vimiumReset">
       <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Navigating history</td></tr>
-      <span id="help-dialog-historyNavigation"></span>
+      </thead>
+      <tbody class="vimiumReset" id="help-dialog-historyNavigation"></tbody>
+      <thead class="vimiumReset">
       <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Manipulating tabs</td></tr>
-      <span id="help-dialog-tabManipulation"></span>
+      </thead>
+      <tbody class="vimiumReset" id="help-dialog-tabManipulation"></tbody>
+      <thead class="vimiumReset">
       <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Miscellaneous</td></tr>
-      <span id="help-dialog-misc"></span>
-      </tbody>
+      </thead>
+      <tbody class="vimiumReset" id="help-dialog-misc"></tbody>
     </table>
   </div>
 

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -231,7 +231,7 @@ initOptionsPage = ->
     event.preventDefault()
 
   activateHelpDialog = ->
-    VimiumHelpDialog.show chrome.extension.getBackgroundPage().helpDialogHtml(true, true, "Command Listing"), frameId
+    HelpDialog.show chrome.extension.getBackgroundPage().helpDialogHtml(true, true, "Command Listing"), frameId
     # Prevent the "show help" link from retaining the focus when clicked.
     document.activeElement.blur()
 

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -231,7 +231,7 @@ initOptionsPage = ->
     event.preventDefault()
 
   activateHelpDialog = ->
-    showHelpDialog chrome.extension.getBackgroundPage().helpDialogHtml(true, true, "Command Listing"), frameId
+    VimiumHelpDialog.show chrome.extension.getBackgroundPage().helpDialogHtml(true, true, "Command Listing"), frameId
     # Prevent the "show help" link from retaining the focus when clicked.
     document.activeElement.blur()
 


### PR DESCRIPTION
This PR refactors the code for the help dialog into an object `HelpDialog`, so that it will be easy to move it into an iframe (as was planned [here](https://github.com/philc/vimium/pull/1236#issuecomment-177103390)).

Note: the unified diff is hard to look over for this; recommend looking at the [split diff](https://github.com/philc/vimium/pull/1966/files?diff=split) instead.