### PR TITLE
Treat mappings as arrays

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -407,9 +407,9 @@ populateValidFirstKeys = ->
 
 populateSingleKeyCommands = ->
   singleKeyCommands = []
-  for own key of Commands.keyToCommandRegistry
-    if (getActualKeyStrokeLength(key) == 1)
-      singleKeyCommands.push(key)
+  for keys in commandKeys
+    if (keys.length == 1)
+      singleKeyCommands.push(keys[0])
 
 populateCommandKeys = ->
   commandKeys = []

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -21,6 +21,7 @@ chrome.runtime.onInstalled.addListener ({ reason }) ->
 currentVersion = Utils.getCurrentVersion()
 keyQueue = "" # Queue of keys typed
 validFirstKeys = {}
+commandKeys = []
 singleKeyCommands = []
 frameIdsForTab = {}
 root.urlForTab = {}
@@ -196,6 +197,7 @@ getCompletionKeysRequest = (request, keysToCheck = "") ->
   name: "refreshCompletionKeys"
   completionKeys: generateCompletionKeys(keysToCheck)
   validFirstKeys: validFirstKeys
+  commandKeys: commandKeys
 
 TabOperations =
   # Opens the url in the current tab.
@@ -407,11 +409,21 @@ populateSingleKeyCommands = ->
     if (getActualKeyStrokeLength(key) == 1)
       singleKeyCommands.push(key)
 
+populateCommandKeys = ->
+  for key of Commands.keyToCommandRegistry
+    splitKey = splitKeyIntoFirstAndSecond(key)
+    if splitKey.second
+      commandKeys.push [splitKey.first, splitKey.second]
+    else
+      commandKeys.push [splitKey.first]
+
 # Invoked by options.coffee.
 root.refreshCompletionKeysAfterMappingSave = ->
   validFirstKeys = {}
   singleKeyCommands = []
+  commandKeys = []
 
+  populateCommandKeys()
   populateValidFirstKeys()
   populateSingleKeyCommands()
 
@@ -629,6 +641,7 @@ Commands.clearKeyMappingsAndSetDefaults()
 if Settings.has("keyMappings")
   Commands.parseCustomKeyMappings(Settings.get("keyMappings"))
 
+populateCommandKeys()
 populateValidFirstKeys()
 populateSingleKeyCommands()
 

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -197,7 +197,6 @@ getCompletionKeysRequest = (request, keysToCheck = "") ->
   name: "refreshCompletionKeys"
   completionKeys: generateCompletionKeys(keysToCheck)
   validFirstKeys: validFirstKeys
-  commandKeys: commandKeys
 
 TabOperations =
   # Opens the url in the current tab.

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -437,10 +437,8 @@ generateCompletionKeys = (keysToCheck) ->
   completionKeys = singleKeyCommands.slice(0)
 
   if (getActualKeyStrokeLength(command) == 1)
-    for own key of Commands.keyToCommandRegistry
-      splitKey = splitKeyIntoFirstAndSecond(key)
-      if (splitKey.first == command)
-        completionKeys.push(splitKey.second)
+    for keys in commandKeys
+      completionKeys.push keys[1] if keys[0] == command
 
   completionKeys
 

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -401,9 +401,9 @@ getActualKeyStrokeLength = (key) ->
 
 populateValidFirstKeys = ->
   validFirstKeys = {}
-  for own key of Commands.keyToCommandRegistry
-    if (getActualKeyStrokeLength(key) == 2)
-      validFirstKeys[splitKeyIntoFirstAndSecond(key).first] = true
+  for keys in commandKeys
+    if (keys.length > 1)
+      validFirstKeys[keys[0]] = true
 
 populateSingleKeyCommands = ->
   singleKeyCommands = []

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -400,16 +400,19 @@ getActualKeyStrokeLength = (key) ->
     key.length
 
 populateValidFirstKeys = ->
+  validFirstKeys = {}
   for own key of Commands.keyToCommandRegistry
     if (getActualKeyStrokeLength(key) == 2)
       validFirstKeys[splitKeyIntoFirstAndSecond(key).first] = true
 
 populateSingleKeyCommands = ->
+  singleKeyCommands = []
   for own key of Commands.keyToCommandRegistry
     if (getActualKeyStrokeLength(key) == 1)
       singleKeyCommands.push(key)
 
 populateCommandKeys = ->
+  commandKeys = []
   for key of Commands.keyToCommandRegistry
     splitKey = splitKeyIntoFirstAndSecond(key)
     if splitKey.second
@@ -419,10 +422,6 @@ populateCommandKeys = ->
 
 # Invoked by options.coffee.
 root.refreshCompletionKeysAfterMappingSave = ->
-  validFirstKeys = {}
-  singleKeyCommands = []
-  commandKeys = []
-
   populateCommandKeys()
   populateValidFirstKeys()
   populateSingleKeyCommands()

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -13,6 +13,7 @@ keyQueue = null
 # The user's operating system.
 currentCompletionKeys = ""
 validFirstKeys = ""
+commandKeys = []
 
 # We track whther the current window has the focus or not.
 windowIsFocused = do ->
@@ -580,6 +581,8 @@ window.refreshCompletionKeys = (response) ->
 
     if (response.validFirstKeys)
       validFirstKeys = response.validFirstKeys
+    if (response.commandKeys)
+      commandKeys = response.commandKeys
   else
     chrome.runtime.sendMessage({ handler: "getCompletionKeys" }, refreshCompletionKeys)
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -13,7 +13,6 @@ keyQueue = null
 # The user's operating system.
 currentCompletionKeys = ""
 validFirstKeys = ""
-commandKeys = []
 
 # We track whther the current window has the focus or not.
 windowIsFocused = do ->
@@ -581,8 +580,6 @@ window.refreshCompletionKeys = (response) ->
 
     if (response.validFirstKeys)
       validFirstKeys = response.validFirstKeys
-    if (response.commandKeys)
-      commandKeys = response.commandKeys
   else
     chrome.runtime.sendMessage({ handler: "getCompletionKeys" }, refreshCompletionKeys)
 


### PR DESCRIPTION
This cherry picks some commits from my branch [here](https://github.com/mrmr1993/vimium/tree/rebase-normal-mode-mappings-in-frontend), which is a rebase of #1775.

This introduces `commandKeys`, an array of arrays of keys which represent the normal mode mappings. The main benefit of this is that we can avoid evaluating the regex `namedKeyRegex` 4 times (or more, for 2-key mappings).