### PR TITLE
Global link hints

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -323,14 +323,14 @@ HintCoordinator =
   tabState: {}
 
   onMessage: (request, sender) ->
-    if request.name of this
-      this[request.name] extend request, tabId: sender.tab.id
+    if request.messageType of this
+      this[request.messageType] extend request, tabId: sender.tab.id
     else
       # The message is not for us.  It's for all frames, so we bounce it there.
-      @sendMessage request.name, sender.tab.id, request
+      @sendMessage request.messageType, sender.tab.id, request
 
-  sendMessage: (handler, tabId, request = {}) ->
-    chrome.tabs.sendMessage tabId, extend request, {name: "linkHintsMessage", handler}
+  sendMessage: (messageType, tabId, request = {}) ->
+    chrome.tabs.sendMessage tabId, extend request, {name: "linkHintsMessage", messageType}
 
   activateMode: ({tabId, frameId, modeIndex}) ->
     @tabState[tabId] = {frameIds: frameIdsForTab[tabId], hints: [], modeIndex, frameId}

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -321,7 +321,6 @@ LocalHints =
 
     hint.hasHref = hint.element.href? for hint in localHints
     if Settings.get "filterLinkHints"
-      DomUtils.textContent.reset()
       @generateLabelMap()
       extend hint, @generateLinkText hint.element for hint in localHints
 
@@ -354,14 +353,14 @@ LocalHints =
         linkText = element.value
         if not linkText and 'placeholder' of element
           linkText = element.placeholder
-      # check if there is an image embedded in the <a> tag
+    # Check if there is an image embedded in the <a> tag.
     else if (nodeName == "a" && !element.textContent.trim() &&
         element.firstElementChild &&
         element.firstElementChild.nodeName.toLowerCase() == "img")
       linkText = element.firstElementChild.alt || element.firstElementChild.title
       showLinkText = true if (linkText)
     else
