### PR TITLE
Do not recognise digits as valid first keys if Shift is depressed.

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -585,7 +585,7 @@ window.refreshCompletionKeys = (response) ->
 
 isValidFirstKey = (keyChar, event) ->
   # Digits are valid first keys only if Shift is not depressed; see #1996 and #1757.
-  validFirstKeys[keyChar] || (not event.shiftKey and /^[1-9]/.test keyChar)
+  validFirstKeys[keyChar] || (KeyboardUtils.hasNoModifiers(event) and /^[1-9]/.test keyChar)
 
 window.handleEscapeForFindMode = ->
   document.body.classList.remove("vimiumFindMode")

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -491,7 +491,7 @@ handlerStack.push
 onKeypress = (event) ->
   keyChar = KeyboardUtils.getKeyCharString event
   if keyChar
-    if currentCompletionKeys.indexOf(keyChar) != -1 or isValidFirstKey keyChar
+    if currentCompletionKeys.indexOf(keyChar) != -1 or isValidFirstKey keyChar, event
       DomUtils.suppressEvent(event)
       keyPort.postMessage keyChar:keyChar, frameId:frameId
       return @stopBubblingAndTrue
@@ -512,7 +512,7 @@ onKeydown = (event) ->
 
   else
     if (keyChar)
-      if (currentCompletionKeys.indexOf(keyChar) != -1 or isValidFirstKey(keyChar))
+      if (currentCompletionKeys.indexOf(keyChar) != -1 or isValidFirstKey keyChar, event)
         DomUtils.suppressEvent event
         KeydownEvents.push event
         keyPort.postMessage({ keyChar:keyChar, frameId:frameId })
@@ -532,7 +532,7 @@ onKeydown = (event) ->
   # TOOD(ilya): Revisit this. Not sure it's the absolute best approach.
   if not keyChar &&
      (currentCompletionKeys.indexOf(KeyboardUtils.getKeyChar(event)) != -1 ||
-      isValidFirstKey(KeyboardUtils.getKeyChar(event)))
+      isValidFirstKey KeyboardUtils.getKeyChar(event), event)
     DomUtils.suppressPropagation(event)
     KeydownEvents.push event
     return @stopBubblingAndTrue
@@ -583,8 +583,9 @@ window.refreshCompletionKeys = (response) ->
   else
     chrome.runtime.sendMessage({ handler: "getCompletionKeys" }, refreshCompletionKeys)
 
-isValidFirstKey = (keyChar) ->
-  validFirstKeys[keyChar] || /^[1-9]/.test(keyChar)
+isValidFirstKey = (keyChar, event) ->
+  # Digits are valid first keys only if Shift is not depressed; see #1996 and #1757.
+  validFirstKeys[keyChar] || (not event.shiftKey and /^[1-9]/.test keyChar)
 
 window.handleEscapeForFindMode = ->
   document.body.classList.remove("vimiumFindMode")

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -94,6 +94,9 @@ KeyboardUtils =
             keyChar = [modifiers..., keyChar].join "-"
             if 1 < keyChar.length then "<#{keyChar}>" else keyChar
 
+  hasNoModifiers: (event) ->
+    not (event.shiftKey or event.metaKey or event.ctrlKey or event.metaKey)
+
 KeyboardUtils.init()
 
 root = exports ? window


### PR DESCRIPTION
Currently, we cannot set passkeys for symbols accessed with `Shift` depressed on a digit key: e.g. `$`, `*`.  This affects native keyboard shortcuts in GMail.

@mrmr1993.  This would be fixed if we had `event.key`, right?  In the meantime, is this fix correct?  Surely there are no keyboards with digits requiring the `Shift` key?

Fixes #1996.
Fixes #1757.