### PR TITLE
Rework logging (dev only)...

### DIFF
--- a/background_scripts/bg_utils.coffee
+++ b/background_scripts/bg_utils.coffee
@@ -53,4 +53,16 @@ class TabRecency
 BgUtils =
   tabRecency: new TabRecency()
 
+  # Log messages to the extension's logging page, but only if that page is open.
+  log: do ->
+    loggingPageUrl = chrome.runtime.getURL "pages/logging.html"
+    console.log "Vimium logging URL:\n  #{loggingPageUrl}" if loggingPageUrl? # Do not output URL for tests.
+    (message, sender = null) ->
+      for viewWindow in chrome.extension.getViews {type: "tab"}
+        if viewWindow.location.pathname == "/pages/logging.html"
+          # Don't log messages from the logging page itself.  We do this check late because most of the time
+          # it's not needed.
+          if sender?.url != loggingPageUrl
+            viewWindow.document.getElementById("log-text").value += "#{(new Date()).toISOString()}: #{message}\n"
+
 root.BgUtils = BgUtils

--- a/background_scripts/bg_utils.coffee
+++ b/background_scripts/bg_utils.coffee
@@ -65,6 +65,14 @@ BgUtils =
           # Don't log messages from the logging page itself.  We do this check late because most of the time
           # it's not needed.
           if sender?.url != loggingPageUrl
-            viewWindow.document.getElementById("log-text").value += "#{(new Date()).toISOString()}: #{message}\n"
+            date = new Date
+            [hours, minutes, seconds, milliseconds] =
+              [date.getHours(), date.getMinutes(), date.getSeconds(), date.getMilliseconds()]
+            minutes = "0" + minutes if minutes < 10
+            seconds = "0" + seconds if seconds < 10
+            milliseconds = "00" + milliseconds if milliseconds < 10
+            milliseconds = "0" + milliseconds if milliseconds < 100
+            dateString = "#{hours}:#{minutes}:#{seconds}.#{milliseconds}"
+            viewWindow.document.getElementById("log-text").value += "#{dateString}: #{message}\n"
 
 root.BgUtils = BgUtils

--- a/background_scripts/bg_utils.coffee
+++ b/background_scripts/bg_utils.coffee
@@ -57,6 +57,8 @@ BgUtils =
   log: do ->
     loggingPageUrl = chrome.runtime.getURL "pages/logging.html"
     console.log "Vimium logging URL:\n  #{loggingPageUrl}" if loggingPageUrl? # Do not output URL for tests.
+    # For development, it's sometimes useful to automatically launch the logging page on reload.
+    chrome.windows.create url: loggingPageUrl, focused: false if localStorage.autoLaunchLoggingPage
     (message, sender = null) ->
       for viewWindow in chrome.extension.getViews {type: "tab"}
         if viewWindow.location.pathname == "/pages/logging.html"

--- a/background_scripts/bg_utils.coffee
+++ b/background_scripts/bg_utils.coffee
@@ -73,6 +73,8 @@ BgUtils =
             milliseconds = "00" + milliseconds if milliseconds < 10
             milliseconds = "0" + milliseconds if milliseconds < 100
             dateString = "#{hours}:#{minutes}:#{seconds}.#{milliseconds}"
-            viewWindow.document.getElementById("log-text").value += "#{dateString}: #{message}\n"
+            logElement = viewWindow.document.getElementById "log-text"
+            logElement.value += "#{dateString}: #{message}\n"
+            logElement.scrollTop = 2000000000
 
 root.BgUtils = BgUtils

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -20,7 +20,7 @@ Commands =
   #    command passed to it. This is used to implement e.g. "closing of 3 tabs".
   addCommand: (command, description, options) ->
     if command of @availableCommands
-      logMessage? "#{command} is already defined! Check commands.coffee for duplicates."
+      BgUtils.log "#{command} is already defined! Check commands.coffee for duplicates."
       return
 
     options ||= {}
@@ -28,7 +28,7 @@ Commands =
 
   mapKeyToCommand: ({ key, command, options }) ->
     unless @availableCommands[command]
-      logMessage? "#{command} doesn't exist!"
+      BgUtils.log "#{command} doesn't exist!"
       return
 
     options ?= {}
@@ -57,13 +57,13 @@ Commands =
             [ _, key, command, optionList... ] = tokens
             if command? and @availableCommands[command]
               key = @normalizeKey key
-              logMessage? "Mapping #{key} to #{command}"
+              BgUtils.log "Mapping #{key} to #{command}"
               @mapKeyToCommand { key, command, options: @parseCommandOptions command, optionList }
 
           when "unmap"
             if tokens.length == 2
               key = @normalizeKey tokens[1]
