### PR TITLE
Use port for frames

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -423,7 +423,7 @@ bgLog = (request, sender) ->
 # Port handler mapping
 portHandlers =
   completions: handleCompletions
-  domReady: Frames.onConnect.bind Frames
+  frames: Frames.onConnect.bind Frames
 
 sendRequestHandlers =
   runBackgroundCommand: runBackgroundCommand

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -384,11 +384,12 @@ Frames =
     port.postMessage name: "registerFrameId", chromeFrameId: frameId
 
     port.onDisconnect.addListener listener = ->
-      if tabId of frameIdsForTab
-        if frameId == 0 # This is the top frame in the tab.
-          delete frameIdsForTab[tabId]
-        else
-          frameIdsForTab[tabId] = frameIdsForTab[tabId].filter (fId) -> fId != frameId
+      # Unregister the frame.  However, we never unregister the main/top frame.  If the tab is navigating to
+      # another page, then there'll be a new top frame (with the same Id) along soon.  If the tab is closing,
+      # then we'll tidy up in the chrome.tabs.onRemoved listener, below.  This approach avoids a dependency on
+      # the order in which register and unregister events happens.
+      if tabId of frameIdsForTab and tabId != 0
+        frameIdsForTab[tabId] = frameIdsForTab[tabId].filter (fId) -> fId != frameId
       port.onDisconnect.removeListener listener
 
 handleFrameFocused = (request, sender) ->

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -380,14 +380,17 @@ openOptionsPageInNewTab = ->
 Frames =
   onConnect: (sender, port) ->
     [tabId, frameId] = [sender.tab.id, sender.frameId]
-    (frameIdsForTab[tabId] ?= []).push frameId
+    # We always add frameId 0, the top frame, automatically, and never unregister it.
+    frameIdsForTab[tabId] ?= [0]
+    frameIdsForTab[tabId].push frameId unless frameId == 0
     port.postMessage name: "registerFrameId", chromeFrameId: frameId
 
     port.onDisconnect.addListener listener = ->
       # Unregister the frame.  However, we never unregister the main/top frame.  If the tab is navigating to
       # another page, then there'll be a new top frame (with the same Id) along soon.  If the tab is closing,
-      # then we'll tidy up in the chrome.tabs.onRemoved listener, below.  This approach avoids a dependency on
-      # the order in which register and unregister events happens.
+      # then we'll tidy up in the chrome.tabs.onRemoved listener, below.  This approach avoids any dependency
+      # on the order in which register and unregister events happens (on navigation, a new top frame
+      # registering before the old one is deregistered).
       if tabId of frameIdsForTab and tabId != 0
         frameIdsForTab[tabId] = frameIdsForTab[tabId].filter (fId) -> fId != frameId
       port.onDisconnect.removeListener listener

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -381,6 +381,7 @@ Frames =
   onConnect: (sender, port) ->
     [tabId, frameId] = [sender.tab.id, sender.frameId]
     # We always add frameId 0, the top frame, automatically, and never unregister it.
+    frameIdsForTab[tabId]?
     frameIdsForTab[tabId] ?= [0]
     frameIdsForTab[tabId].push frameId unless frameId == 0
     port.postMessage name: "registerFrameId", chromeFrameId: frameId
@@ -391,14 +392,14 @@ Frames =
       # then we'll tidy up in the chrome.tabs.onRemoved listener, below.  This approach avoids any dependency
       # on the order in which register and unregister events happens (on navigation, a new top frame
       # registering before the old one is deregistered).
-      if tabId of frameIdsForTab and tabId != 0
+      if tabId of frameIdsForTab and frameId != 0
         frameIdsForTab[tabId] = frameIdsForTab[tabId].filter (fId) -> fId != frameId
       port.onDisconnect.removeListener listener
 
 handleFrameFocused = (request, sender) ->
   [tabId, frameId] = [sender.tab.id, sender.frameId]
   # This might be the first time we've heard from this tab.