-      linkText = DomUtils.textContent.get element
+      linkText = (element.textContent.trim() || element.innerHTML.trim())[...512]
 
     {linkText, showLinkText}
 

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -52,8 +52,8 @@ availableModes = [OPEN_IN_CURRENT_TAB, OPEN_IN_NEW_BG_TAB, OPEN_IN_NEW_FG_TAB, O
 HintCoordinator =
   onExit: []
 
-  sendMessage: (name, request = {}) ->
-    chrome.runtime.sendMessage extend request, {handler: "linkHintsMessage", name, frameId}
+  sendMessage: (messageType, request = {}) ->
+    chrome.runtime.sendMessage extend request, {handler: "linkHintsMessage", messageType, frameId}
 
   activateMode: (mode, onExit) ->
     @onExit = [onExit]

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -71,7 +71,7 @@ HintCoordinator =
 
   postKeyState: (request) -> @linkHintsMode.postKeyState request
   activateActiveHintMarker: -> @linkHintsMode.activateLink @linkHintsMode.markerMatcher.activeHintMarker
-  setMode: ({modeIndex}) -> @linkHintsMode.setOpenLinkMode availableModes[modeIndex], true
+  setMode: ({modeIndex}) -> @linkHintsMode.setOpenLinkMode availableModes[modeIndex], false
   getLocalHintMarker: (hint) -> if hint.frameId == frameId then @localHints[hint.localIndex] else null
 
   exit: ->
@@ -140,7 +140,7 @@ class LinkHintsModeBase
           (event?.type == "keydown" and event.keyCode in [ keyCodes.backspace, keyCodes.deleteKey ])
         HintCoordinator.sendMessage "exitFailure"
 
-    @setOpenLinkMode mode, true
+    @setOpenLinkMode mode, false
 
     # Note(philc): Append these markers as top level children instead of as child nodes to the link itself,
     # because some clickable elements cannot contain children, e.g. submit buttons.
@@ -150,9 +150,9 @@ class LinkHintsModeBase
     @hideMarker marker for marker in hintMarkers when marker.hint.frameId != frameId
     @postKeyState = @postKeyState.bind this, hintMarkers
 
-  setOpenLinkMode: (@mode, doNotPropagate = false) ->
-    @hintMode.setIndicator @mode.indicator if DomUtils.isTopFrame()
-    unless doNotPropagate
+  setOpenLinkMode: (@mode, shouldPropagtetoOtherFrames = true) ->
+    @hintMode.setIndicator @mode.indicator if windowIsFocused()
+    if shouldPropagtetoOtherFrames
       HintCoordinator.sendMessage "setMode", modeIndex: availableModes.indexOf @mode
 
   #

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -332,6 +332,7 @@ ClickableElements =
 
   # Generate a map of input element => label
   generateLabelMap: ->
+    @labelMap = {}
     labels = document.querySelectorAll("label")
     for label in labels
       forElement = label.getAttribute("for")
@@ -564,7 +565,6 @@ class FilterHints
     @linkHintNumbers = Settings.get "linkHintNumbers"
     @hintKeystrokeQueue = []
     @linkTextKeystrokeQueue = []
-    @labelMap = {}
     @activeHintMarker = null
     # The regexp for splitting typed text and link texts.  We split on sequences of non-word characters and
     # link-hint numbers.
@@ -716,4 +716,4 @@ root = exports ? window
 root.LinkHints = LinkHints
 root.HintCoordinator = HintCoordinator
 # For tests:
-root.AlphabetHints = AlphabetHints
+extend root, {LinkHintsMode, ClickableElements, AlphabetHints}

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -253,6 +253,9 @@ LocalHints =
         isClickable ||= not element.disabled
       when "label"
         isClickable ||= element.control? and (@getVisibleClickable element.control).length == 0
+      when "body"
+        isClickable ||= element == document.body and not document.hasFocus() and
+          window.innerWidth > 3 and window.innerHeight > 3
 
     # Elements with tabindex are sometimes useful, but usually not. We can treat them as second class
     # citizens when it improves UX, so take special note of them.
@@ -359,6 +362,9 @@ LocalHints =
         element.firstElementChild.nodeName.toLowerCase() == "img"
       linkText = element.firstElementChild.alt || element.firstElementChild.title
       showLinkText = true if linkText
+    else if element == document.body
+      linkText = "Frame."
+      showLinkText = true
     else
       linkText = (element.textContent.trim() || element.innerHTML.trim())[...512]
 
@@ -459,7 +465,9 @@ class LinkHintsMode extends LinkHintsModeBase
 
     if clickEl?
       HintCoordinator.onExit.push =>
-        if DomUtils.isSelectable clickEl
+        if clickEl == document.body
+          Utils.nextTick -> focusThisFrame highlight: true
+        else if DomUtils.isSelectable clickEl
           window.focus()
           DomUtils.simulateSelect clickEl
         else

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -140,9 +140,8 @@ class LinkHintsModeBase # This is temporary, because the "visible hints" code is
       keypress: @onKeyPressInMode.bind this, hintMarkers
 
     @hintMode.onExit (event) =>
-      if event?.type == "click" or (event?.type == "keydown" and KeyboardUtils.isEscape event) or
-          (event?.type == "keydown" and event.keyCode in [ keyCodes.backspace, keyCodes.deleteKey ])
-        HintCoordinator.sendMessage "deactivate"
+      HintCoordinator.sendMessage "deactivate" if event?.type == "click" or (event?.type == "keydown" and
+        (KeyboardUtils.isEscape(event) or event.keyCode in [keyCodes.backspace, keyCodes.deleteKey]))
 
     @setOpenLinkMode mode, false
 
@@ -150,8 +149,7 @@ class LinkHintsModeBase # This is temporary, because the "visible hints" code is
     # because some clickable elements cannot contain children, e.g. submit buttons.
     @hintMarkerContainingDiv = DomUtils.addElementList hintMarkers,
       id: "vimiumHintMarkerContainer", className: "vimiumReset"
-    # Hide markers from other frames.
-    @hideMarker marker for marker in hintMarkers when marker.hintDescriptor.frameId != frameId
+    @hideMarker hintMarker for hintMarker in hintMarkers when hintMarker.hintDescriptor.frameId != frameId
     @updateKeyState = @updateKeyState.bind this, hintMarkers # TODO(smblott): This can be refactored out.
 
   setOpenLinkMode: (@mode, shouldPropagateToOtherFrames = true) ->
@@ -169,7 +167,7 @@ class LinkHintsModeBase # This is temporary, because the "visible hints" code is
       marker = DomUtils.createElement "div"
       marker.className = "vimiumReset internalVimiumHintMarker vimiumHintMarker"
       marker.stableSortCount = ++stableSortCount
-      # Extract other relevant fields from the hint descriptor. TODO(smblott) The name "link" here is misleading.
+      # Extract other relevant fields from the hint descriptor. TODO(smblott) "link" here is misleading.
       extend marker,
         {hintDescriptor: link, linkText: link.linkText, showLinkText: link.showLinkText, rect: link.rect}
 
@@ -180,7 +178,7 @@ class LinkHintsModeBase # This is temporary, because the "visible hints" code is
       marker
 
 # TODO(smblott)  This is temporary.  Unfortunately, this code is embedded in the "old" link-hints mode class.
-# It should be moved, but it's left here for the moment to help make the diff clearer.
+# It should be moved, but it's left here for the moment to help keep the diff clearer.
 LocalHints =
   #
   # Determine whether the element is visible and clickable. If it is, find the rect bounding the element in
@@ -321,12 +319,12 @@ LocalHints =
         # click some elements that we could click before.
         nonOverlappingElements.push visibleElement unless visibleElement.secondClassCitizen
 
+    hint.hasHref = hint.element.href? for hint in localHints
     if Settings.get "filterLinkHints"
       DomUtils.textContent.reset()
       @generateLabelMap()
       extend hint, @generateLinkText hint.element for hint in localHints
 
-    hint.hasHref = hint.element.href? for hint in localHints
     localHints
 
   # Generate a map of input element => label
@@ -453,9 +451,9 @@ class LinkHintsMode extends LinkHintsModeBase
       @hideMarker marker for marker in hintMarkers
       @showMarker matched, @markerMatcher.hintKeystrokeQueue.length for matched in linksMatched
 
-  # When only one link hint remains, activate it in the appropriate way.  The current frame may
-  # or may not contain the matched link, and may or may not have the focus.  The resulting four cases are
-  # accounted for here by selectively pushing the appropriate HintCoordinator.onExit handlers.
+  # When only one hint remains, activate it in the appropriate way.  The current frame may or may not contain
+  # the matched link, and may or may not have the focus.  The resulting four cases are accounted for here by
+  # selectively pushing the appropriate HintCoordinator.onExit handlers.
   activateLink: (linkMatched, userMightOverType=false) ->
     @removeHintMarkers()
     clickEl = HintCoordinator.getLocalHintMarker(linkMatched.hintDescriptor)?.element

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -69,11 +69,10 @@ HintCoordinator =
     @onExit = [] unless frameId == activateModeFrameId
     @linkHintsMode = new LinkHintsMode hints, availableModes[modeIndex]
 
-  postKeyState: (request) ->
-    @linkHintsMode.postKeyState request
-
-  activateActiveHintMarker: ->
-    @linkHintsMode.activateLink @linkHintsMode.markerMatcher.activeHintMarker
+  postKeyState: (request) -> @linkHintsMode.postKeyState request
+  activateActiveHintMarker: -> @linkHintsMode.activateLink @linkHintsMode.markerMatcher.activeHintMarker
+  setMode: ({modeIndex}) -> @linkHintsMode.setOpenLinkMode availableModes[modeIndex], true
+  getLocalHintMarker: (hint) -> if hint.frameId == frameId then @localHints[hint.localIndex] else null
 
   exit: ->
     @onExit.pop()() while 0 < @onExit.length
@@ -82,9 +81,6 @@ HintCoordinator =
   exitFailure: ->
     @onExit = [=> @linkHintsMode.deactivateMode()]
     @exit()
-
-  getLocalHintMarker: (hint) ->
-    if hint.frameId == frameId then @localHints[hint.localIndex] else null
 
 LinkHints =
   activateMode: (count = 1, mode = OPEN_IN_CURRENT_TAB) ->
@@ -144,7 +140,7 @@ class LinkHintsModeBase
           (event?.type == "keydown" and event.keyCode in [ keyCodes.backspace, keyCodes.deleteKey ])
         HintCoordinator.sendMessage "exitFailure"
 
-    @setOpenLinkMode mode
+    @setOpenLinkMode mode, true
 
     # Note(philc): Append these markers as top level children instead of as child nodes to the link itself,
     # because some clickable elements cannot contain children, e.g. submit buttons.
@@ -154,8 +150,10 @@ class LinkHintsModeBase
     @hideMarker marker for marker in hintMarkers when marker.hint.frameId != frameId
     @postKeyState = @postKeyState.bind this, hintMarkers
 
-  setOpenLinkMode: (@mode) ->
+  setOpenLinkMode: (@mode, doNotPropagate = false) ->
     @hintMode.setIndicator @mode.indicator if DomUtils.isTopFrame()
+    unless doNotPropagate
+      HintCoordinator.sendMessage "setMode", modeIndex: availableModes.indexOf @mode
 
   #
   # Creates a link marker for the given link.

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -699,7 +699,6 @@ class WaitForEnter extends Mode
     super
       name: "hint/wait-for-enter"
       suppressAllKeyboardEvents: true
-      exitOnEscape: true
       indicator: "Hit <Enter> to proceed..."
 
     @push

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -464,6 +464,7 @@ class LinkHintsMode extends LinkHintsModeBase
     if clickEl?
       HintCoordinator.onExit.push =>
         if DomUtils.isSelectable clickEl
+          window.focus()
           DomUtils.simulateSelect clickEl
         else
           clickActivator = (modifiers) -> (link) -> DomUtils.simulateClick link, modifiers

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -65,7 +65,7 @@ LinkHints =
   activateModeToOpenIncognito: (count) -> @activateMode count, OPEN_INCOGNITO
   activateModeToDownloadLink: (count) -> @activateMode count, DOWNLOAD_LINK_URL
 
-class LinkHintsMode
+class LinkHintsModeBase
   hintMarkerContainingDiv: null
   # One of the enums listed at the top of this file.
   mode: undefined
@@ -80,7 +80,7 @@ class LinkHintsMode
     # we need documentElement to be ready in order to append links
     return unless document.documentElement
 
-    elements = @getVisibleClickableElements()
+    elements = ClickableElements.getVisibleClickableElements()
     # For these modes, we filter out those elements which don't have an HREF (since there's nothing we can do
     # with them).
     elements = (el for el in elements when el.element.href?) if mode in [ COPY_LINK_URL, OPEN_INCOGNITO ]
@@ -146,6 +146,9 @@ class LinkHintsMode
 
       marker
 
+# TODO(smblott) It is not intended that the code remain structured this way.  This a temporary in order to
+# keep the diff smaller and clearer.  Basically, we need to move a lot of lines around.
+ClickableElements =
   #
   # Determine whether the element is visible and clickable. If it is, find the rect bounding the element in
   # the viewport.  There may be more than one part of element which is clickable (for example, if it's an
@@ -286,6 +289,11 @@ class LinkHintsMode
         nonOverlappingElements.push visibleElement unless visibleElement.secondClassCitizen
 
     nonOverlappingElements
+
+# TODO(smblott) It is not intended that the code remain structured this way.  This a temporary in order to
+# keep the diff smaller and clearer.  Basically, we need to move a lot of lines around.
+class LinkHintsMode extends LinkHintsModeBase
+  constructor: (args...) -> super args...
 
   # Handles <Shift> and <Ctrl>.
   onKeyDownInMode: (hintMarkers, event) ->

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -67,8 +67,7 @@ HintCoordinator =
 
   activateLinkHintsMode: ({hints, modeIndex, frameId: activateModeFrameId}) ->
     @onExit = [] unless frameId == activateModeFrameId
-    mode = availableModes[modeIndex]
-    @linkHintsMode = new LinkHintsMode hints, mode
+    @linkHintsMode = new LinkHintsMode hints, availableModes[modeIndex]
 
   postKeyState: (request) ->
     @linkHintsMode.postKeyState request
@@ -78,8 +77,7 @@ HintCoordinator =
 
   exit: ->
     @onExit.pop()() while 0 < @onExit.length
-    @linkHintsMode = null
-    @localHints = null
+    @linkHintsMode = @localHints = null
 
   exitFailure: ->
     @onExit = [=> @linkHintsMode.deactivateMode()]
@@ -170,7 +168,7 @@ class LinkHintsModeBase
       marker.className = "vimiumReset internalVimiumHintMarker vimiumHintMarker"
       marker.clickableItem = link.element
       marker.stableSortCount = ++stableSortCount
-      # Keep track of the original hint descriptor.  We'll need this to decide which markers to display.
+      # Keep track of the original hint descriptor, we'll need it to decide which markers to display.
       marker.hint = link
       marker.linkText = link.linkText
       marker.showLinkText = link.showLinkText

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -154,6 +154,7 @@ initializePreDomReady = ->
     checkEnabledAfterURLChange: checkEnabledAfterURLChange
     runInTopFrame: ({sourceFrameId, registryEntry}) ->
       Utils.invokeCommandString registryEntry.command, sourceFrameId, registryEntry if DomUtils.isTopFrame()
+    linkHintsMessage: (request) -> HintCoordinator[request.messageType] request
 
   chrome.runtime.onMessage.addListener (request, sender, sendResponse) ->
     # These requests are intended for the background page, but they're delivered to the options page too.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -638,8 +638,8 @@ root.frameId = frameId
 root.Frame = Frame
 root.windowIsFocused = windowIsFocused
 root.bgLog = bgLog
-# These are exported for find mode.
+# These are exported for find mode and link-hints mode.
 extend root, {handleEscapeForFindMode, handleEnterForFindMode, performFind, performBackwardsFind,
-  enterFindMode}
+  enterFindMode, focusThisFrame}
 # These are exported only for the tests.
 extend root, {installModes, installListeners}

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -316,25 +316,6 @@ DomUtils =
     else
       sel.focusNode
 
