### PR TITLE
move keyboard shortcut dialog to right side

### DIFF
--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -163,12 +163,14 @@ div#vimiumHelpDialog {
   border:2px solid #b3b3b3;
   border-radius:6px;
   padding:8px 12px;
-  width:640px;
+  width: 45%;
+  max-width:640px; 
   max-height: calc(100% - 80px);
-  left:50%;
+  /* left:50%; */
   /* This needs to be 1/2 width to horizontally center the help dialog */
-  margin-left:-320px;
-  top:50px;
+  /* margin-left:-320px; */
+  top: 2%;
+  right: 1%;
   -webkit-box-shadow: rgba(0, 0, 0, 0.4) 0px 0px 6px;
   overflow-y: auto;
 }


### PR DESCRIPTION
This anchors the keyboard shortcuts help dialog / modal to the right side of the page (was previously centered), so that it is out of the way when you're trying to edit shortcuts

![image](https://cloud.githubusercontent.com/assets/199599/13511050/8ee39ff0-e161-11e5-80af-a8708bbd164f.png)
