### PR TITLE
New command: visit previous tab.

### DIFF
--- a/background_scripts/bg_utils.coffee
+++ b/background_scripts/bg_utils.coffee
@@ -39,12 +39,11 @@ class TabRecency
     @cache[tabId] ||= 1
     if tabId == @current then 0.0 else @cache[tabId] / @timestamp
 
-  # Get the tab Id of the count-th most recently visited tab (excluding tabId, which is the current tab).
-  getRecentTab: (tabId, count) ->
-    tabId = tabId.toString()
-    tabIds = (tId for own tId of @cache when tId != tabId)
+  # Returns a list of tab Ids sorted by recency, most recent tab first.
+  getTabsByRecency: ->
+    tabIds = (tId for own tId of @cache)
     tabIds.sort (a,b) => @cache[b] - @cache[a]
-    parseInt tabIds[(count-1)%tabIds.length]
+    tabIds.map (tId) -> parseInt tId
 
 BgUtils =
   tabRecency: new TabRecency()

--- a/background_scripts/bg_utils.coffee
+++ b/background_scripts/bg_utils.coffee
@@ -39,6 +39,13 @@ class TabRecency
     @cache[tabId] ||= 1
     if tabId == @current then 0.0 else @cache[tabId] / @timestamp
 
+  # Get the tab Id of the count-th most recently visited tab (excluding tabId, which is the current tab).
+  getRecentTab: (tabId, count) ->
+    tabId = tabId.toString()
+    tabIds = (tId for own tId of @cache when tId != tabId)
+    tabIds.sort (a,b) => @cache[b] - @cache[a]
+    parseInt tabIds[(count-1)%tabIds.length]
+
 BgUtils =
   tabRecency: new TabRecency()
 