-  # Get the text content of an element (and its descendents), but omit the text content of previously-visited
-  # nodes.  See #1514.
-  # NOTE(smblott).  This is currently O(N^2) (when called on N elements).  An alternative would be to mark
-  # each node visited, and then clear the marks when we're done.
-  textContent: do ->
-    visitedNodes = null
-    reset: -> visitedNodes = []
-    get: (element) ->
-      nodes = document.createTreeWalker element, NodeFilter.SHOW_TEXT
-      texts =
-        while node = nodes.nextNode()
-          continue unless node.nodeType == 3
-          continue if node in visitedNodes
-          text = node.data.trim()
-          continue unless 0 < text.length
-          visitedNodes.push node
-          text
-      texts.join " "
-
   # Get the element in the DOM hierachy that contains `element`.
   # If the element is rendered in a shadow DOM via a <content> element, the <content> element will be
   # returned, so the shadow DOM is traversed rather than passed over.

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -61,6 +61,9 @@ getHintMarkers = ->
 
 stubSettings = (key, value) -> stub Settings.cache, key, JSON.stringify value
 
+HintCoordinator.sendMessage = (name, request = {}) -> HintCoordinator[name]? request; request
+activateLinkHintsMode = -> HintCoordinator.activateLinkHintsMode HintCoordinator.getHints()
+
 #
 # Generate tests that are common to both default and filtered
 # link hinting modes.
