### PR TITLE
Make command names in the help diablog clickable.

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -205,7 +205,6 @@ class LinkHintsMode
     if (element.hasAttribute("onclick") or
         element.getAttribute("role")?.toLowerCase() in ["button", "link"] or
         element.getAttribute("class")?.toLowerCase().indexOf("button") >= 0 or
-        element.getAttribute("class")?.indexOf("vimiumClickable") >= 0 or
         element.getAttribute("contentEditable")?.toLowerCase() in ["", "contentEditable", "true"])
       isClickable = true
 

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -205,6 +205,7 @@ class LinkHintsMode
     if (element.hasAttribute("onclick") or
         element.getAttribute("role")?.toLowerCase() in ["button", "link"] or
         element.getAttribute("class")?.toLowerCase().indexOf("button") >= 0 or
+        element.getAttribute("class")?.indexOf("vimiumClickable") >= 0 or
         element.getAttribute("contentEditable")?.toLowerCase() in ["", "contentEditable", "true"])
       isClickable = true
 

--- a/pages/help_dialog.coffee
+++ b/pages/help_dialog.coffee
@@ -42,7 +42,7 @@ HelpDialog =
     # clicked with link hints).
     for element in @dialogElement.getElementsByClassName "commandName"
       do (element) ->
-        element.classList.add "vimiumClickable"
+        element.setAttribute "role", "link"
         element.addEventListener "click", ->
           commandName = element.textContent.replace("(","").replace ")", ""
           chrome.runtime.sendMessage handler: "copyToClipboard", data: commandName

--- a/pages/help_dialog.coffee
+++ b/pages/help_dialog.coffee
@@ -38,6 +38,16 @@ HelpDialog =
 
     @showAdvancedCommands(@getShowAdvancedCommands())
 
+    # When command names are shown, clicking on them copies their text to the clipboard (and they can be
+    # clicked with link hints).
+    for element in @dialogElement.getElementsByClassName "commandName"
+      do (element) ->
+        element.classList.add "vimiumClickable"
+        element.addEventListener "click", ->
+          commandName = element.textContent.replace("(","").replace ")", ""
+          chrome.runtime.sendMessage handler: "copyToClipboard", data: commandName
+          HUD.showForDuration("Yanked #{commandName}.", 2000)
+
   hide: -> UIComponentServer.postMessage "hide"
 
   toggle: (html) ->


### PR DESCRIPTION
Clicking on command names in the help dialog copies the command name to the clipboard.  Moreover, command names can be clicked (hence copied) with link hints.

Looks like this, ... here, I've already typed the text `vomn`, ...

![snapshot](https://cloud.githubusercontent.com/assets/2641335/13519536/7cadcfda-e1d0-11e5-9dc3-cc1b8fc198e4.png)

~~As a a side effect, any element on any page with the `vimiumClickable` class becomes clickable.  That's zero elements on zero pages, currently.  But there was an issue some time ago where a web developer was looking for a way to make their elements vimium clickable (#1157).~~ Edit... No longer true (58e332fe942d01c8f4633b3415c460f678b2c75b).

On the negative side, this is pretty undiscoverable.  Also, the `indexOf()` class-name test within a string isn't exactly precise.