### PR TITLE
Do not initialise UI components when disabled.

### DIFF
--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -13,9 +13,10 @@ HUD =
   # it doesn't sit on top of horizontal scrollbars like Chrome's HUD does.
 
   init: ->
-    @hudUI = new UIComponent "pages/hud.html", "vimiumHUDFrame", ({data}) =>
-      this[data.name]? data
-    @tween = new Tween "iframe.vimiumHUDFrame.vimiumUIComponentVisible", @hudUI.shadowDOM
+    unless @hudUI?
+      @hudUI = new UIComponent "pages/hud.html", "vimiumHUDFrame", ({data}) =>
+        this[data.name]? data
+      @tween = new Tween "iframe.vimiumHUDFrame.vimiumUIComponentVisible", @hudUI.shadowDOM
 
   showForDuration: (text, duration) ->
     @show(text)

--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -86,7 +86,7 @@ HUD =
   isReady: do ->
     ready = false
     DomUtils.documentReady -> ready = true
-    -> ready and document.body != null
+    -> ready and document.body != null and @hudUI?
 
   enabled: -> true
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -438,7 +438,7 @@ initializeTopFrame = (request = null) ->
   initializeTopFrame = -> # Only do this initialization once.
   # We only initialize the vomnibar in the tab's top/main frame, because it's only ever opened there.
   if DomUtils.isTopFrame()
-    Vomnibar.init()
+    DomUtils.documentReady -> Vomnibar.init()
   else
     # Ignore requests from other frames (we're not the top frame).
     unless request?

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -440,10 +440,12 @@ initializeTopFrame = (request = null) ->
   if DomUtils.isTopFrame()
     Vomnibar.init()
   else
-    # Ignore requests from other frames (if we're not the top frame).
+    # Ignore requests from other frames (we're not the top frame).
     unless request?
-      # Tell the top frame to initialize the Vomnibar.
-      chrome.runtime.sendMessage handler: "sendMessageToFrames", message: name: "initializeTopFrame"
+      # Tell the top frame to initialize the Vomnibar.  We wait until "DOMContentLoaded" to ensure that the
+      # listener in the main/top frame (which are installed pre-DomReady) is already installed.
+      DomUtils.documentReady ->
+        chrome.runtime.sendMessage handler: "sendMessageToFrames", message: name: "initializeTopFrame"
 
 # Checks if Vimium should be enabled or not in this frame.  As a side effect, it also informs the background
 # page whether this frame has the focus, allowing the background page to track the active frame's URL.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -149,6 +149,7 @@ initializePreDomReady = ->
     # A frame has received the focus.  We don't care here (the Vomnibar/UI-component handles this).
     frameFocused: ->
     checkEnabledAfterURLChange: checkEnabledAfterURLChange
+    initializeTopFrame: initializeTopFrame
     runInTopFrame: ({sourceFrameId, registryEntry}) ->
       Utils.invokeCommandString registryEntry.command, [sourceFrameId, registryEntry] if DomUtils.isTopFrame()
 
@@ -218,9 +219,6 @@ initializeOnDomReady = ->
     isEnabledForUrl = false
     chrome.runtime.sendMessage = ->
     window.removeEventListener "focus", onFocus
-  # We only initialize the vomnibar in the tab's main frame, because it's only ever opened there.
-  Vomnibar.init() if DomUtils.isTopFrame()
-  HUD.init()
 
 registerFrame = ->
   # Don't register frameset containers; focusing them is no use.
@@ -436,6 +434,17 @@ extend window,
               indicator: false
 
 