@@ -81,7 +84,7 @@ createGeneralHintTests = (isFilteredMode) ->
       document.getElementById("test-div").innerHTML = ""
 
     should "create hints when activated, discard them when deactivated", ->
-      linkHints = LinkHints.activateMode()
+      linkHints = activateLinkHintsMode()
       assert.isFalse not linkHints.hintMarkerContainingDiv?
       linkHints.deactivateMode()
       assert.isTrue not linkHints.hintMarkerContainingDiv?
@@ -91,13 +94,13 @@ createGeneralHintTests = (isFilteredMode) ->
         assert.equal element1.getClientRects()[0].left, element2.getClientRects()[0].left
         assert.equal element1.getClientRects()[0].top, element2.getClientRects()[0].top
       stub document.body, "style", "static"
-      linkHints = LinkHints.activateMode()
+      linkHints = activateLinkHintsMode()
       hintMarkers = getHintMarkers()
       assertStartPosition document.getElementsByTagName("a")[0], hintMarkers[0]
       assertStartPosition document.getElementsByTagName("a")[1], hintMarkers[1]
       linkHints.deactivateMode()
       stub document.body.style, "position", "relative"
-      linkHints = LinkHints.activateMode()
+      linkHints = activateLinkHintsMode()
       hintMarkers = getHintMarkers()
       assertStartPosition document.getElementsByTagName("a")[0], hintMarkers[0]
       assertStartPosition document.getElementsByTagName("a")[1], hintMarkers[1]
