### PR TITLE
A small refactor link hints.

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -43,8 +43,6 @@ class LinkHintsMode
   mode: undefined
   # Function that does the appropriate action on the selected link.
   linkActivator: undefined
-  # Lock to ensure only one instance runs at a time.
-  isActive: false
   # The link-hints "mode" (in the key-handler, indicator sense).
   hintMode: null
   # Call this function on exit (if defined).
@@ -55,7 +53,6 @@ class LinkHintsMode
   constructor: (mode = OPEN_IN_CURRENT_TAB, onExit = (->)) ->
     # we need documentElement to be ready in order to append links
     return unless document.documentElement
-    @isActive = true
 
     elements = @getVisibleClickableElements()
     # For these modes, we filter out those elements which don't have an HREF (since there's nothing we can do
@@ -88,7 +85,7 @@ class LinkHintsMode
       keypress: @onKeyPressInMode.bind this, hintMarkers
 
     @hintMode.onExit =>
-      @deactivateMode() if @isActive
+      @deactivateMode()
     @hintMode.onExit onExit
 
     @setOpenLinkMode mode
@@ -322,7 +319,7 @@ class LinkHintsMode
           keyup: (event) =>
             if event.keyCode == keyCode
               handlerStack.remove()
-              @setOpenLinkMode previousMode if @isActive
+              @setOpenLinkMode previousMode
             true # Continue bubbling the event.
 
         # For some (unknown) reason, we don't always receive the keyup event needed to remove this handler.
@@ -419,13 +416,8 @@ class LinkHintsMode
 
   deactivateMode: ->
     @removeHintMarkers()
-    @markerMatcher = null
-    @isActive = false
     @hintMode?.exit()
-    @hintMode = null
     @onExit?()
-    @onExit = null
-    @tabCount = 0
 
   removeHintMarkers: ->
     DomUtils.removeElement @hintMarkerContainingDiv if @hintMarkerContainingDiv

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -680,7 +680,7 @@ class WaitForEnter extends Mode
           callback()
           DomUtils.suppressEvent event
         else
-          true 
+          true
 
     flashEl = DomUtils.addFlashRect rect
     @onExit -> DomUtils.removeElement flashEl

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -376,9 +376,9 @@ class LinkHintsMode
   #
   # When only one link hint remains, this function activates it in the appropriate way.
   #
-  activateLink: (@matchedLink, {delay, waitForEnter} = {}) ->
+  activateLink: (linkMatched, {delay, waitForEnter} = {}) ->
     @removeHintMarkers()
-    clickEl = @matchedLink.clickableItem
+    clickEl = linkMatched.clickableItem
 
     linkActivator = =>
       @deactivateMode()
@@ -392,13 +392,13 @@ class LinkHintsMode
         LinkHints.activateModeWithQueue() if @mode is OPEN_WITH_QUEUE
 
     if waitForEnter? and waitForEnter
-      new WaitForEnter @matchedLink.rect, linkActivator
+      new WaitForEnter linkMatched.rect, linkActivator
     else if delay? and 0 < delay
       # Install a mode to block keyboard events if the user is still typing.  The intention is to prevent the
       # user from inadvertently launching Vimium commands when typing the link text.
-      new TypingProtector delay, @matchedLink?.rect, linkActivator
+      new TypingProtector delay, linkMatched?.rect, linkActivator
     else
-      DomUtils.flashRect @matchedLink.rect
+      DomUtils.flashRect linkMatched.rect
       linkActivator()
 
   #

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -393,7 +393,7 @@ class LinkHintsMode
     else if userMightOverType
       # Block keyboard events while the user is still typing.  The intention is to prevent the user from
       # inadvertently launching Vimium commands when (over-)typing the link text.
-      new TypingProtector 200, linkMatched?.rect, linkActivator
+      new TypingProtector 200, linkMatched.rect, linkActivator
     else
       DomUtils.flashRect linkMatched.rect
       linkActivator()
@@ -633,24 +633,22 @@ class TypingProtector extends Mode
   constructor: (delay, rect, callback) ->
     @timer = Utils.setTimeout delay, => @exit()
 
-    handler = (event) =>
+    resetExitTimer = (event) =>
       clearTimeout @timer
       @timer = Utils.setTimeout delay, => @exit()
 
     super
       name: "hint/typing-protector"
       suppressAllKeyboardEvents: true
-      keydown: handler
-      keypress: handler
-
-    if rect
-      # We keep a "flash" overlay active while the user is typing; this provides visual feeback that something
-      # has been selected.
-      flashEl = DomUtils.addFlashRect rect
-      @onExit -> DomUtils.removeElement flashEl
+      keydown: resetExitTimer
+      keypress: resetExitTimer
 
     @onExit callback
 
+    # We keep a "flash" overlay active while the user is typing; this provides visual feeback that something
+    # has been selected.
+    flashEl = DomUtils.addFlashRect rect
+    @onExit -> DomUtils.removeElement flashEl
 
 class WaitForEnter extends Mode
   constructor: (rect, callback) ->


### PR DESCRIPTION
Link hints is in need of a major refactoring.  But here are two small changes:

- Fix the hint-activation sequence.  We have several ways of activating a hint (immediately, with delay, wait-for-enter).  And the logic previously was complicated (and wrong in at least one case).  This puts all of the logic in one place: 3671382a6a3c14d1f834b6ebcf10605921201c53.  This also ensures that the links are hidden at the correct point in the exit sequence.

- Previously, we re-used the `LinkHints` object, so it was necessary to reset its state on exit.  For quite some time, we have not been reusing the object, so we do not need to reset its state: 0761521e45af560453abb10b35dfae410ae8bce9.