### PR TITLE
Make `moveToNewWindow` accept a count.

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -329,7 +329,7 @@ commandDescriptions =
     (if chrome.session then chrome.session.MAX_SESSION_RESULTS else 25) }]
   restoreTab: ["Restore closed tab", { background: true, repeatLimit: 20 }]
 
-  moveTabToNewWindow: ["Move tab to new window", { background: true }]
+  moveTabToNewWindow: ["Move tab to new window", { background: true, passCountToFunction: true }]
   togglePinTab: ["Pin/unpin current tab", { background: true }]
 
   closeTabsOnLeft: ["Close tabs on the left", {background: true, noRepeat: true}]

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -275,10 +275,14 @@ BackgroundCommands =
     chrome.tabs.getSelected(null, (tab) ->
       chrome.tabs.duplicate(tab.id)
       selectionChangedHandlers.push(callback))
-  moveTabToNewWindow: (callback) ->
-    chrome.tabs.query {active: true, currentWindow: true}, (tabs) ->
-      tab = tabs[0]
-      chrome.windows.create {tabId: tab.id, incognito: tab.incognito}
+  moveTabToNewWindow: (count) ->
+    chrome.tabs.query {currentWindow: true}, (tabs) ->
+      chrome.tabs.query {currentWindow: true, active: true}, (activeTabs) ->
+        activeTabIndex = activeTabs[0].index
+        startTabIndex = Math.max 0, Math.min activeTabIndex, tabs.length - count
+        [ tab, tabs... ] = tabs[startTabIndex...startTabIndex + count]
+        chrome.windows.create {tabId: tab.id, incognito: tab.incognito}, (window) ->
+          chrome.tabs.move (tab.id for tab in tabs), {windowId: window.id, index: -1}
   nextTab: (count) -> selectTab "next", count
   previousTab: (count) -> selectTab "previous", count
   firstTab: (count) -> selectTab "first", count


### PR DESCRIPTION
This make `moveToNewWindow` accept a count.  For example, `3W` to move three tabs to (the same) new window.

The tabs chosen are the current tab, then those to the right of the current tab, and then those to the left of the current tab.

`999W` moves *all* tabs to a new window.  It's not clear why you would want to do that.  An alternative would be to leave the last tab behind.