### PR TITLE
New command: Pass next key

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -67,16 +67,10 @@ Commands =
           when "unmapAll"
             @keyToCommandRegistry = {}
 
-    # Push the mapping for passNextKey into Settings so that it's available in the front end for insert mode.
-    passNextKeyKey = null
-    for own key of @keyToCommandRegistry
-      if @keyToCommandRegistry[key].command == "passNextKey"
-        passNextKeyKey = key
-        break
-    if passNextKeyKey
-      Settings.set "passNextKeyKey", passNextKeyKey
-    else
-      Settings.clear "passNextKeyKey"
+    # Push the key mapping for passNextKey into Settings so that it's available in the front end for insert
+    # mode.
+    Settings.set "passNextKeyKeys",
+      (key for own key of @keyToCommandRegistry when @keyToCommandRegistry[key].command == "passNextKey")
 
   clearKeyMappingsAndSetDefaults: ->
     @keyToCommandRegistry = {}

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -67,6 +67,17 @@ Commands =
           when "unmapAll"
             @keyToCommandRegistry = {}
 
+    # Push the mapping for passNextKey into Settings so that it's available in the front end for insert mode.
+    passNextKeyKey = null
+    for own key of @keyToCommandRegistry
+      if @keyToCommandRegistry[key].command == "passNextKey"
+        passNextKeyKey = key
+        break
+    if passNextKeyKey
+      Settings.set "passNextKeyKey", passNextKeyKey
+    else
+      Settings.clear "passNextKeyKey"
+
   clearKeyMappingsAndSetDefaults: ->
     @keyToCommandRegistry = {}
     @mapKeyToCommand { key, command } for own key, command of defaultKeyMappings

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -96,6 +96,7 @@ Commands =
       "goUp",
       "goToRoot",
       "enterInsertMode",
+      "passNextKey",
       "enterVisualMode",
       "enterVisualLineMode",
       "focusInput",
@@ -164,7 +165,8 @@ Commands =
     "moveTabRight",
     "closeTabsOnLeft",
     "closeTabsOnRight",
-    "closeOtherTabs"]
+    "closeOtherTabs",
+    "passNextKey"]
 
 defaultKeyMappings =
   "?": "showHelp"
@@ -277,6 +279,7 @@ commandDescriptions =
   openCopiedUrlInNewTab: ["Open the clipboard's URL in a new tab", { background: true, repeatLimit: 20 }]
 
   enterInsertMode: ["Enter insert mode", { noRepeat: true }]
+  passNextKey: ["Pass the next key to Chrome", { passCountToFunction: true }]
   enterVisualMode: ["Enter visual mode", { noRepeat: true }]
   enterVisualLineMode: ["Enter visual line mode", { noRepeat: true }]
 

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -68,9 +68,11 @@ Commands =
             @keyToCommandRegistry = {}
 
     # Push the key mapping for passNextKey into Settings so that it's available in the front end for insert
+    # mode.  We exclude single-key mappings (that is, printable keys) because when users press printable keys
+    # in insert mode they expect the character to be input, not to be droppped into some special Vimium
     # mode.
     Settings.set "passNextKeyKeys",
-      (key for own key of @keyToCommandRegistry when @keyToCommandRegistry[key].command == "passNextKey")
+      (key for own key of @keyToCommandRegistry when @keyToCommandRegistry[key].command == "passNextKey" and 1 < key.length)
 
   clearKeyMappingsAndSetDefaults: ->
     @keyToCommandRegistry = {}

--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -10,6 +10,13 @@ class InsertMode extends Mode
 
     handleKeyEvent = (event) =>
       return @continueBubbling unless @isActive event
+
+      # Check for the pass-next-key key.
+      keyChar = KeyboardUtils.getKeyCharString event
+      if keyChar and keyChar == Settings.get "passNextKeyKey"
+        new PassNextKeyMode
+        return false
+
       return @stopBubblingAndTrue unless event.type == 'keydown' and KeyboardUtils.isEscape event
       DomUtils.suppressKeyupAfterEscape handlerStack
       target = event.srcElement