@@ -143,8 +146,9 @@ context "Test link hints for focusing input elements correctly",
       input.addEventListener "focus", activeListener, false
       input.addEventListener "click", activeListener, false
 
-      LinkHints.activateMode()
-      [hint] = getHintMarkers().filter (hint) -> input == hint.clickableItem
+      activateLinkHintsMode()
+      [hint] = getHintMarkers().filter (hint) ->
+        input == HintCoordinator.getLocalHintMarker(hint.hint).element
       sendKeyboardEvent char for char in hint.hintString
 
       input.removeEventListener "focus", activeListener, false
@@ -185,7 +189,7 @@ context "Alphabetical link hints",
 
     # Three hints will trigger double hint chars.
     createLinks 3
-    @linkHints = LinkHints.activateMode()
+    @linkHints = activateLinkHintsMode()
 
   tearDown ->
     @linkHints.deactivateMode()
@@ -233,7 +237,7 @@ context "Filtered link hints",
       initializeModeState()
       testContent = "<a>test</a>" + "<a>tress</a>" + "<a>trait</a>" + "<a>track<img alt='alt text'/></a>"
       document.getElementById("test-div").innerHTML = testContent
-      @linkHints = LinkHints.activateMode()
+      @linkHints = activateLinkHintsMode()
 
     tearDown ->
       document.getElementById("test-div").innerHTML = ""