-  frameIdsForTab[tabId] ?= []
+  frameIdsForTab[tabId] ?= [0]
   # Cycle frameIdsForTab to the focused frame.
   frameIdsForTab[tabId] = cycleToFrame frameIdsForTab[tabId], frameId
   # Inform all frames that a frame has received the focus.

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -360,10 +360,9 @@ Frames =
 
     port.onDisconnect.addListener listener = ->
       # Unregister the frame.  However, we never unregister the main/top frame.  If the tab is navigating to
-      # another page, then there'll be a new top frame (with the same Id) along soon.  If the tab is closing,
-      # then we'll tidy up in the chrome.tabs.onRemoved listener, below.  This approach avoids any dependency
-      # on the order in which register and unregister events happens (e.g. on navigation, a new top frame
-      # registering before the old one is deregistered).
+      # another page, then there'll be a new top frame with the same Id soon.  If the tab is closing, then
+      # we tidy up in the chrome.tabs.onRemoved listener.  This elides any dependency on the order in which
+      # events happen (e.g. on navigation, a new top frame registers before the old one unregisters).
       if tabId of frameIdsForTab and frameId != 0
         frameIdsForTab[tabId] = frameIdsForTab[tabId].filter (fId) -> fId != frameId
 

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -367,7 +367,6 @@ Frames =
   onConnect: (sender, port) ->
     [tabId, frameId] = [sender.tab.id, sender.frameId]
     # We always add frameId 0, the top frame, automatically, and never unregister it.
-    frameIdsForTab[tabId]?
     frameIdsForTab[tabId] ?= [0]
     frameIdsForTab[tabId].push frameId unless frameId == 0
     port.postMessage handler: "registerFrameId", chromeFrameId: frameId
@@ -376,7 +375,7 @@ Frames =
       # Unregister the frame.  However, we never unregister the main/top frame.  If the tab is navigating to
       # another page, then there'll be a new top frame (with the same Id) along soon.  If the tab is closing,
       # then we'll tidy up in the chrome.tabs.onRemoved listener, below.  This approach avoids any dependency
-      # on the order in which register and unregister events happens (on navigation, a new top frame
+      # on the order in which register and unregister events happens (e.g. on navigation, a new top frame
       # registering before the old one is deregistered).
       if tabId of frameIdsForTab and frameId != 0
         frameIdsForTab[tabId] = frameIdsForTab[tabId].filter (fId) -> fId != frameId

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -1,5 +1,5 @@
 #
-# This content script  must be run prior to domReady so that we perform some operations very early.
+# This content script must be run prior to domReady so that we perform some operations very early.
 #
 
 isEnabledForUrl = true
@@ -224,12 +224,10 @@ Frame =
     @port.onMessage.addListener (request) =>
       handler request for handler in @listeners[request.handler]
 
-    @port.onDisconnect.addListener =>
-      # We disable content scripts when we lose contact with the background page.
+    @port.onDisconnect.addListener ->
+      # We disable the content scripts when we lose contact with the background page.
       isEnabledForUrl = false
-      chrome.runtime.sendMessage = ->
       window.removeEventListener "focus", onFocus
-      @port.postMessage = ->
 
 handleShowHUDforDuration = ({ text, duration }) ->
   if DomUtils.isTopFrame()
@@ -271,7 +269,7 @@ focusThisFrame = (request) ->
   unless request.forceFocusThisFrame
     if window.innerWidth < 3 or window.innerHeight < 3 or document.body?.tagName.toLowerCase() == "frameset"
       # This frame is too small to focus or it's a frameset. Cancel and tell the background page to focus the
-      # next frame instead.  This affects sites like Google Inbox, which have many tiny iframes. See 1317.
+      # next frame instead.  This affects sites like Google Inbox, which have many tiny iframes. See #1317.
       chrome.runtime.sendMessage handler: "nextFrame", frameId: frameId
       return
   window.focus()

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -169,7 +169,7 @@ initializePreDomReady = ->
 # Wrapper to install event listeners.  Syntactic sugar.
 installListener = (element, event, callback) ->
   element.addEventListener(event, ->
-    if isEnabledForUrl and frameId? then callback.apply(this, arguments) else true
+    if isEnabledForUrl then callback.apply(this, arguments) else true
   , true)
 
 #

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -214,25 +214,13 @@ window.addEventListener "hashchange", onFocus
 #
 initializeOnDomReady = ->
   # Tell the background page we're in the dom ready state.
