### PR TITLE
Use for (not for own) when iterating over an event's properties

### DIFF
--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -16,7 +16,8 @@ document.addEventListener "keydown", (event) ->
   inputElement = document.getElementById "hud-find-input"
   return unless inputElement? # Don't do anything if we're not in find mode.
   transferrableEvent = {}
-  for own key, value of event
+  # NOTE(mrmr1993): We use for, not for own, here, since we want to access members from the Event prototype.
+  for key, value of event
     transferrableEvent[key] = value if typeof value in ["number", "string"]
 
   if (event.keyCode in [keyCodes.backspace, keyCodes.deleteKey] and inputElement.textContent.length == 0) or


### PR DESCRIPTION
Moving to `for own` broke find mode history (and thus also next/previous).

This reverts that part of commit 56fed2ac6663d99ca03023f3ffa313c51de5fe32.