@@ -264,7 +268,7 @@ context "Filtered link hints",
       testContent = "<a><img alt='alt text'/></a><a><img alt='alt text' title='some title'/></a>
         <a><img title='some title'/></a>" + "<a><img src='' width='320px' height='100px'/></a>"
       document.getElementById("test-div").innerHTML = testContent
-      @linkHints = LinkHints.activateMode()
+      @linkHints = activateLinkHintsMode()
 
     tearDown ->
       document.getElementById("test-div").innerHTML = ""
@@ -289,7 +293,7 @@ context "Filtered link hints",
         <input type='text' id='test-input' value='some value'/>
         <label for='test-input-2'/>a label: </label><input type='text' id='test-input-2' value='some value'/>"
       document.getElementById("test-div").innerHTML = testContent
-      @linkHints = LinkHints.activateMode()
+      @linkHints = activateLinkHintsMode()
 
     tearDown ->
       document.getElementById("test-div").innerHTML = ""

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -62,7 +62,7 @@ getHintMarkers = ->
 stubSettings = (key, value) -> stub Settings.cache, key, JSON.stringify value
 
 HintCoordinator.sendMessage = (name, request = {}) -> HintCoordinator[name]? request; request
-activateLinkHintsMode = -> HintCoordinator.activateLinkHintsMode HintCoordinator.getHints()
+activateLinkHintsMode = -> HintCoordinator.activateMode HintCoordinator.getHintDescriptors()
 
 #
 # Generate tests that are common to both default and filtered