-  chrome.runtime.connect(name: "domReady").onDisconnect.addListener ->
+  port = chrome.runtime.connect name: "domReady"
+  port.postMessage handler: "registerFrame", frameId: frameId, isTopFrame: DomUtils.isTopFrame()
+  port.onDisconnect.addListener ->
     # We disable content scripts when we lose contact with the background page.
     isEnabledForUrl = false
     chrome.runtime.sendMessage = ->
     window.removeEventListener "focus", onFocus
-
-registerFrame = ->
-  # Don't register frameset containers; focusing them is no use.
-  unless document.body?.tagName.toLowerCase() == "frameset"
-    chrome.runtime.sendMessage
-      handler: "registerFrame"
-      frameId: frameId
-
-# Unregister the frame if we're going to exit.
-unregisterFrame = ->
-  chrome.runtime.sendMessage
-    handler: "unregisterFrame"
-    frameId: frameId
-    tab_is_closing: DomUtils.isTopFrame()
 
 handleShowHUDforDuration = ({ text, duration }) ->
   if DomUtils.isTopFrame()
@@ -271,12 +259,12 @@ DomUtils.documentReady ->
 # Called from the backend in order to change frame focus.
 #
 focusThisFrame = (request) ->
-  if window.innerWidth < 3 or window.innerHeight < 3
-    # This frame is too small to focus. Cancel and tell the background frame to focus the next one instead.
-    # This affects sites like Google Inbox, which have many tiny iframes. See #1317.
-    # Here we're assuming that there is at least one frame large enough to focus.
-    chrome.runtime.sendMessage({ handler: "nextFrame", frameId: frameId })
-    return
+  unless request.forceFocusThisFrame
+    if window.innerWidth < 3 or window.innerHeight < 3 or document.body?.tagName.toLowerCase() == "frameset"
+      # This frame is too small to focus or its a frameset. Cancel and tell the background page to focus the
+      # next frame instead.  This affects sites like Google Inbox, which have many tiny iframes. See 1317.
+      chrome.runtime.sendMessage handler: "nextFrame", frameId: frameId
+      return
   window.focus()
   flashFrame() if request.highlight
 
@@ -317,7 +305,7 @@ extend window,
   goToRoot: ->
     window.location.href = window.location.origin
 
-  mainFrame: -> focusThisFrame highlight: true
+  mainFrame: -> focusThisFrame highlight: true, forceFocusThisFrame: true
 
   toggleViewSource: ->
     chrome.runtime.sendMessage { handler: "getCurrentTabUrl" }, (url) ->
@@ -662,8 +650,6 @@ window.HelpDialog ?=
 
 initializePreDomReady()
 DomUtils.documentReady initializeOnDomReady
-DomUtils.documentReady registerFrame
-window.addEventListener "unload", unregisterFrame
 
 root = exports ? window
 root.handlerStack = handlerStack

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -225,11 +225,11 @@ Frame =
   registerFrameId: ({chromeFrameId}) -> frameId = window.frameId = chromeFrameId
 
   init: (callback) ->
+    @addEventListener "registerFrameId", Frame.registerFrameId
     @port = chrome.runtime.connect name: "frames"
+    @port.onDisconnect.addListener => @port.postMessage = ->
     @port.onMessage.addListener (request) =>
       handler request for handler in @listeners[request.handler]
-
-    @addEventListener "registerFrameId", Frame.registerFrameId
 
 handleShowHUDforDuration = ({ text, duration }) ->
   if DomUtils.isTopFrame()
@@ -270,7 +270,7 @@ DomUtils.documentReady ->
 focusThisFrame = (request) ->
   unless request.forceFocusThisFrame
     if window.innerWidth < 3 or window.innerHeight < 3 or document.body?.tagName.toLowerCase() == "frameset"
