### PR TITLE
hideHUD option applies to insert mode only.

### DIFF
--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -87,8 +87,7 @@ HUD =
     DomUtils.documentReady -> ready = true
     -> ready and document.body != null
 
-  # A preference which can be toggled in the Options page. */
-  enabled: -> !Settings.get("hideHud")
+  enabled: -> true
 
 class Tween
   opacity: 0

--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -30,7 +30,7 @@ class InsertMode extends Mode
 
     defaults =
       name: "insert"
-      indicator: if @permanent then null else "Insert mode"
+      indicator: if not @permanent and not Settings.get "hideHud"  then "Insert mode"
       keypress: handleKeyEvent
       keyup: handleKeyEvent
       keydown: handleKeyEvent

--- a/pages/options.html
+++ b/pages/options.html
@@ -163,12 +163,12 @@ b: http://b.com/?q=%s description
             <td verticalAlign="top" class="booleanOption">
               <div class="help">
                 <div class="example">
-                  When enabled, the HUD will not be displayed.
+                  When enabled, the HUD will not be displayed in insert mode.
                 </div>
               </div>
               <label>
                 <input id="hideHud" type="checkbox"/>
-                Hide the Heads Up Display (HUD)
+                Hide the Heads Up Display (HUD) in insert mode
               </label>
             </td>
           </tr>


### PR DESCRIPTION
This makes the `hideHud` option apply only to insert mode (when entered with `i`).

Fixes #1953.
Fixes #487.

We could rename the option itself and add migration code, but that seems overkill.

An alternative would be to remove this option entirely.