### PR TITLE
Implement yanking tab url in markdown form. Mapped to 'ym' be default.

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -45,5 +45,6 @@ Contributors:
   Utkarsh Upadhyay <musically.ut@gmail.com) (github: musically-ut)
   Michael Salihi <admin@prestance-informatique.fr> (github: PrestanceDesign)
   Dahan Gong <gdh1995@qq.com> (github: gdh1995)
+  Ivan Smirnov <ismirnov@google.com> (github: issmirnov)
 
 Feel free to add real names in addition to GitHub usernames.

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -134,6 +134,7 @@ Commands =
       "reload",
       "toggleViewSource",
       "copyCurrentUrl",
+      "copyCurrentUrlMarkdown"
       "LinkHints.activateModeToCopyLinkUrl",
       "openCopiedUrlInCurrentTab",
       "openCopiedUrlInNewTab",
@@ -253,6 +254,7 @@ defaultKeyMappings =
   "]]": "goNext"
 
   "yy": "copyCurrentUrl"
+  "ym": "copyCurrentUrlMarkdown"
   "yf": "LinkHints.activateModeToCopyLinkUrl"
 
   "p": "openCopiedUrlInCurrentTab"
@@ -318,6 +320,7 @@ commandDescriptions =
   toggleViewSource: ["View page source", { noRepeat: true }]
 
   copyCurrentUrl: ["Copy the current URL to the clipboard", { noRepeat: true }]
+  copyCurrentUrlMarkdown: ["Copy the current URL in markdown form to the clipboard", { noRepeat: true }]
   "LinkHints.activateModeToCopyLinkUrl": ["Copy a link URL to the clipboard", { passCountToFunction: true }]
   openCopiedUrlInCurrentTab: ["Open the clipboard's URL in the current tab", { background: true }]
   openCopiedUrlInNewTab: ["Open the clipboard's URL in a new tab", { background: true, repeatLimit: 20 }]

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -103,6 +103,12 @@ logMessage = do ->
 getCurrentTabUrl = (request, sender) -> sender.tab.url
 
 #
+# Returns a payload containing the tab url and the title. This is used client side to generate a markdown link.
+#
+getCurrentTabUrlMarkdown = (request, sender) -> {url : sender.tab.url, title: sender.tab.title }
+
+
+#
 # Checks the user's preferences in local storage to determine if Vimium is enabled for the given URL, and
 # whether any keys should be passed through to the underlying page.
 # The source frame also informs us whether or not it has the focus, which allows us to track the URL of the
@@ -424,6 +430,7 @@ portHandlers =
 sendRequestHandlers =
   runBackgroundCommand: runBackgroundCommand
   getCurrentTabUrl: getCurrentTabUrl
+  getCurrentTabUrlMarkdown: getCurrentTabUrlMarkdown
   openUrlInNewTab: TabOperations.openUrlInNewTab
   openUrlInIncognito: TabOperations.openUrlInIncognito
   openUrlInCurrentTab: TabOperations.openUrlInCurrentTab

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -336,6 +336,16 @@ extend window,
       url = url[0..25] + "...." if 28 < url.length
       HUD.showForDuration("Yanked #{url}", 2000)
 
+  copyCurrentUrlMarkdown: ->
+    chrome.runtime.sendMessage { handler: "getCurrentTabUrlMarkdown" }, (payload) ->
+      url = payload.url
+      title = payload.title
+      link = "[" + title + "]" + "(" + url + ")"
+      chrome.runtime.sendMessage { handler: "copyToClipboard", data: link }
+      #url = url[0..25] + "...." if 28 < url.length
+      #HUD.showForDuration("Yanked #{url}", 2000)
+      HUD.showForDuration("Yanked markdown link.", 2000)
+
   enterInsertMode: ->
     # If a focusable element receives the focus, then we exit and leave the permanently-installed insert-mode
     # instance to take over.


### PR DESCRIPTION
Hello. Please review a small patch that adds the capability to yank a url to markdown form. I find myself often using `yy` and then manually adding the title - this will greatly speed up the workflow of all people working with markdown tools.

If you're happy with the code quality, docs message and default mapping please merge!