### PR TITLE
Add options-page button to sort exclusion rules.

### DIFF
--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -133,8 +133,8 @@ class ExclusionRulesOption extends Option
     rules = @readValueFromElement()
     for rule in rules
       key = rule.pattern
-      key = RegExp.$1 if 0 == key.search /[a-z?*]+:\/\/(.*)/
-      key = RegExp.$1 if 0 == key.search /www\.(.*)/
+      key = RegExp.$1 if 0 == key.search /^[a-z?*]+:\/\/(.*)/
+      key = RegExp.$1 if 0 == key.search /^www\.(.*)/
       rule.key = key
 
     rules.sort (a,b) -> if a.key < b.key then -1 else if b.key < a.key then 1 else 0

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -80,6 +80,8 @@ class ExclusionRulesOption extends Option
     super(args...)
     $("exclusionAddButton").addEventListener "click", (event) =>
       @addRule()
+    $("exclusionSortButton").addEventListener "click", (event) =>
+      @sortRules()
 
   # Add a new rule, focus its pattern, scroll it into view, and return the newly-added element.  On the
   # options page, there is no current URL, so there is no initial pattern.  This is the default.  On the popup
@@ -126,6 +128,19 @@ class ExclusionRulesOption extends Option
   getPattern: (element) -> element.querySelector(".pattern")
   getPassKeys: (element) -> element.querySelector(".passKeys")
   getRemoveButton: (element) -> element.querySelector(".exclusionRemoveButton")
+
+  sortRules: ->
+    rules = @readValueFromElement()
+    for rule in rules
+      key = rule.pattern
+      key = RegExp.$1 if 0 == key.search /[a-z?*]+:\/\/(.*)/
+      key = RegExp.$1 if 0 == key.search /www\.(.*)/
+      rule.key = key
+
+    rules.sort (a,b) -> if a.key < b.key then -1 else if b.key < a.key then 1 else 0
+    @element.innerHTML = ""
+    @appendRule rule for rule in rules
+    @onUpdated()
 
 # ExclusionRulesOnPopupOption is ExclusionRulesOption, extended with some UI tweeks suitable for use in the
 # page popup.  This also differs from ExclusionRulesOption in that, on the page popup, there is always a URL

--- a/pages/options.css
+++ b/pages/options.css
@@ -201,10 +201,11 @@ input.pattern, input.passKeys, .exclusionHeaderText {
   padding-left: 3px;
   color: #979ca0;
 }
-#exclusionAddButton {
+#exclusionAddButton, #exclusionSortButton {
   float: right;
   margin-right: 0px;
   margin-top: 5px;
+  margin-left: 5px;
 }
 #footer {
   background: #f5f5f5;

--- a/pages/options.css
+++ b/pages/options.css
@@ -201,10 +201,12 @@ input.pattern, input.passKeys, .exclusionHeaderText {
   padding-left: 3px;
   color: #979ca0;
 }
-#exclusionAddButton, #exclusionSortButton {
+#exclusionButtons {
   float: right;
-  margin-right: 0px;
   margin-top: 5px;
+}
+#exclusionAddButton, #exclusionSortButton {
+  margin-right: 0px;
   margin-left: 5px;
 }
 #footer {

--- a/pages/options.html
+++ b/pages/options.html
@@ -26,8 +26,10 @@
                <div id="exclusionScrollBox">
                   <!-- Populated from exclusions.html by options.coffee. -->
                </div>
-               <button id="exclusionAddButton">Add Rule</button>
-               <button id="exclusionSortButton">Sort Rules</button>
+               <div id="exclusionButtons">
+                 <button id="exclusionSortButton">Sort Rules</button>
+                 <button id="exclusionAddButton">Add Rule</button>
+               </div>
             </div>
           </td>
         </tr>

--- a/pages/options.html
+++ b/pages/options.html
@@ -27,6 +27,7 @@
                   <!-- Populated from exclusions.html by options.coffee. -->
                </div>
                <button id="exclusionAddButton">Add Rule</button>
+               <button id="exclusionSortButton">Sort Rules</button>
             </div>
           </td>
         </tr>


### PR DESCRIPTION
After a while, the list of exclusion rules on the options page can become quite long, and it can be difficult to find the rule (or rules) pertaining to a particular site.

This adds a button to the options page to sort the rules.  The sort order currently is...  strip any leading `protocol://`, then strip any leading `www.`, then sort what's left.  So `https://github.com` and `http://www.github.com` sort beside each other.

It currently looks like this...

![snapshot](https://cloud.githubusercontent.com/assets/2641335/13729806/ac6fd814-e935-11e5-9ec0-6a241ca4f663.png)

(Perhaps it would look better if the buttons were of equal width?)