--- a/background_scripts/bg_utils.coffee
+++ b/background_scripts/bg_utils.coffee
@@ -1,0 +1,45 @@
+root = exports ? window
+
+# TabRecency associates a logical timestamp with each tab id.  These are used to provide an initial
+# recency-based ordering in the tabs vomnibar (which allows jumping quickly between recently-visited tabs).
+class TabRecency
+  timestamp: 1
+  current: -1
+  cache: {}
+  lastVisited: null
+  lastVisitedTime: null
+  timeDelta: 500 # Milliseconds.
+
+  constructor: ->
+    chrome.tabs.onActivated.addListener (activeInfo) => @register activeInfo.tabId
+    chrome.tabs.onRemoved.addListener (tabId) => @deregister tabId
+
+    chrome.tabs.onReplaced.addListener (addedTabId, removedTabId) =>
+      @deregister removedTabId
+      @register addedTabId
+
+  register: (tabId) ->
+    currentTime = new Date()
+    # Register tabId if it has been visited for at least @timeDelta ms.  Tabs which are visited only for a
+    # very-short time (e.g. those passed through with `5J`) aren't registered as visited at all.
+    if @lastVisitedTime? and @timeDelta <= currentTime - @lastVisitedTime
+      @cache[@lastVisited] = ++@timestamp
+
+    @current = @lastVisited = tabId
+    @lastVisitedTime = currentTime
+
+  deregister: (tabId) ->
+    if tabId == @lastVisited
+      # Ensure we don't register this tab, since it's going away.
+      @lastVisited = @lastVisitedTime = null
+    delete @cache[tabId]
+
+  # Recently-visited tabs get a higher score (except the current tab, which gets a low score).
+  recencyScore: (tabId) ->
+    @cache[tabId] ||= 1
+    if tabId == @current then 0.0 else @cache[tabId] / @timestamp
+
+BgUtils =
+  tabRecency: new TabRecency()
+
+root.BgUtils = BgUtils

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -125,6 +125,7 @@ Commands =
     tabManipulation:
       ["nextTab",
       "previousTab",
+      "visitPreviousTab",
       "firstTab",
       "lastTab",
       "createTab",
@@ -215,6 +216,7 @@ defaultKeyMappings =
   "J": "previousTab"
   "gt": "nextTab"
   "gT": "previousTab"
+  "^": "visitPreviousTab"
   "<<": "moveTabLeft"
   ">>": "moveTabRight"
   "g0": "firstTab"
@@ -306,6 +308,7 @@ commandDescriptions =
   # Manipulating tabs
   nextTab: ["Go one tab right", { background: true, passCountToFunction: true }]
   previousTab: ["Go one tab left", { background: true, passCountToFunction: true }]
+  visitPreviousTab: ["Go to previously-visited tab", { background: true, passCountToFunction: true }]
   firstTab: ["Go to the first tab", { background: true, passCountToFunction: true }]
   lastTab: ["Go to the last tab", { background: true, passCountToFunction: true }]
 

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -351,47 +351,6 @@ class DomainCompleter
   parseDomainAndScheme: (url) ->
       Utils.hasFullUrlPrefix(url) and not Utils.hasChromePrefix(url) and url.split("/",3).join "/"
 
-# TabRecency associates a logical timestamp with each tab id.  These are used to provide an initial
-# recency-based ordering in the tabs vomnibar (which allows jumping quickly between recently-visited tabs).
-class TabRecency
-  timestamp: 1
-  current: -1
-  cache: {}
-  lastVisited: null
-  lastVisitedTime: null
-  timeDelta: 500 # Milliseconds.
-
-  constructor: ->
-    chrome.tabs.onActivated.addListener (activeInfo) => @register activeInfo.tabId
-    chrome.tabs.onRemoved.addListener (tabId) => @deregister tabId
-
-    chrome.tabs.onReplaced.addListener (addedTabId, removedTabId) =>
-      @deregister removedTabId
-      @register addedTabId
-
-  register: (tabId) ->
-    currentTime = new Date()
-    # Register tabId if it has been visited for at least @timeDelta ms.  Tabs which are visited only for a
-    # very-short time (e.g. those passed through with `5J`) aren't registered as visited at all.
-    if @lastVisitedTime? and @timeDelta <= currentTime - @lastVisitedTime
-      @cache[@lastVisited] = ++@timestamp
-
-    @current = @lastVisited = tabId
-    @lastVisitedTime = currentTime
-
-  deregister: (tabId) ->
-    if tabId == @lastVisited
-      # Ensure we don't register this tab, since it's going away.
-      @lastVisited = @lastVisitedTime = null
-    delete @cache[tabId]
-
-  # Recently-visited tabs get a higher score (except the current tab, which gets a low score).
-  recencyScore: (tabId) ->
-    @cache[tabId] ||= 1
-    if tabId == @current then 0.0 else @cache[tabId] / @timestamp
-
-tabRecency = new TabRecency()
-
 # Searches through all open tabs, matching on title and URL.
 class TabCompleter
   filter: ({ queryTerms }, onComplete) ->
@@ -414,7 +373,7 @@ class TabCompleter
     if suggestion.queryTerms.length
       RankingUtils.wordRelevancy(suggestion.queryTerms, suggestion.url, suggestion.title)
     else
-      tabRecency.recencyScore(suggestion.tabId)
+      BgUtils.tabRecency.recencyScore(suggestion.tabId)
 
 class SearchEngineCompleter
   @debug: false
@@ -862,4 +821,3 @@ root.SearchEngineCompleter = SearchEngineCompleter
 root.HistoryCache = HistoryCache
 root.RankingUtils = RankingUtils
 root.RegexpCache = RegexpCache
-root.TabRecency = TabRecency

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -335,6 +335,11 @@ BackgroundCommands =
   closeTabsOnRight: -> removeTabsRelative "after"
   closeOtherTabs: -> removeTabsRelative "both"
 
+  visitPreviousTab: (count) ->
+    chrome.tabs.getSelected null, (tab) ->
+      newTabId = BgUtils.tabRecency.getRecentTab tab.id, count
+      chrome.tabs.update newTabId, selected: true
+
 # Remove tabs before, after, or either side of the currently active tab
 removeTabsRelative = (direction) ->
   chrome.tabs.query {currentWindow: true}, (tabs) ->

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -337,8 +337,9 @@ BackgroundCommands =
 
   visitPreviousTab: (count) ->
     chrome.tabs.getSelected null, (tab) ->
-      newTabId = BgUtils.tabRecency.getRecentTab tab.id, count
-      chrome.tabs.update newTabId, selected: true
+      tabIds = BgUtils.tabRecency.getTabsByRecency().filter (tabId) -> tabId != tab.id
+      if 0 < tabIds.length
+        selectSpecificTab id: tabIds[(count-1) % tabIds.length]
 
 # Remove tabs before, after, or either side of the currently active tab
 removeTabsRelative = (direction) ->

--- a/manifest.json
+++ b/manifest.json
@@ -12,6 +12,7 @@
       "lib/settings.js",
       "background_scripts/commands.js",
       "lib/clipboard.js",
+      "background_scripts/bg_utils.js",
       "background_scripts/exclusions.js",
       "background_scripts/completion_engines.js",
       "background_scripts/completion_search.js",

--- a/tests/unit_tests/completion_test.coffee
+++ b/tests/unit_tests/completion_test.coffee
@@ -1,5 +1,6 @@
 require "./test_helper.js"
 extend(global, require "../../lib/utils.js")
+extend(global, require "../../background_scripts/bg_utils.js")
 extend(global, require "../../background_scripts/completion_engines.js")
 extend(global, require "../../background_scripts/completion.js")
 extend global, require "./test_chrome_stubs.js"
@@ -411,7 +412,7 @@ fakeTimeDeltaElapsing = ->
 
 context "TabRecency",
   setup ->
-    @tabRecency = new TabRecency()
+    @tabRecency = BgUtils.tabRecency
 
     fakeTimeDeltaElapsing = =>
       if @tabRecency.lastVisitedTime?


### PR DESCRIPTION
As discussed in #1955, this implements `visitPreviousTab`.

- 4ada22e85dcd061fa806a5fe72a9dc3f1cfe0442 is a no-op; it moves the tab-recency code from `completions.coffee` to a new `bg_utils.coffee`.  There are other things (like `logMessage()`) which could similarly be moved to a separate "utils" file for the background page.
- 60d33d20026cdcdd0c4ecef20410d38341c86633 is the actual new command.

Issues:

- Is `visitPreviousTab` a good name?  Unfortunately `previousTab` is already taken.
- Is `^` a good default binding?
- My sense is that this is _not_ an "advanced command".