@@ -148,7 +148,7 @@ context "Test link hints for focusing input elements correctly",
 
       activateLinkHintsMode()
       [hint] = getHintMarkers().filter (hint) ->
-        input == HintCoordinator.getLocalHintMarker(hint.hint).element
+        input == HintCoordinator.getLocalHintMarker(hint.hintDescriptor).element
       sendKeyboardEvent char for char in hint.hintString
 
       input.removeEventListener "focus", activeListener, false

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -160,7 +160,7 @@ context "Test link hints for changing mode",
     initializeModeState()
     testDiv = document.getElementById("test-div")
     testDiv.innerHTML = "<a>link</a>"
-    @linkHints = LinkHints.activateMode()
+    @linkHints = activateLinkHintsMode()
 
   tearDown ->
     document.getElementById("test-div").innerHTML = ""
@@ -328,9 +328,9 @@ context "Filtered link hints",
         {id: 9, text: "test abc one - longer still"}         # For tab test - 3.
       ].map(({id,text}) -> "<a id=\"#{id}\">#{text}</a>").join " "
       document.getElementById("test-div").innerHTML = testContent
-      @linkHints = LinkHints.activateMode()
+      @linkHints = activateLinkHintsMode()
       @getActiveHintMarker = ->
-        @linkHints.markerMatcher.activeHintMarker.clickableItem.id
+        HintCoordinator.getLocalHintMarker(@linkHints.markerMatcher.activeHintMarker.hintDescriptor).element.id
 
     tearDown ->
       document.getElementById("test-div").innerHTML = ""


### PR DESCRIPTION
This implements global link hints (so, link hints can be used to activate hints across *all* frames).

Observation:

- `LinkHintsMode` has very little to do with links.  It does three things: 1. find clickable things, 2. show hints and pick one, 3. "click" the thing we picked.
- 1. and 3. happen at the start and end.  Everything in between (2.) has *nothing* to do with links.  We're just picking something.  And that's where much of the link-hints logic is.
- Therefore, we can equally pick things which are not in the current frame.  So, we can pick hints from the current frame along with hints from other frames all at the same time.  We just don't display the hints from other frames.
- Therefore, if we give all frames *exactly the same list of things*, and run `linkHintsMode` in all frames, and feed them all the same key state, then they will all end up picking the same thing.
- When we pick a thing, we activate it in its own frame and silently exit in all other frames.

So that's the approach here.  We generate a list of hint descriptors (frame Id, rect, and for filtered hints the link's text and "show" state), and pass that list to a `LinkHintsMode` instance in _every frame_.  Each frame has everything it needs to know about every hint in every frame.  We then run those link-hint modes in lock step until a hint descriptor is chosen.

Use cases:

- You can pick conversations from the Hangouts frame in Google Inbox while the main frame has the focus.  (I haven't tried GMail, but it's probably the same.)
- You can select the little iframe popups that appear in Google inbox (e.g., "Confirm Sweep", "Undo Discard").

Test pages: [Google Inbox](https://inbox.google.com/u/0/), a [frames](http://www.quackit.com/html/templates/frames/frames_example_5.html) test page.

To do:

- ~~Fix tests.~~
- Many of the variable names and comments are out of date.  However, I've left them as is for now to keep the diff as simple as possible.
- There is some code which is in the wrong place.  In particular, the code for finding clickable things is physically in the middle of the (old) link-hints class.  This needs to be moved out.  However, here we go through some gymnastics to avoid doing it right now, since it would make the diff unnecessarily difficult to read.
- ~~It's broken on the help dialog, but that looks like another artefact #2045.~~

Background... I've tried several approaches to implementing global link hints (as have others, #1182).  The problem is that they all become pretty complicated very quickly, and end up having a massive footprint.  The observation at the top of this post seems to point the way to the a relatively simple implementation.  It's still complicated, but probably more manageable.

Edit... More "to do":

- ~~Reinstate filtering for hints with hrefs for modes which only use those.~~
- ~~Reinstate Shift/Ctrl to toggle hint mode.~~