--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -98,5 +98,32 @@ class InsertMode extends Mode
   @suppressedEvent: null
   @suppressEvent: (event) -> @suppressedEvent = event
 
+# This implements the pasNexKey command.
+class PassNextKeyMode extends Mode
+  constructor: (count = 1) ->
+    seenKeyDown = false
+    keyDownCount = 0
+
+    super
+      name: "pass-next-key"
+      indicator: "Pass next key."
+      # We exit on blur because, once we lose the focus, we can no longer track key events.
+      exitOnBlur: window
+      keypress: =>
+        @stopBubblingAndTrue
+
+      keydown: =>
+        seenKeyDown = true
+        keyDownCount += 1
+        @stopBubblingAndTrue
+
+      keyup: =>
+        if seenKeyDown
+          unless 0 < --keyDownCount
+            unless 0 < --count
+              @exit()
+        @stopBubblingAndTrue
+
 root = exports ? window
 root.InsertMode = InsertMode
+root.PassNextKeyMode = PassNextKeyMode

--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -11,9 +11,8 @@ class InsertMode extends Mode
     handleKeyEvent = (event) =>
       return @continueBubbling unless @isActive event
 
-      # Check for the pass-next-key key.
-      keyChar = KeyboardUtils.getKeyCharString event
-      if keyChar and keyChar == Settings.get "passNextKeyKey"
+      # Check for a pass-next-key key.
+      if KeyboardUtils.getKeyCharString(event) in Settings.get "passNextKeyKeys"
         new PassNextKeyMode
         return false
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -530,7 +530,7 @@ onKeydown = (event) ->
   # Subject to internationalization issues since we're using keyIdentifier instead of charCode (in keypress).
   #
   # TOOD(ilya): Revisit this. Not sure it's the absolute best approach.
-  if keyChar == "" &&
+  if not keyChar &&
      (currentCompletionKeys.indexOf(KeyboardUtils.getKeyChar(event)) != -1 ||
       isValidFirstKey(KeyboardUtils.getKeyChar(event)))
     DomUtils.suppressPropagation(event)

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -368,6 +368,9 @@ extend window,
   enterVisualLineMode: ->
     new VisualLineMode
 
+  passNextKey: (count) ->
+    new PassNextKeyMode count
+
   focusInput: do ->
     # Track the most recently focused input element.
     recentlyFocusedElement = null

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -489,50 +489,20 @@ handlerStack.push
 #
 # @/this, here, is the the normal-mode Mode object.
 onKeypress = (event) ->
-  keyChar = ""
+  keyChar = KeyboardUtils.getKeyCharString event
+  if keyChar
+    if currentCompletionKeys.indexOf(keyChar) != -1 or isValidFirstKey keyChar
+      DomUtils.suppressEvent(event)
+      keyPort.postMessage keyChar:keyChar, frameId:frameId
+      return @stopBubblingAndTrue
 
-  # Ignore modifier keys by themselves.
-  if (event.keyCode > 31)
-    keyChar = String.fromCharCode(event.charCode)
-
-    if (keyChar)
-      if currentCompletionKeys.indexOf(keyChar) != -1 or isValidFirstKey(keyChar)
-        DomUtils.suppressEvent(event)
-        keyPort.postMessage({ keyChar:keyChar, frameId:frameId })
-        return @stopBubblingAndTrue
-
-      keyPort.postMessage({ keyChar:keyChar, frameId:frameId })
+    keyPort.postMessage keyChar:keyChar, frameId:frameId
 
   return @continueBubbling
 
 # @/this, here, is the the normal-mode Mode object.
 onKeydown = (event) ->
