### PR TITLE
Use `for own ... of` instead of `for ... of`

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -22,7 +22,7 @@ spawn = (procName, optArray, silent = false, sync = false) ->
 
 optArrayFromDict = (opts) ->
   result = []
-  for key, value of opts
+  for own key, value of opts
     if value instanceof Array
       result.push "--#{key}=#{v}" for v in value
     else
@@ -147,7 +147,7 @@ task "coverage", "generate coverage report", ->
 
       # marshal the counts into a form that the JSCoverage front-end expects
       result = {}
-      for fname, coverage of _$jscoverage
+      for own fname, coverage of _$jscoverage
         result[fname] =
           coverage: coverage
           source: (Utils.escapeHtml fs.readFileSync fname, 'utf-8').split '\n'

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -1,6 +1,6 @@
 Commands =
   init: ->
-    for command, description of commandDescriptions
+    for own command, description of commandDescriptions
       @addCommand(command, description[0], description[1])
 
   availableCommands: {}
@@ -69,7 +69,7 @@ Commands =
 
   clearKeyMappingsAndSetDefaults: ->
     @keyToCommandRegistry = {}
-    @mapKeyToCommand { key, command } for key, command of defaultKeyMappings
+    @mapKeyToCommand { key, command } for own key, command of defaultKeyMappings
 
   # An ordered listing of all available commands, grouped by type. This is the order they will
   # be shown in the help page.

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -301,7 +301,7 @@ class DomainCompleter
 
   performSearch: (queryTerms, onComplete) ->
     query = queryTerms[0]
