### PR TITLE
Add count command option

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -56,7 +56,7 @@ Commands =
             if command? and @availableCommands[command]
               key = @normalizeKey key
               logMessage? "Mapping #{key} to #{command}"
-              @mapKeyToCommand { key, command, options: @parseCommandOptions optionList }
+              @mapKeyToCommand { key, command, options: @parseCommandOptions command, optionList }
 
           when "unmap"
             if tokens.length == 2
@@ -77,7 +77,7 @@ Commands =
   # Command options follow command mappings, and are of one of two forms:
   #   key=value     - a value
   #   key           - a flag
-  parseCommandOptions: (optionList) ->
+  parseCommandOptions: (command, optionList) ->
     options = {}
     for option in optionList
       parse = option.split "="
@@ -88,6 +88,11 @@ Commands =
           options[parse[0]] = parse[1]
         else
           console.log "Vimium configuration error: invalid option: #{option}."
+
+    # We parse any `count` option immediately (to avoid having to parse it repeatedly later).
+    unless @availableCommands[command].noRepeat
+      options.count = try Math.max 1, parseInt options.count
+
     options
 
   clearKeyMappingsAndSetDefaults: ->

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -80,14 +80,8 @@ Commands =
   parseCommandOptions: (command, optionList) ->
     options = {}
     for option in optionList
-      parse = option.split "="
-      switch parse.length
-        when 1
-          options[parse[0]] = true
-        when 2
-          options[parse[0]] = parse[1]
-        else
-          console.log "Vimium configuration error: invalid option: #{option}."
+      parse = option.split "=", 2
+      options[parse[0]] = if parse.length == 1 then true else parse[1]
 
     # We parse any `count` option immediately (to avoid having to parse it repeatedly later).
     unless @availableCommands[command].noRepeat

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -52,11 +52,11 @@ Commands =
         tokens = line.replace(/\s+$/, "").split /\s+/
         switch tokens[0]
           when "map"
-            [ _, key, command, options... ] = tokens
+            [ _, key, command, optionList... ] = tokens
             if command? and @availableCommands[command]
               key = @normalizeKey key
               logMessage? "Mapping #{key} to #{command}"
-              @mapKeyToCommand { key, command, options }
+              @mapKeyToCommand { key, command, options: @parseCommandOptions optionList }
 
           when "unmap"
             if tokens.length == 2
@@ -73,6 +73,22 @@ Commands =
     # mode.
     Settings.set "passNextKeyKeys",
       (key for own key of @keyToCommandRegistry when @keyToCommandRegistry[key].command == "passNextKey" and 1 < key.length)
+
+  # Command options follow command mappings, and are of one of two forms:
+  #   key=value     - a value
+  #   key           - a flag
+  parseCommandOptions: (optionList) ->
+    options = {}
+    for option in optionList
+      parse = option.split "="
+      switch parse.length
+        when 1
+          options[parse[0]] = true
+        when 2
+          options[parse[0]] = parse[1]
+        else
+          console.log "Vimium configuration error: invalid option: #{option}."
+    options
 
   clearKeyMappingsAndSetDefaults: ->
     @keyToCommandRegistry = {}

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -573,6 +573,8 @@ checkKeyQueue = (keysToCheck, tabId, frameId) ->
       """
 
     if runCommand
+      # Account for any command-option "count".
+      count *= registryEntry.options.count ? 1
       if not registryEntry.isBackgroundCommand
         chrome.tabs.sendMessage tabId,
           name: "executePageCommand"

--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -10,18 +10,7 @@ Vomnibar =
     options = {}
     searchEngines = Settings.get("searchEngines") ? ""
     SearchEngines.refreshAndUse searchEngines, (engines) ->
-      for option in registryEntry.options
-        [ key, value ] = option.split "="
-        switch key
-          when "keyword"
-            if value? and engines[value]?
-              options.keyword = value
-            else
-              console.log "Vimium configuration error: no such custom search engine: #{option}."
-          else
-              console.log "Vimium configuration error: unused flag: #{option}."
-
-      callback? options
+      callback? registryEntry.options
 
   # sourceFrameId here (and below) is the ID of the frame from which this request originates, which may be different
   # from the current frame.


### PR DESCRIPTION
Examples:

    # This approximates a closeWindow command.
    map q removeTab count=9999
    
    # This approximates LinkHints.activateModeWithQueue.
    map <a-f> LinkHints.activateModeToOpenInNewTab count=9999
    
    # Download many links.
    map <a-d> LinkHints.activateModeToDownloadLink count=9999
    
    # Have multiple scroll speeds.
    map J scrollDown count=3

Currently, there are two commits:

- 61ce82be4acae20562bb2ccb93ff64772ba553c1 just refactors (and generalises) the command-option parsing.  Previously it was in the vomnibar code (which was silly), now it's in `commands.coffee`.

- 2c634d9b2324c760007d59d5cafd97a364125991 adds the `count=N` command option.