-      # This frame is too small to focus or its a frameset. Cancel and tell the background page to focus the
+      # This frame is too small to focus or it's a frameset. Cancel and tell the background page to focus the
       # next frame instead.  This affects sites like Google Inbox, which have many tiny iframes. See 1317.
       chrome.runtime.sendMessage handler: "nextFrame", frameId: frameId
       return
@@ -476,7 +476,6 @@ checkIfEnabledForUrl = do ->
 # correct enabled state (but only if this frame has the focus).
 checkEnabledAfterURLChange = ->
   checkIfEnabledForUrl() if windowIsFocused()
-
 
 window.handleEscapeForFindMode = ->
   document.body.classList.remove("vimiumFindMode")

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -2,6 +2,7 @@
 # Install frontend event handlers.
 installListeners()
 HUD.init()
+Frame.registerFrameId chromeFrameId: 0
 
 installListener = (element, event, callback) ->
   element.addEventListener event, (-> callback.apply(this, arguments)), true

--- a/tests/unit_tests/exclusion_test.coffee
+++ b/tests/unit_tests/exclusion_test.coffee
@@ -20,7 +20,7 @@ extend(global, require "../../background_scripts/commands.js")
 extend(global, require "../../background_scripts/main.js")
 
 isEnabledForUrl = (request) ->
-  Frames.isEnabledForUrl {request, tabId: 0, port: postMessage: (id) -> id}
+  Frames.isEnabledForUrl {request, tabId: 0, port: postMessage: (request) -> request}
 
 # These tests cover only the most basic aspects of excluded URLs and passKeys.
 #

--- a/tests/unit_tests/exclusion_test.coffee
+++ b/tests/unit_tests/exclusion_test.coffee
@@ -19,7 +19,8 @@ extend(global, require "../../background_scripts/exclusions.js")
 extend(global, require "../../background_scripts/commands.js")
 extend(global, require "../../background_scripts/main.js")
 
-isEnabledForUrl = (request) -> Frames.isEnabledForUrl {request, tabId: 0}
+isEnabledForUrl = (request) ->
+  Frames.isEnabledForUrl {request, tabId: 0, port: postMessage: (id) -> id}
 
 # These tests cover only the most basic aspects of excluded URLs and passKeys.
 #

--- a/tests/unit_tests/exclusion_test.coffee
+++ b/tests/unit_tests/exclusion_test.coffee
@@ -19,6 +19,8 @@ extend(global, require "../../background_scripts/exclusions.js")
 extend(global, require "../../background_scripts/commands.js")
 extend(global, require "../../background_scripts/main.js")
 
+isEnabledForUrl = (request) -> Frames.isEnabledForUrl {request, tabId: 0}
+
 # These tests cover only the most basic aspects of excluded URLs and passKeys.
 #
 context "Excluded URLs and pass keys",


### PR DESCRIPTION
This is a bundle of small changes related to managing frames and frame Ids.

**Register/unregister**.  Use the `domReady` port connect/disconnect events to register and unregister frames.  As far as I know, the existing logic is sound.  However, it's always looked a bit flakey (e.g., the fact that [this](https://github.com/philc/vimium/blob/1.54/background_scripts/main.coffee#L687) is needed).  (This is related to point 1 in  [this comment](https://github.com/philc/vimium/pull/2048#issuecomment-196176731).)

**Framesets**.  Unlikely previously, here we *do* register framesets (and skip over them in `focusThisFrame` instead).  This just seems like a better approach.  It means that `frameIdsForTab` *really is* a list of all of the frame Ids in which we're running.

**Frame Ids**.  This changes from using a random frame Id (which has always seemed dodgy), to using Chrome frame Ids -- which are guaranteed to be unique.  Also, a Chrome frameId of `0` is the top frame, which might prove helpful.

Going forward, I can see us moving more messages onto the port (e.g. `checkIfEnabledForUrl`) and possibly reducing our dependence on our own `frameId`.  And there are probably other ways in which the frame-handling logic can be simplified.