### PR TITLE
Perform background commands on the requesting tab (v2)

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -298,7 +298,7 @@ defaultKeyMappings =
 # If the noRepeat and repeatLimit options are both specified, then noRepeat takes precedence.
 commandDescriptions =
   # Navigating the current page
-  showHelp: ["Show help", { background: true }]
+  showHelp: ["Show help", { background: true, noRepeat: true }]
   scrollDown: ["Scroll down", { passCountToFunction: true }]
   scrollUp: ["Scroll up", { passCountToFunction: true }]
   scrollLeft: ["Scroll left", { passCountToFunction: true }]
@@ -319,7 +319,7 @@ commandDescriptions =
 
   copyCurrentUrl: ["Copy the current URL to the clipboard", { noRepeat: true }]
   "LinkHints.activateModeToCopyLinkUrl": ["Copy a link URL to the clipboard", { passCountToFunction: true }]
-  openCopiedUrlInCurrentTab: ["Open the clipboard's URL in the current tab", { background: true }]
+  openCopiedUrlInCurrentTab: ["Open the clipboard's URL in the current tab", { background: true, noRepeat: true }]
   openCopiedUrlInNewTab: ["Open the clipboard's URL in a new tab", { background: true, repeatLimit: 20 }]
 
   enterInsertMode: ["Enter insert mode", { noRepeat: true }]
@@ -353,28 +353,28 @@ commandDescriptions =
   goToRoot: ["Go to root of current URL hierarchy", { passCountToFunction: true }]
 
   # Manipulating tabs
-  nextTab: ["Go one tab right", { background: true, passCountToFunction: true }]
-  previousTab: ["Go one tab left", { background: true, passCountToFunction: true }]
-  visitPreviousTab: ["Go to previously-visited tab", { background: true, passCountToFunction: true }]
-  firstTab: ["Go to the first tab", { background: true, passCountToFunction: true }]
-  lastTab: ["Go to the last tab", { background: true, passCountToFunction: true }]
+  nextTab: ["Go one tab right", { background: true }]
+  previousTab: ["Go one tab left", { background: true }]
+  visitPreviousTab: ["Go to previously-visited tab", { background: true }]
+  firstTab: ["Go to the first tab", { background: true }]
+  lastTab: ["Go to the last tab", { background: true }]
 
   createTab: ["Create new tab", { background: true, repeatLimit: 20 }]
