### PR TITLE
Rework the `duplicateTab` implementation...

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -339,7 +339,7 @@ commandDescriptions =
   lastTab: ["Go to the last tab", { background: true, passCountToFunction: true }]
 
   createTab: ["Create new tab", { background: true, repeatLimit: 20 }]
-  duplicateTab: ["Duplicate current tab", { background: true, repeatLimit: 20 }]
+  duplicateTab: ["Duplicate current tab", { background: true, passCountToFunction: true, repeatLimit: 20 }]
   removeTab: ["Close current tab", { background: true, repeatLimit:
     # Require confirmation to remove more tabs than we can restore.
     (if chrome.session then chrome.session.MAX_SESSION_RESULTS else 25) }]

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -270,10 +270,11 @@ BackgroundCommands =
         # "pages/blank.html" does not work in incognito mode, so fall back to "chrome://newtab" instead.
         url = if tab.incognito then "chrome://newtab" else chrome.runtime.getURL url
       TabOperations.openUrlInNewTab { url }, callback
-  duplicateTab: (callback) ->
-    chrome.tabs.getSelected(null, (tab) ->
-      chrome.tabs.duplicate(tab.id)
-      selectionChangedHandlers.push(callback))
+  duplicateTab: (count) ->
+    chrome.tabs.getSelected null, (tab) ->
+      createTab = (tab) ->
+        chrome.tabs.duplicate tab.id, createTab if 0 < count--
+      createTab tab
   moveTabToNewWindow: (count) ->
     chrome.tabs.query {currentWindow: true}, (tabs) ->
       chrome.tabs.query {currentWindow: true, active: true}, (activeTabs) ->


### PR DESCRIPTION
Specifically, avoid reliance on `chrome.tabs.onSelectionChanged`.

If we merge this and #2006, then we can delete all of the `chrome.tabs.onSelectionChanged` code.