### PR TITLE
Remove (unused) `tabInfoMap`.

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -772,12 +772,6 @@ DomUtils.documentReady initializeOnDomReady
 DomUtils.documentReady registerFrame
 window.addEventListener "unload", unregisterFrame
 
-window.onbeforeunload = ->
-  chrome.runtime.sendMessage(
-    handler: "updateScrollPosition"
-    scrollX: window.scrollX
-    scrollY: window.scrollY)
-
 root = exports ? window
 root.handlerStack = handlerStack
 root.frameId = frameId


### PR DESCRIPTION
It appears `tabInfoMap` (and related machinery) is not being used.  This removes it.

@mrmr1993 -- Could you double check this, please?