-  duplicateTab: ["Duplicate current tab", { background: true, passCountToFunction: true, repeatLimit: 20 }]
-  removeTab: ["Close current tab", { background: true, passCountToFunction: true, repeatLimit:
+  duplicateTab: ["Duplicate current tab", { background: true, repeatLimit: 20 }]
+  removeTab: ["Close current tab", { background: true, repeatLimit:
     # Require confirmation to remove more tabs than we can restore.
     (if chrome.session then chrome.session.MAX_SESSION_RESULTS else 25) }]
   restoreTab: ["Restore closed tab", { background: true, repeatLimit: 20 }]
 
-  moveTabToNewWindow: ["Move tab to new window", { background: true, passCountToFunction: true }]
-  togglePinTab: ["Pin/unpin current tab", { background: true }]
+  moveTabToNewWindow: ["Move tab to new window", { background: true }]
+  togglePinTab: ["Pin/unpin current tab", { background: true, noRepeat: true }]
 
   closeTabsOnLeft: ["Close tabs on the left", {background: true, noRepeat: true}]
   closeTabsOnRight: ["Close tabs on the right", {background: true, noRepeat: true}]
   closeOtherTabs: ["Close all other tabs", {background: true, noRepeat: true}]
 
-  moveTabLeft: ["Move tab to the left", { background: true, passCountToFunction: true }]
-  moveTabRight: ["Move tab to the right", { background: true, passCountToFunction: true  }]
+  moveTabLeft: ["Move tab to the left", { background: true }]
+  moveTabRight: ["Move tab to the right", { background: true }]
 
   "Vomnibar.activate": ["Open URL, bookmark, or history entry", { topFrame: true }]
   "Vomnibar.activateInNewTab": ["Open URL, bookmark, history entry, in a new tab", { topFrame: true }]
@@ -384,7 +384,7 @@ commandDescriptions =
   "Vomnibar.activateEditUrl": ["Edit the current URL", { topFrame: true }]
   "Vomnibar.activateEditUrlInNewTab": ["Edit the current URL and open in a new tab", { topFrame: true }]
 
-  nextFrame: ["Cycle forward to the next frame on the page", { background: true, passCountToFunction: true }]
+  nextFrame: ["Cycle forward to the next frame on the page", { background: true }]
   mainFrame: ["Select the tab's main/top frame", { topFrame: true, noRepeat: true }]
 
   "Marks.activateCreateMode": ["Create a new mark", { noRepeat: true }]

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -150,7 +150,7 @@ TabOperations =
   openUrlInCurrentTab: (request) ->
     chrome.tabs.update request.tabId, url: Utils.convertToUrl request.url
 
-  # Opens request.url in new tab and switches to it if request.selected is true.
+  # Opens request.url in new tab and switches to it.
   openUrlInNewTab: (request, callback = (->)) ->
     tabConfig =
       url: Utils.convertToUrl request.url

--- a/background_scripts/marks.coffee
+++ b/background_scripts/marks.coffee
@@ -50,7 +50,7 @@ Marks =
             duration: 1000
         else if markInfo.vimiumSecret != vimiumSecret
           # This is a different Vimium instantiation, so markInfo.tabId is definitely out of date.
-          @focusOrLaunch markInfo
+          @focusOrLaunch markInfo, req
         else
           # Check whether markInfo.tabId still exists.  According to here (https://developer.chrome.com/extensions/tabs),
           # tab Ids are unqiue within a Chrome session.  So, if we find a match, we can use it.
@@ -60,7 +60,7 @@ Marks =
               @gotoPositionInTab markInfo
             else
               # The original tab no longer exists.
-              @focusOrLaunch markInfo
+              @focusOrLaunch markInfo, req
 
   # Focus an existing tab and scroll to the given position within it.
   gotoPositionInTab: ({ tabId, scrollX, scrollY, markName }) ->
@@ -74,7 +74,7 @@ Marks =
 
   # The tab we're trying to find no longer exists.  We either find another tab with a matching URL and use it,
   # or we create a new tab.
-  focusOrLaunch: (markInfo) ->
+  focusOrLaunch: (markInfo, req) ->
     chrome.tabs.query { url: markInfo.url }, (tabs) =>
       if 0 < tabs.length
         # We have a matching tab: use it (prefering, if there are more than one, one in the current window).
@@ -82,7 +82,7 @@ Marks =
           @gotoPositionInTab extend markInfo, tabId: tab.id
       else
         # There is no existing matching tab, we'll have to create one.
-        TabOperations.openUrlInNewTab { url: @getBaseUrl markInfo.url }, (tab) =>
+        TabOperations.openUrlInNewTab (extend req, url: @getBaseUrl markInfo.url), (tab) =>
           # Note. tabLoadedHandlers is defined in "main.coffee".  The handler below will be called when the tab
           # is loaded, its DOM is ready and it registers with the background page.
           tabLoadedHandlers[tab.id] = => @gotoPositionInTab extend markInfo, tabId: tab.id

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -313,7 +313,7 @@ extend window,
         url = url.substr(12, url.length - 12)
       else
         url = "view-source:" + url
-      chrome.runtime.sendMessage({ handler: "openUrlInNewTab", url: url, selected: true })
+      chrome.runtime.sendMessage {handler: "openUrlInNewTab", url}
 
   copyCurrentUrl: ->
     # TODO(ilya): When the following bug is fixed, revisit this approach of sending back to the background

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -325,7 +325,6 @@ class BackgroundCompleter
       chrome.runtime.sendMessage
         handler: if openInNewTab then "openUrlInNewTab" else "openUrlInCurrentTab"
         url: url
-        selected: openInNewTab
 
     switchToTab: (tabId) -> ->
       chrome.runtime.sendMessage handler: "selectSpecificTab", id: tabId


### PR DESCRIPTION
This does two things:

- It uses the originating tab as the active tab, instead of looking the tab up on the background page.  This avoids a race condition.
- It standardises the arguments passed to all background commands.

This is similar to #1259.  However, #1259 takes the approach of explicitly enumerating (and standardising) each command's arguments.  Here, we extend the `request` with a fixed set of properties (`tab`, `tabId` and `count`), and then pass the `request` around to all commands.  This has two advantages: first, it means any future change to the arguments we need will be less disruptive, and second, it leads a considerable reduction in the number of LoC (-40 here, versus an increase in #1259).

As a follow on (not yet done), we can also have the `frameId` added to the `request` in the background page and cull all of the corresponding code in the content scripts. (Edit: 2dfee7789672ea760d9d592ebd1230d61cfb9be7 does this - but 2dfee7789672ea760d9d592ebd1230d61cfb9be7 is not on this branch.)

Edit: We can also do [this](https://github.com/smblott-github/vimium/tree/standardise-foreground-commands) which gets rid of the `passCountToCommand` option entirely.