### PR TITLE
Fix help dialog issues #2045 (release blockers)

### DIFF
--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -37,12 +37,17 @@ class KeyHandlerMode extends Mode
   onKeydown: (event) ->
     keyChar = KeyboardUtils.getKeyCharString event
     isEscape = KeyboardUtils.isEscape event
-    if isEscape and @countPrefix == 0 and @keyState.length == 1
-      @continueBubbling
-    else if isEscape
+    if isEscape and (@countPrefix != 0 or @keyState.length != 1)
       @keydownEvents[event.keyCode] = true
       @reset()
       false # Suppress event.
+    # If the help dialog loses the focus, then Escape should hide it; see point 2 in #2045.
+    else if isEscape and HelpDialog?.showing
+      @keydownEvents[event.keyCode] = true
+      HelpDialog.hide()
+      @stopBubblingAndTrue
+    else if isEscape
+      @continueBubbling
     else if @isMappedKey keyChar
       @keydownEvents[event.keyCode] = true
       @handleKeyChar keyChar

--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -45,7 +45,7 @@ class KeyHandlerMode extends Mode
     else if isEscape and HelpDialog?.showing
       @keydownEvents[event.keyCode] = true
       HelpDialog.hide()
-      @stopBubblingAndTrue
+      false # Suppress event.
     else if isEscape
       @continueBubbling
     else if @isMappedKey keyChar

--- a/pages/help_dialog.coffee
+++ b/pages/help_dialog.coffee
@@ -27,10 +27,18 @@ HelpDialog =
       HelpDialog.toggleAdvancedCommands, false)
 
     document.documentElement.addEventListener "click", (event) =>
-      @hide() unless @dialogElement.contains event.target
+      # Normally, we hide the help dialog on "click".  On the options page though, we do not.  This allows the
+      # user to view the help page while typing command names into the key mappings input; see #2045.
+      @hide() unless @isVimiumOptionsPage() or @dialogElement.contains event.target
     , false
 
   isReady: -> true
+
+  isVimiumOptionsPage: ->
+    try
+      window.top.isVimiumOptionsPage
+    catch
+      false
 
   show: (html) ->
     for own placeholder, htmlString of html

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -322,4 +322,4 @@ document.addEventListener "DOMContentLoaded", ->
 
 # Exported for tests.
 root = exports ? window
-root.Options = Options
+extend root, {Options, isVimiumOptionsPage: true}


### PR DESCRIPTION
This fixes #2045.  From there...

> There are two issues with the help dialog...

>The help dialog closes if the user clicks outside of it (that is, elsewhere on the page). This makes it not possible to enter new command mappings (on the options page) with the help dialog open (e.g. to read the command names).

> Try this... ?, gf, Esc. Previously, this closed the help dialog. Now, with the help dialog in an iframe (and in part due #2022), the help dialog doesn't see the Esc, so doesn't close.