-  keyChar = ""
-
-  # handle special keys, and normal input keys with modifiers being pressed. don't handle shiftKey alone (to
-  # avoid / being interpreted as ?
-  if (((event.metaKey || event.ctrlKey || event.altKey) && event.keyCode > 31) || (
-      # TODO(philc): some events don't have a keyidentifier. How is that possible?
-      event.keyIdentifier && event.keyIdentifier.slice(0, 2) != "U+"))
-    keyChar = KeyboardUtils.getKeyChar(event)
-    # Again, ignore just modifiers. Maybe this should replace the keyCode>31 condition.
-    if (keyChar != "")
-      modifiers = []
-
-      if (event.shiftKey)
-        keyChar = keyChar.toUpperCase()
-      if (event.metaKey)
-        modifiers.push("m")
-      if (event.ctrlKey)
-        modifiers.push("c")
-      if (event.altKey)
-        modifiers.push("a")
-
-      for own i of modifiers
-        keyChar = modifiers[i] + "-" + keyChar
-
-      if (modifiers.length > 0 || keyChar.length > 1)
-        keyChar = "<" + keyChar + ">"
+  keyChar = KeyboardUtils.getKeyCharString event
 
   if (HelpDialog.showing && KeyboardUtils.isEscape(event))
     HelpDialog.hide()

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -92,8 +92,7 @@ KeyboardUtils =
             modifiers.push "a" if event.altKey
 
             keyChar = [modifiers..., keyChar].join "-"
-            keyChar = "<#{keyChar}>" if 1 < keyChar.length
-            keyChar
+            if 1 < keyChar.length then "<#{keyChar}>" else keyChar
 
 KeyboardUtils.init()
 

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -66,6 +66,35 @@ KeyboardUtils =
         @getKeyChar event
     keyChar.length == 1
 
+  # Return the Vimium key representation for this keyboard event. Return a falsy value (the empty string or
+  # undefined) when no Vimium representation is appropriate.
+  getKeyCharString: (event) ->
+    switch event.type
+      when "keypress"
+        # Ignore modifier keys by themselves.
+        if 31 < event.keyCode
+          String.fromCharCode event.charCode
+
+      when "keydown"
+        # handle special keys, and normal input keys with modifiers being pressed. don't handle shiftKey alone (to
+        # avoid / being interpreted as ?
+        if (((event.metaKey || event.ctrlKey || event.altKey) && event.keyCode > 31) || (
+            # TODO(philc): some events don't have a keyidentifier. How is that possible?
+            event.keyIdentifier && event.keyIdentifier.slice(0, 2) != "U+"))
+          keyChar = @getKeyChar event
+          # Again, ignore just modifiers. Maybe this should replace the keyCode>31 condition.
+          if 0 < keyChar.length
+            modifiers = []
+
+            keyChar = keyChar.toUpperCase() if event.shiftKey
+            modifiers.push "m" if event.metaKey
+            modifiers.push "c" if event.ctrlKey
+            modifiers.push "a" if event.altKey
+
+            keyChar = [modifiers..., keyChar].join "-"
+            keyChar = "<#{keyChar}>" if 1 < keyChar.length
+            keyChar
+
 KeyboardUtils.init()
 
 root = exports ? window

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -174,7 +174,7 @@ Settings =
     settingsVersion: Utils.getCurrentVersion()
     helpDialog_showAdvancedCommands: false
     optionsPage_showAdvancedOptions: false
-    passNextKeyKey: ""
+    passNextKeyKeys: []
 
 Settings.init()
 

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -174,6 +174,7 @@ Settings =
     settingsVersion: Utils.getCurrentVersion()
     helpDialog_showAdvancedCommands: false
     optionsPage_showAdvancedOptions: false
+    passNextKeyKey: ""
 
 Settings.init()
 


### PR DESCRIPTION
As discussed in #1955.

Example:

    map <c-]> passNextKey

Works in normal mode *and* in insert mode:

- In normal mode, accepts a count prefix.
- In insert mode, only works for single-key mappings.  (In insert mode, multi-key mappings don't make sense, because we've already passed the first key.)

Currently, this is only one command.  Better bindings might be possible, however, if we were to have separate commands for normal and insert modes.

This should make it possible, for example, to close chat popups on Facebook: `<c-]><Esc>`.