### PR TITLE
Help dialog to top frame

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -298,7 +298,7 @@ defaultKeyMappings =
 # If the noRepeat and repeatLimit options are both specified, then noRepeat takes precedence.
 commandDescriptions =
   # Navigating the current page
-  showHelp: ["Show help", { background: true }]
+  showHelp: ["Show help", { topFrame: true }]
   scrollDown: ["Scroll down", { passCountToFunction: true }]
   scrollUp: ["Scroll up", { passCountToFunction: true }]
   scrollLeft: ["Scroll left", { passCountToFunction: true }]

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -124,8 +124,7 @@ chrome.webNavigation.onHistoryStateUpdated.addListener onURLChange # history.pus
 chrome.webNavigation.onReferenceFragmentUpdated.addListener onURLChange # Hash changed.
 
 # Retrieves the help dialog HTML template from a file, and populates it with the latest keybindings.
-# This is called by options.coffee.
-root.helpDialogHtml = (showUnboundCommands, showCommandNames, customTitle) ->
+helpDialogHtml = ({showUnboundCommands, showCommandNames, customTitle}) ->
   commandsToKey = {}
   for own key of Commands.keyToCommandRegistry
     command = Commands.keyToCommandRegistry[key].command
@@ -278,10 +277,6 @@ BackgroundCommands =
   togglePinTab: (request) ->
     chrome.tabs.getSelected(null, (tab) ->
       chrome.tabs.update(tab.id, { pinned: !tab.pinned }))
-  showHelp: (callback, frameId) ->
-    chrome.tabs.getSelected(null, (tab) ->
-      chrome.tabs.sendMessage(tab.id,
-        { name: "toggleHelpDialog", dialogHtml: helpDialogHtml(), frameId:frameId }))
   moveTabLeft: (count) -> moveTab -count
   moveTabRight: (count) -> moveTab count
   nextFrame: (count,frameId) ->
@@ -446,6 +441,7 @@ sendRequestHandlers =
   sendMessageToFrames: sendMessageToFrames
   log: bgLog
   fetchFileContents: (request, sender) -> fetchFileContents request.fileName
+  getHelpPageHTML: helpDialogHtml
 
 # We always remove chrome.storage.local/findModeRawQueryListIncognito on startup.
 chrome.storage.local.remove "findModeRawQueryListIncognito"

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -94,6 +94,7 @@ class UIComponent
     @onFocus = null
     @iframeElement.classList.remove "vimiumUIComponentVisible"
     @iframeElement.classList.add "vimiumUIComponentHidden"
+    @iframeElement.blur()
     @options = null
     @showing = false
 

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -82,14 +82,7 @@ class UIComponent
       @showing = true
 
   hide: (focusWindow = true)->
-    if focusWindow and sourceFrameId = @options?.sourceFrameId
-      # FIXME(smblott)  This is an unacceptable hack -- and must be fixed.  When closing a UI component, we
-      # cannot predict which frame Chrome focus; moreover, we cannot know exactly *when* that frame will be
-      # focused.  As a temporary fix, we wait a bit here, then focus the frame that we we really want focused.
-      Utils.setTimeout 150, ->
-        chrome.runtime.sendMessage
-          handler: "sendMessageToFrames"
-          message: name: "focusFrame", frameId: sourceFrameId
+    @refocusSourceFrame @options?.sourceFrameId if focusWindow
     window.removeEventListener "focus", @onFocus if @onFocus
     @onFocus = null
     @iframeElement.classList.remove "vimiumUIComponentVisible"
@@ -97,6 +90,32 @@ class UIComponent
     @iframeElement.blur()
     @options = null
     @showing = false
+
+  # Refocus the frame from which the UI component was opened.  This may be different from the current frame.
+  # After hiding the UI component, Chrome refocuses the containing frame. To avoid a race condition, we need
+  # to wait until that frame first receives the focus, before then focusing the frame which should now have
+  # the focus.
+  refocusSourceFrame: (sourceFrameId) ->
+    if @showing and sourceFrameId?
+      refocusSourceFrame = ->
+        chrome.runtime.sendMessage
+          handler: "sendMessageToFrames"
+          message:
+            name: "focusFrame"
+            frameId: sourceFrameId
+
+      if windowIsFocused()
+        # We already have the focus.
+        refocusSourceFrame()
+      else
+        # We don't yet have the focus (but we'll be getting it soon).
+        console.log "000"
+        window.addEventListener "focus", handler = (event) ->
+          console.log "aaa"
+          if event.target == window
+            console.log "bbb"
+            window.removeEventListener "focus", handler
+            refocusSourceFrame()
 
   # Fetch a Vimium file/resource (such as "content_scripts/vimium.css").
   # We try making an XMLHttpRequest request.  That can fail (see #1817), in which case we fetch the

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -96,7 +96,7 @@ class UIComponent
   # to wait until that frame first receives the focus, before then focusing the frame which should now have
   # the focus.
   refocusSourceFrame: (sourceFrameId) ->
-    if @showing and sourceFrameId?
+    if @showing and sourceFrameId? and sourceFrameId != frameId
       refocusSourceFrame = ->
         chrome.runtime.sendMessage
           handler: "sendMessageToFrames"
@@ -109,11 +109,8 @@ class UIComponent
         refocusSourceFrame()
       else
         # We don't yet have the focus (but we'll be getting it soon).
-        console.log "000"
         window.addEventListener "focus", handler = (event) ->