-              logMessage? "Unmapping #{key}"
+              BgUtils.log "Unmapping #{key}"
               delete @keyToCommandRegistry[key]
 
           when "unmapAll"

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -384,7 +384,7 @@ sendMessageToFrames = (request, sender) ->
 
 # For debugging only. This allows content scripts to log messages to the extension's logging page.
 bgLog = (request, sender) ->
-  BgUtils.log "#{sender.tab.id}/#{request.frameId} #{request.message}", sender
+  BgUtils.log "#{request.frameId} #{request.message}", sender
 
 # Port handler mapping
 portHandlers =

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -72,18 +72,6 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) ->
   # Ensure the sendResponse callback is freed.
   return false)
 
-# Log messages to the extension's logging page, but only if that page is open.
-logMessage = do ->
-  loggingPageUrl = chrome.runtime.getURL "pages/logging.html"
-  console.log "Vimium logging URL:\n  #{loggingPageUrl}" if loggingPageUrl? # Do not output URL for tests.
-  (message, sender = null) ->
-    for viewWindow in chrome.extension.getViews {type: "tab"}
-      if viewWindow.location.pathname == "/pages/logging.html"
-        # Don't log messages from the logging page itself.  We do this check late because most of the time
-        # it's not needed.
-        if sender?.url != loggingPageUrl
-          viewWindow.document.getElementById("log-text").value += "#{(new Date()).toISOString()}: #{message}\n"
-
 #
 # Used by the content scripts to get their full URL. This is needed for URLs like "view-source:http:# .."
 # because window.location doesn't know anything about the Chrome-specific "view-source:".
@@ -396,7 +384,7 @@ sendMessageToFrames = (request, sender) ->
 
 # For debugging only. This allows content scripts to log messages to the extension's logging page.
 bgLog = (request, sender) ->
-  logMessage "#{sender.tab.id}/#{request.frameId} #{request.message}", sender
+  BgUtils.log "#{sender.tab.id}/#{request.frameId} #{request.message}", sender
 
 # Port handler mapping
 portHandlers =
@@ -476,5 +464,4 @@ chrome.runtime.onInstalled.addListener ({reason}) ->
     chrome.storage.local.set installDate: new Date().toString()
 
 root.TabOperations = TabOperations
-root.logMessage = logMessage
 root.Frames = Frames

--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -20,7 +20,7 @@ class KeyHandlerMode extends Mode
 
   # Reset the key state, optionally retaining the count provided.
   reset: (@countPrefix = 0) ->
-    bgLog "Clearing key state, set count=#{@countPrefix}."
+    bgLog "Clearing key state: #{@countPrefix} (#{@name})"
     @keyState = [@keyMapping]
 
   constructor: (options) ->
@@ -88,7 +88,7 @@ class KeyHandlerMode extends Mode
     @countPrefix == 0 and @keyState.length == 1 and keyChar in (@passKeys ? "")
 
   handleKeyChar: (keyChar) ->
-    bgLog "Handling key #{keyChar}, mode=#{@name}."
+    bgLog "Handle key #{keyChar} (#{@name})"
     # A count prefix applies only so long a keyChar is mapped in @keyState[0]; e.g. 7gj should be 1j.
     @countPrefix = 0 unless keyChar of @keyState[0]
     # Advance the key state.  The new key state is the current mappings of keyChar, plus @keyMapping.
@@ -96,7 +96,7 @@ class KeyHandlerMode extends Mode
     command = (mapping for mapping in @keyState when "command" of mapping)[0]
     if command
       count = if 0 < @countPrefix then @countPrefix else 1
-      bgLog "Calling mode=#{@name}, command=#{command.command}, count=#{count}."
+      bgLog "Call #{command.command}[#{count}] (#{@mode})"
       @reset()
       @commandHandler {command, count}
     false # Suppress event.

--- a/manifest.json
+++ b/manifest.json
@@ -10,9 +10,9 @@
     "scripts": [
       "lib/utils.js",
       "lib/settings.js",
+      "background_scripts/bg_utils.js",
       "background_scripts/commands.js",
       "lib/clipboard.js",
-      "background_scripts/bg_utils.js",
       "background_scripts/exclusions.js",
       "background_scripts/completion_engines.js",
       "background_scripts/completion_search.js",


### PR DESCRIPTION
Tweaks to make Vimium's logging more useful...

- Reformat some log messages for consistency and to save horizontal space.  We do not need to know what date it is.
- Add ability to automatically launch a logging-page window on reload (set `localStorage.autoLaunchLoggingPage`).
- Automatically scroll the logging text area.
- Move logging to `bgUtils`.