-    domains = (domain for domain of @domains when 0 <= domain.indexOf query)
+    domains = (domain for own domain of @domains when 0 <= domain.indexOf query)
     domains = @sortDomainsByRelevancy queryTerms, domains
     onComplete [
       new Suggestion
@@ -439,7 +439,7 @@ class SearchEngineCompleter
       if queryTerms.length == 0
         []
       else
-        for _, suggestion of @previousSuggestions[searchUrl]
+        for own _, suggestion of @previousSuggestions[searchUrl]
           continue unless RankingUtils.matches queryTerms, suggestion.title
           # Reset various fields, they may not be correct wrt. the current query.
           extend suggestion, relevancy: null, html: null, queryTerms: queryTerms
@@ -507,7 +507,7 @@ class SearchEngineCompleter
 
   postProcessSuggestions: (request, suggestions) ->
     return unless request.searchEngines
-    engines = (engine for _, engine of request.searchEngines)
+    engines = (engine for own _, engine of request.searchEngines)
     engines.sort (a,b) -> b.searchUrl.length - a.searchUrl.length
     engines.push keyword: null, description: "search history", searchUrl: Settings.get "searchUrl"
     for suggestion in suggestions

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -140,7 +140,7 @@ chrome.webNavigation.onReferenceFragmentUpdated.addListener onURLChange # Hash c
 # This is called by options.coffee.
 root.helpDialogHtml = (showUnboundCommands, showCommandNames, customTitle) ->
   commandsToKey = {}
-  for key of Commands.keyToCommandRegistry
+  for own key of Commands.keyToCommandRegistry
     command = Commands.keyToCommandRegistry[key].command
     commandsToKey[command] = (commandsToKey[command] || []).concat(key)
 
@@ -148,7 +148,7 @@ root.helpDialogHtml = (showUnboundCommands, showCommandNames, customTitle) ->
     version: currentVersion
     title: customTitle || "Help"
 
-  for group of Commands.commandGroups
+  for own group of Commands.commandGroups
     replacementStrings[group] =
         helpDialogHtmlForCommandGroup(group, commandsToKey, Commands.availableCommands,
                                       showUnboundCommands, showCommandNames)
@@ -446,7 +446,7 @@ chrome.tabs.onRemoved.addListener (tabId) ->
   # a blacklist in the future.
   unless chrome.sessions
     if (/^(chrome|view-source:)[^:]*:\/\/.*/.test(openTabInfo.url))
-      for i of tabQueue[openTabInfo.windowId]
+      for own i of tabQueue[openTabInfo.windowId]
         if (tabQueue[openTabInfo.windowId][i].positionIndex > openTabInfo.positionIndex)
           tabQueue[openTabInfo.windowId][i].positionIndex--
       return
@@ -489,12 +489,12 @@ getActualKeyStrokeLength = (key) ->
     key.length
 
 populateValidFirstKeys = ->
-  for key of Commands.keyToCommandRegistry
+  for own key of Commands.keyToCommandRegistry
     if (getActualKeyStrokeLength(key) == 2)
       validFirstKeys[splitKeyIntoFirstAndSecond(key).first] = true
 
 populateSingleKeyCommands = ->
-  for key of Commands.keyToCommandRegistry
+  for own key of Commands.keyToCommandRegistry
     if (getActualKeyStrokeLength(key) == 1)
       singleKeyCommands.push(key)
 
@@ -517,7 +517,7 @@ generateCompletionKeys = (keysToCheck) ->
   completionKeys = singleKeyCommands.slice(0)
 
   if (getActualKeyStrokeLength(command) == 1)
-    for key of Commands.keyToCommandRegistry
+    for own key of Commands.keyToCommandRegistry
       splitKey = splitKeyIntoFirstAndSecond(key)
       if (splitKey.first == command)
         completionKeys.push(splitKey.second)

--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -68,7 +68,7 @@ class InsertMode extends Mode
             blur: (event) ->
               if event.target.shadowRoot == shadowRoot
                 handlerStack.remove()
-                for type, listener of eventListeners
+                for own type, listener of eventListeners
                   shadowRoot.removeEventListener type, listener, true
 
     # Only for tests.  This gives us a hook to test the status of the permanently-installed instance.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -525,7 +525,7 @@ onKeydown = (event) ->
       if (event.altKey)
         modifiers.push("a")
 
-      for i of modifiers
+      for own i of modifiers
         keyChar = modifiers[i] + "-" + keyChar
 
       if (modifiers.length > 0 || keyChar.length > 1)

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -285,7 +285,7 @@ String::reverse = -> @split("").reverse().join ""
 
 globalRoot = window ? global
 globalRoot.extend = (hash1, hash2) ->
-  for key of hash2
+  for own key of hash2
     hash1[key] = hash2[key]
   hash1
 

--- a/pages/help_dialog.coffee
+++ b/pages/help_dialog.coffee
@@ -33,7 +33,7 @@ HelpDialog =
   isReady: -> true
 
   show: (html) ->
-    for placeholder, htmlString of html
+    for own placeholder, htmlString of html
       @dialogElement.querySelector("#help-dialog-#{placeholder}").innerHTML = htmlString
 
     @showAdvancedCommands(@getShowAdvancedCommands())

--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -16,7 +16,7 @@ document.addEventListener "keydown", (event) ->
   inputElement = document.getElementById "hud-find-input"
   return unless inputElement? # Don't do anything if we're not in find mode.
   transferrableEvent = {}
-  for key, value of event
+  for own key, value of event
     transferrableEvent[key] = value if typeof value in ["number", "string"]
 
   if (event.keyCode in [keyCodes.backspace, keyCodes.deleteKey] and inputElement.textContent.length == 0) or

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -255,7 +255,7 @@ initOptionsPage = ->
       saveOptions()
 
   # Populate options. The constructor adds each new object to "Option.all".
-  for name, type of Options
+  for own name, type of Options
     new type(name,onUpdated)
 
   maintainLinkHintsView()

--- a/tests/unit_tests/commands_test.coffee
+++ b/tests/unit_tests/commands_test.coffee
@@ -15,15 +15,15 @@ context "Validate commands and options",
   should "have either noRepeat or repeatLimit, but not both", ->
     # TODO(smblott) For this and each following test, is there a way to structure the tests such that the name
     # of the offending command appears in the output, if the test fails?
-    for command, options of Commands.availableCommands
+    for own command, options of Commands.availableCommands
       assert.isTrue not (options.noRepeat and options.repeatLimit)
 
   should "describe each command", ->
-    for command, options of Commands.availableCommands
+    for own command, options of Commands.availableCommands
       assert.equal 'string', typeof options.description
 
   should "define each command in each command group", ->
-    for group, commands of Commands.commandGroups
+    for own group, commands of Commands.commandGroups
       for command in commands
         assert.equal 'string', typeof command
         assert.isTrue Commands.availableCommands[command]
@@ -36,13 +36,13 @@ context "Validate commands and options",
   should "have valid commands for each default key mapping", ->
     count = Object.keys(Commands.keyToCommandRegistry).length
     assert.isTrue (0 < count)
-    for key, command of Commands.keyToCommandRegistry
+    for own key, command of Commands.keyToCommandRegistry
       assert.equal 'object', typeof command
       assert.isTrue Commands.availableCommands[command.command]
 
 context "Validate advanced commands",
   setup ->
-    @allCommands = [].concat.apply [], (commands for group, commands of Commands.commandGroups)
+    @allCommands = [].concat.apply [], (commands for own group, commands of Commands.commandGroups)
 
   should "include each advanced command in a command group", ->
     for command in Commands.advancedCommands

--- a/tests/unit_tests/test_helper.coffee
+++ b/tests/unit_tests/test_helper.coffee
@@ -1,5 +1,5 @@
 require("../shoulda.js/shoulda.js")
 global.extend = (hash1, hash2) ->
-  for key of hash2
+  for own key of hash2
     hash1[key] = hash2[key]
   hash1


### PR DESCRIPTION
This is a redo of #1265. From there:

> This stops us traversing object prototypes when we're only interested in their direct properties.