### PR TITLE
declare min(chrome.ver) as 37 since we moved to chrome.sessions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": 2,
   "name": "Vimium",
   "version": "1.54",
+  "minimum_chrome_version": "37.0",
   "description": "The Hacker's Browser. Vimium provides keyboard shortcuts for navigation and control in the spirit of Vim.",
   "icons": {  "16": "icons/icon16.png",
               "48": "icons/icon48.png",


### PR DESCRIPTION
Chrome's sessions functionality began from version 37, so we may declare it in Vimium's manifest.