### PR TITLE
Split filtered hints on non-word and hint characters.

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -479,6 +479,9 @@ class FilterHints
     @linkTextKeystrokeQueue = []
     @labelMap = {}
     @activeHintMarker = null
+    # The regexp for splitting typed text and link texts.  We split on sequences of non-word characters and
+    # link-hint numbers.
+    @splitRegexp = new RegExp "[\\W#{Utils.escapeRegexSpecialCharacters @linkHintNumbers}]+"
 
   #
   # Generate a map of input element => label
@@ -602,10 +605,10 @@ class FilterHints
   # Assign a score to a filter match (higher is better).  We assign a higher score for matches at the start of
   # a word, and a considerably higher score still for matches which are whole words.
   scoreLinkHint: (linkSearchString) ->
-    searchWords = linkSearchString.trim().split /\s+/
-    (linkMarker) ->
+    searchWords = linkSearchString.trim().split @splitRegexp
+    (linkMarker) =>
       text = linkMarker.linkText.trim()
-      linkWords = linkMarker.linkWords ?= text.toLowerCase().split /\s+/
+      linkWords = linkMarker.linkWords ?= text.toLowerCase().split @splitRegexp
 
       searchWordScores =
         for searchWord in searchWords


### PR DESCRIPTION
This affects the scoring system for filtered link hits, and therefore affects their usability.

Example link text:

    "We open all day", say 7Eleven

Previously:

    "We
    open
    all
    day",
    say
    7Eleven

With this PR:

    we
    open
    all
    day
    say
    Eleven

Previously: the typed text `we` and `day` would receive poor scores (not the start of a word, and not a whole word).  Now, these get high scores, so are more likely to be selected as the active link.  Also, `7Eleven` cannot be typed (because `7` is a hint character).

With this PR, the typed text `we` and `day` now get high scores, as they should.