-          console.log "aaa"
           if event.target == window
-            console.log "bbb"
             window.removeEventListener "focus", handler
             refocusSourceFrame()
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -301,9 +301,8 @@ extend window,
 
 extend window,
   showHelp: (sourceFrameId) ->
-    if DomUtils.isTopFrame()
-      chrome.runtime.sendMessage {handler: "getHelpPageHTML"}, (html) ->
-        HelpDialog.toggle {html,sourceFrameId}
+    chrome.runtime.sendMessage {handler: "getHelpPageHTML"}, (html) ->
+      HelpDialog.toggle {html,sourceFrameId}
 
   reload: -> window.location.reload()
   goBack: (count) -> history.go(-count)

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -142,7 +142,6 @@ initializePreDomReady = ->
 
   requestHandlers =
     showHUDforDuration: handleShowHUDforDuration
-    toggleHelpDialog: (request) -> if frameId == request.frameId then HelpDialog.toggle request.dialogHtml
     focusFrame: (request) -> if (frameId == request.frameId) then focusThisFrame request
     getScrollPosition: -> scrollX: window.scrollX, scrollY: window.scrollY
     setScrollPosition: setScrollPosition
@@ -301,6 +300,11 @@ extend window,
   scrollRight: (count) -> Scroller.scrollBy "x", Settings.get("scrollStepSize") * count
 
 extend window,
+  showHelp: (sourceFrameId) ->
+    if DomUtils.isTopFrame()
+      chrome.runtime.sendMessage {handler: "getHelpPageHTML"}, (html) ->
+        HelpDialog.toggle {html,sourceFrameId}
+
   reload: -> window.location.reload()
   goBack: (count) -> history.go(-count)
   goForward: (count) -> history.go(count)
@@ -630,18 +634,18 @@ window.HelpDialog ?=
 
   isReady: -> @helpUI?
 
-  show: (html) ->
+  show: (options) ->
     @init()
     return if @showing or !@isReady()
     @showing = true
-    @helpUI.activate html
+    @helpUI.activate options
 
   hide: ->
     @showing = false
     @helpUI.hide()
 
-  toggle: (html) ->
-    if @showing then @hide() else @show html
+  toggle: (options) ->
+    if @showing then @hide() else @show options
 
 initializePreDomReady()
 DomUtils.documentReady initializeOnDomReady

--- a/pages/help_dialog.coffee
+++ b/pages/help_dialog.coffee
@@ -6,7 +6,6 @@
 #   top-level frame), and then we don't need to be concerned about nested help dialog frames.
 HelpDialog =
   dialogElement: null
-  showing: true
 
   # This setting is pulled out of local storage. It's false by default.
   getShowAdvancedCommands: -> Settings.get("helpDialog_showAdvancedCommands")
@@ -30,9 +29,7 @@ HelpDialog =
       @hide() unless @dialogElement.contains event.target
     , false
 
-  isReady: -> true
-
-  show: (html) ->
+  show: ({html}) ->
     for own placeholder, htmlString of html
       @dialogElement.querySelector("#help-dialog-#{placeholder}").innerHTML = htmlString
 
@@ -54,9 +51,6 @@ HelpDialog =
   hide: ->
     @exitOnEscape?.exit()
     UIComponentServer.postMessage "hide"
-
-  toggle: (html) ->
-    if @showing then @hide() else @show html
 
   #
   # Advanced commands are hidden by default so they don't overwhelm new and casual users.

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -234,7 +234,9 @@ initOptionsPage = ->
     event.preventDefault()
 
   activateHelpDialog = ->
-    HelpDialog.show chrome.extension.getBackgroundPage().helpDialogHtml(true, true, "Command Listing"), frameId
+    request = handler: "getHelpPageHTML", showUnboundCommands: true, showCommandNames:true, customTitle: "Command Listing"
+    chrome.runtime.sendMessage request, (html) ->
+      HelpDialog.show {html}, frameId
 
   saveOptions = ->
     Option.saveOptions()

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -235,8 +235,7 @@ initOptionsPage = ->
 
   activateHelpDialog = ->
     request = handler: "getHelpPageHTML", showUnboundCommands: true, showCommandNames:true, customTitle: "Command Listing"
-    chrome.runtime.sendMessage request, (html) ->
-      HelpDialog.show {html}, frameId
+    chrome.runtime.sendMessage request, (html) -> HelpDialog.show {html}, frameId
 
   saveOptions = ->
     Option.saveOptions()


### PR DESCRIPTION
This moves the help dialog such that it is always shown in the main/top frame, just like the Vomnibar.

**Edit: The following issue has been fixed**... 7c78211bdcc4e92acdc9ab66b1ebe11f707e1c93.  Leaving the comment below, though, for the record.

This works.  But...

There is a problem.  When a UI component closes, Chrome focuses some other frame.  Previously, (with just the Vomnibar) we could predict that it would be the main/top frame, and we could wait for that frame to receive the focus before re-focusing the original frame.

Here, however, we can open the Vomnibar from within the help dialog.  In this case, if we then close all of the frames with `Esc`, the focus ends up in the (hidden!) help dialog.  This is not actually a new problem.  It exists in `master` too.

In the first commit here, there is a big "FIXME".  We get around the issue by waiting an aribitrary short time (150ms) before sending the request to re-focus the original frame.  So there's a pretty serious race condition.  Also, during that waiting period, keyboard events are being sent to some unknown frame.