### PR TITLE
Fix focus issue with UI components (#2038)

### DIFF
--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -87,6 +87,7 @@ class UIComponent
     @onFocus = null
     @iframeElement.classList.remove "vimiumUIComponentVisible"
     @iframeElement.classList.add "vimiumUIComponentHidden"
+    @iframeElement.blur()
     @options = null
     @showing = false
 


### PR DESCRIPTION
Problem:

- `?`, `o`, `Esc`, `Esc` leaves the focus in the (invisible) help dialog frame, rendering Vimium broken.

Since we do

```Coffeescript
@iframeElement.focus()
```

when we activate a UI component, here we do

```Coffeescript
@iframeElement.blur()
```

when hiding such elements.

@mrmr1993.  Could you confirm that this is correct, please?

Fixes #2038.