### PR TITLE
Fix `<count>removeTab`.

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -339,7 +339,7 @@ commandDescriptions =
 
   createTab: ["Create new tab", { background: true, repeatLimit: 20 }]
   duplicateTab: ["Duplicate current tab", { background: true, repeatLimit: 20 }]
-  removeTab: ["Close current tab", { background: true, repeatLimit:
+  removeTab: ["Close current tab", { background: true, passCountToFunction: true, repeatLimit:
     # Require confirmation to remove more tabs than we can restore.
     (if chrome.session then chrome.session.MAX_SESSION_RESULTS else 25) }]
   restoreTab: ["Restore closed tab", { background: true, repeatLimit: 20 }]

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -286,10 +286,12 @@ BackgroundCommands =
   previousTab: (count) -> selectTab "previous", count
   firstTab: (count) -> selectTab "first", count
   lastTab: (count) -> selectTab "last", count
-  removeTab: (callback) ->
-    chrome.tabs.getSelected(null, (tab) ->
-      chrome.tabs.remove(tab.id)
-      selectionChangedHandlers.push(callback))
+  removeTab: (count) ->
+    chrome.tabs.query {currentWindow: true}, (tabs) ->
+      chrome.tabs.query {currentWindow: true, active: true}, (activeTabs) ->
+        activeTabIndex = activeTabs[0].index
+        startTabIndex = Math.max 0, Math.min activeTabIndex, tabs.length - count
+        chrome.tabs.remove (tab.id for tab in tabs[startTabIndex...startTabIndex + count])
   restoreTab: (callback) ->
     chrome.sessions.restore null, ->
         callback() unless chrome.runtime.lastError


### PR DESCRIPTION
There's a nasty little bug in `removeTab` when you remove more tabs than there are in the window (and there is a second window):

- all of the tabs in the currently-focused window are removed
- then, later (so, time passes), when you change tab in the other window, we begin removing tabs again!

The source of the bug is our reliance on `chrome.tabs.onSelectionChanged`, which doesn't fire when removing the last tab in a window (and there is another window).

Regardless, the previous semantics of `<count>removeTab` was questionable.  It was preactically impossible to predict which tabs would removed.  This picks the current tab, then those to the right of the current tab, then those to the left.  And never removes tabs in other windows.