+initializeTopFrame = (request = null) ->
+  initializeTopFrame = -> # Only do this initialization once.
+  # We only initialize the vomnibar in the tab's top/main frame, because it's only ever opened there.
+  if DomUtils.isTopFrame()
+    Vomnibar.init()
+  else
+    # Ignore requests from other frames (if we're not the top frame).
+    unless request?
+      # Tell the top frame to initialize the Vomnibar.
+      chrome.runtime.sendMessage handler: "sendMessageToFrames", message: name: "initializeTopFrame"
+
 # Checks if Vimium should be enabled or not in this frame.  As a side effect, it also informs the background
 # page whether this frame has the focus, allowing the background page to track the active frame's URL.
 checkIfEnabledForUrl = (frameIsFocused = windowIsFocused()) ->
@@ -443,7 +452,11 @@ checkIfEnabledForUrl = (frameIsFocused = windowIsFocused()) ->
   chrome.runtime.sendMessage { handler: "isEnabledForUrl", url: url, frameIsFocused: frameIsFocused }, (response) ->
     { isEnabledForUrl, passKeys } = response
     installListeners() # But only if they have not been installed already.
-    if HUD.isReady() and not isEnabledForUrl
+    # Initialize UI components. We only initialize these once we know that Vimium is enabled; see #1838.
+    if isEnabledForUrl
+      initializeTopFrame()
+      HUD.init() if frameIsFocused
+    else if HUD.isReady()
       # Quickly hide any HUD we might already be showing, e.g. if we entered insert mode on page load.
       HUD.hide()
     normalMode?.setPassKeys passKeys

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -438,7 +438,7 @@ initializeTopFrame = (request = null) ->
   initializeTopFrame = -> # Only do this initialization once.
   # We only initialize the vomnibar in the tab's top/main frame, because it's only ever opened there.
   if DomUtils.isTopFrame()
-    DomUtils.documentReady -> Vomnibar.init()
+    DomUtils.documentReady Vomnibar.init.bind Vomnibar
   else
     # Ignore requests from other frames (we're not the top frame).
     unless request?

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -457,7 +457,7 @@ checkIfEnabledForUrl = (frameIsFocused = windowIsFocused()) ->
     # Initialize UI components. We only initialize these once we know that Vimium is enabled; see #1838.
     if isEnabledForUrl
       initializeTopFrame()
-      HUD.init() if frameIsFocused
+      DomUtils.documentReady HUD.init.bind HUD if frameIsFocused
     else if HUD.isReady()
       # Quickly hide any HUD we might already be showing, e.g. if we entered insert mode on page load.
       HUD.hide()

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -2,11 +2,13 @@ DomUtils =
   #
   # Runs :callback if the DOM has loaded, otherwise runs it on load
   #
-  documentReady: (func) ->
+  documentReady: (callback) ->
     if document.readyState == "loading"
-      window.addEventListener "DOMContentLoaded", func
+      window.addEventListener "DOMContentLoaded", handler = ->
+        window.removeEventListener "DOMContentLoaded", handler
+        callback()
     else
-      func()
+      callback()
 
   createElement: (tagName) ->
     element = document.createElement tagName

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -1,6 +1,7 @@
 
 # Install frontend event handlers.
 installListeners()
+HUD.init()
 
 installListener = (element, event, callback) ->
   element.addEventListener event, (-> callback.apply(this, arguments)), true

--- a/tests/dom_tests/vomnibar_test.coffee
+++ b/tests/dom_tests/vomnibar_test.coffee
@@ -1,5 +1,6 @@
 vomnibarFrame = null
 SearchEngines.refresh ""
+Vomnibar.init()
 
 context "Keep selection within bounds",
 


### PR DESCRIPTION
We delay initialising UI components until we know that Vimium is enabled.  In addition to being a reasonable thing to do, this suppresses the resulting `XMLHttpRequest` requests on pages where Vimium is disabled, and hence doesn't clog up the dev console with useless Vimium network requests.

The idea is that devs for whom these requests are a problem can simply disable Vimium.

Fixes #1838 (mostly).  Devs have to disable Vimium on pages where they're working.  But Vimium can be enabled and disabled on a page (via the popup) with just a couple of keystrokes.