### PR TITLE
use chrome.windows.onFocusChanged to listen window switching

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -44,5 +44,6 @@ Contributors:
   Shiyong Chen <billbill290@gmail.com> (github: UncleBill)
   Utkarsh Upadhyay <musically.ut@gmail.com) (github: musically-ut)
   Michael Salihi <admin@prestance-informatique.fr> (github: PrestanceDesign)
+  Dahan Gong <gdh1995@qq.com> (github: gdh1995)
 
 Feel free to add real names in addition to GitHub usernames.

--- a/background_scripts/bg_utils.coffee
+++ b/background_scripts/bg_utils.coffee
@@ -18,6 +18,13 @@ class TabRecency
       @deregister removedTabId
       @register addedTabId
 
+    self = @
+    chrome.windows.onFocusChanged.addListener (wnd) ->
+      return if wnd == chrome.windows.WINDOW_ID_NONE
+      chrome.tabs.query {windowId: wnd, active: true}, (tabs) ->
+        self.register tabs[0].id if tabs[0]
+        chrome.runtime.lastError
+
   register: (tabId) ->
     currentTime = new Date()
     # Register tabId if it has been visited for at least @timeDelta ms.  Tabs which are visited only for a

--- a/tests/unit_tests/test_chrome_stubs.coffee
+++ b/tests/unit_tests/test_chrome_stubs.coffee
@@ -60,6 +60,8 @@ exports.chrome =
     onRemoved:
       addListener: () -> true
     getAll: () -> true
+    onFocusChanged:
+      addListener: () -> true
 
   browserAction:
     setBadgeBackgroundColor: ->


### PR DESCRIPTION
This fix the problem that `chrome.tabs.onActivated` won't be triggered
when we switch Chrome windows.

fix #2005.