### PR TITLE
Pass to count to scroll commands.

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -278,20 +278,20 @@ defaultKeyMappings =
 commandDescriptions =
   # Navigating the current page
   showHelp: ["Show help", { background: true }]
-  scrollDown: ["Scroll down"]
-  scrollUp: ["Scroll up"]
-  scrollLeft: ["Scroll left"]
-  scrollRight: ["Scroll right"]
+  scrollDown: ["Scroll down", { passCountToFunction: true }]
+  scrollUp: ["Scroll up", { passCountToFunction: true }]
+  scrollLeft: ["Scroll left", { passCountToFunction: true }]
+  scrollRight: ["Scroll right", { passCountToFunction: true }]
 
   scrollToTop: ["Scroll to the top of the page", { passCountToFunction: true }]
   scrollToBottom: ["Scroll to the bottom of the page", { noRepeat: true }]
   scrollToLeft: ["Scroll all the way to the left", { noRepeat: true }]
   scrollToRight: ["Scroll all the way to the right", { noRepeat: true }]
 
-  scrollPageDown: ["Scroll a page down"]
-  scrollPageUp: ["Scroll a page up"]
-  scrollFullPageDown: ["Scroll a full page down"]
-  scrollFullPageUp: ["Scroll a full page up"]
+  scrollPageDown: ["Scroll a page down", { passCountToFunction: true }]
+  scrollPageUp: ["Scroll a page up", { passCountToFunction: true }]
+  scrollFullPageDown: ["Scroll a full page down", { passCountToFunction: true }]
+  scrollFullPageUp: ["Scroll a full page up", { passCountToFunction: true }]
 
   reload: ["Reload the page", { noRepeat: true }]
   toggleViewSource: ["View page source", { noRepeat: true }]

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -312,14 +312,14 @@ extend window,
     Scroller.scrollTo "y", (count - 1) * Settings.get("scrollStepSize")
   scrollToLeft: -> Scroller.scrollTo "x", 0
   scrollToRight: -> Scroller.scrollTo "x", "max"
-  scrollUp: -> Scroller.scrollBy "y", -1 * Settings.get("scrollStepSize")
-  scrollDown: -> Scroller.scrollBy "y", Settings.get("scrollStepSize")
-  scrollPageUp: -> Scroller.scrollBy "y", "viewSize", -1/2
-  scrollPageDown: -> Scroller.scrollBy "y", "viewSize", 1/2
-  scrollFullPageUp: -> Scroller.scrollBy "y", "viewSize", -1
-  scrollFullPageDown: -> Scroller.scrollBy "y", "viewSize"
-  scrollLeft: -> Scroller.scrollBy "x", -1 * Settings.get("scrollStepSize")
-  scrollRight: -> Scroller.scrollBy "x", Settings.get("scrollStepSize")
+  scrollUp: (count) -> Scroller.scrollBy "y", -1 * Settings.get("scrollStepSize") * count
+  scrollDown: (count) -> Scroller.scrollBy "y", Settings.get("scrollStepSize") * count
+  scrollPageUp: (count) -> Scroller.scrollBy "y", "viewSize", -1/2 * count
+  scrollPageDown: (count) -> Scroller.scrollBy "y", "viewSize", 1/2 * count
+  scrollFullPageUp: (count) -> Scroller.scrollBy "y", "viewSize", -1 * count
+  scrollFullPageDown: (count) -> Scroller.scrollBy "y", "viewSize", 1 * count
+  scrollLeft: (count) -> Scroller.scrollBy "x", -1 * Settings.get("scrollStepSize") * count
+  scrollRight: (count) -> Scroller.scrollBy "x", Settings.get("scrollStepSize") * count
 
 extend window,
   reload: -> window.location.reload()


### PR DESCRIPTION
Currently, `10j` keeping `j` held down scrolls quickly for a time then reduces back the regular hold-`j` scroll speed.  Therefore, the user cannot use a count to influence the smooth-scrolling scroll speed.

This PR fixes that by passing the count to the scroll functions.  Consequently, we adjust the actual scroll amount (which affects the scroll speed) rather than calling the scroll commands several times (which doesn't).