### PR TITLE
Add install date to logging page.

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -658,5 +658,10 @@ showUpgradeMessage = ->
 
 showUpgradeMessage()
 
+# The install date is shown on the logging page.
+chrome.runtime.onInstalled.addListener ({reason}) ->
+  unless reason in ["chrome_update", "shared_module_update"]
+    chrome.storage.local.set installDate: new Date().toString()
+
 root.TabOperations = TabOperations
 root.logMessage = logMessage

--- a/pages/logging.coffee
+++ b/pages/logging.coffee
@@ -8,7 +8,11 @@ document.addEventListener "DOMContentLoaded", ->
 
   branchRefRequest = new XMLHttpRequest()
   branchRefRequest.addEventListener "load", ->
-    $("branchRef").innerText = branchRefRequest.responseText
+    branchRefParts = branchRefRequest.responseText.split "refs/heads/", 2
+    if branchRefParts.length == 2
+      $("branchRef").innerText = branchRefParts[1]
+    else
+      $("branchRef").innerText = "HEAD detatched at #{branchRefParts[0]}"
     $("branchRef-wrapper").classList.add "no-hide"
   branchRefRequest.open "GET", chrome.extension.getURL ".git/HEAD"
   branchRefRequest.send()

--- a/pages/logging.coffee
+++ b/pages/logging.coffee
@@ -2,6 +2,14 @@ $ = (id) -> document.getElementById id
 
 document.addEventListener "DOMContentLoaded", ->
   $("vimiumVersion").innerText = Utils.getCurrentVersion()
+
   chrome.storage.local.get "installDate", (items) ->
     $("installDate").innerText = items.installDate.toString()
+
+  branchRefRequest = new XMLHttpRequest()
+  branchRefRequest.addEventListener "load", ->
+    $("branchRef").innerText = branchRefRequest.responseText
+    $("branchRef-wrapper").classList.add "no-hide"
+  branchRefRequest.open "GET", chrome.extension.getURL ".git/HEAD"
+  branchRefRequest.send()
 

--- a/pages/logging.coffee
+++ b/pages/logging.coffee
@@ -3,8 +3,5 @@ $ = (id) -> document.getElementById id
 document.addEventListener "DOMContentLoaded", ->
   $("vimiumVersion").innerText = Utils.getCurrentVersion()
   chrome.storage.local.get "installDate", (items) ->
-    console.log new Date
-    console.log items
-    console.log items.installDate, items.installDate.toString()
     $("installDate").innerText = items.installDate.toString()
 

--- a/pages/logging.coffee
+++ b/pages/logging.coffee
@@ -1,0 +1,10 @@
+$ = (id) -> document.getElementById id
+
+document.addEventListener "DOMContentLoaded", ->
+  $("vimiumVersion").innerText = Utils.getCurrentVersion()
+  chrome.storage.local.get "installDate", (items) ->
+    console.log new Date
+    console.log items
+    console.log items.installDate, items.installDate.toString()
+    $("installDate").innerText = items.installDate.toString()
+

--- a/pages/logging.html
+++ b/pages/logging.html
@@ -24,6 +24,12 @@
         width: 100%;
         height: 80%;
       }
+      #branchRef-wrapper {
+        display: none;
+      }
+      #branchRef-wrapper.no-hide {
+        display: block;
+      }
     </style>
   </head>
 
@@ -35,6 +41,7 @@
       <br />
       Version: <span id="vimiumVersion"></span><br />
       Installed: <span id="installDate"></span>
+      <div id="branchRef-wrapper">Branch: <span id="branchRef"></span></div>
     </div>
   </body>
 </html>

--- a/pages/logging.html
+++ b/pages/logging.html
@@ -2,6 +2,7 @@
   <head>
     <title>Vimium Options</title>
     <script src="content_script_loader.js"></script>
+    <script src="logging.js"></script>
     <style type="text/css">
       body {
         font: 14px "DejaVu Sans", "Arial", sans-serif;
@@ -32,6 +33,8 @@
       <br />
       <textarea id="log-text" readonly></textarea>
       <br />
+      Version: <span id="vimiumVersion"></span><br />
+      Installed: <span id="installDate"></span>
     </div>
   </body>
 </html>


### PR DESCRIPTION
This implements a poor-man's build info.

See #1352.  Unfortunately, that requires a separate build target, and does not work with `cake autobuild`.

This just records the *install date* and displays that info on the logging page.  "Install date" because we can reliably determine it, and because it does answer the question *have I upgrade Vimium on this machine since last week?*.  And on the logging page because that's out of the way, and not part of the regular Vimium interface.

![snapshot](https://cloud.githubusercontent.com/assets/2641335/13215490/928493ba-d94d-11e5-88e4-e800d247630c.png)
