### PR TITLE
Link hints: false positives and scrollable divs

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -321,8 +321,8 @@ LocalHints =
           while index < position
             candidateDescendant = visibleElements[index].element
             for _ in descendantsToCheck
-              return true if candidateDescendant == element.element
               candidateDescendant = candidateDescendant?.parentElement
+              return true if candidateDescendant == element.element
             index += 1
           false # This is not a false positive.
         element

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -262,7 +262,7 @@ LocalHints =
             reason = "Frame."
       when "div", "ol", "ul"
         isClickable ||=
-          if Scroller.isScrollableElement element
+          if element.clientHeight < element.scrollHeight and Scroller.isScrollableElement element
             reason = "Scroll."
 
     # An element with a class name containing the text "button" might be clickable.  However, real clickables

--- a/content_scripts/scroller.coffee
+++ b/content_scripts/scroller.coffee
@@ -77,12 +77,14 @@ doesScroll = (element, direction, amount, factor) ->
   delta = getSign delta # 1 or -1
   performScroll(element, direction, delta) and performScroll(element, direction, -delta)
 
+isScrollableElement = (element, direction = "y", amount = 1, factor = 1) ->
+  doesScroll(element, direction, amount, factor) and shouldScroll element, direction
+
 # From element and its parents, find the first which we should scroll and which does scroll.
 findScrollableElement = (element, direction, amount, factor) ->
-  while element != document.body and
-    not (doesScroll(element, direction, amount, factor) and shouldScroll(element, direction))
-      element = (DomUtils.getContainingElement element) ? document.body
-  if element == document.body then firstScrollableElement element else element
+  while element != document.body and not isScrollableElement element, direction, amount, factor
+    element = DomUtils.getContainingElement(element) ? document.body
+  element
 
 # On some pages, document.body is not scrollable.  Here, we search the document for the largest visible
 # element which does scroll vertically. This is used to initialize activatedElement. See #1358.
@@ -256,6 +258,9 @@ Scroller =
     element = findScrollableElement activatedElement, direction, pos, 1
     amount = getDimension(element,direction,pos) - element[scrollProperties[direction].axisName]
     CoreScroller.scroll element, direction, amount
+
+  isScrollableElement: (element) ->
+    isScrollableElement element
 
   # Scroll the top, bottom, left and right of element into view.  The is used by visual mode to ensure the
   # focus remains visible.

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -109,6 +109,25 @@ createGeneralHintTests = (isFilteredMode) ->
 createGeneralHintTests false
 createGeneralHintTests true
 
+context "False positives in link-hint",
+
+  setup ->
+    testContent = '<span class="buttonWrapper">false positive<a>clickable</a></span>' + '<span class="buttonWrapper">clickable</span>'
+    document.getElementById("test-div").innerHTML = testContent
+    stubSettings "filterLinkHints", true
+    stubSettings "linkHintNumbers", "12"
+
+  tearDown ->
+    document.getElementById("test-div").innerHTML = ""
+
+  should "handle false positives", ->
+    linkHints = activateLinkHintsMode()
+    hintMarkers = getHintMarkers()
+    linkHints.deactivateMode()
+    assert.equal 2, hintMarkers.length
+    for hintMarker in hintMarkers
+      assert.equal "clickable", hintMarker.linkText
+
 inputs = []
 context "Test link hints for focusing input elements correctly",
 


### PR DESCRIPTION
This builds on #2048 (global link hints) adding two new features:

###### Filter out false positives

We mark any element with a class name containing the text `button` as clickable.  Many of these are wrappers around real clickables.  E.g....

```html
<span class="buttonWrapper"><input type="button"/></span>
```

Here, we treat the outer `span` as a false positive (because a close descendent is a real clickable).  This has two effects:

1. We get fewer useless hints.
2. Because we have fewer hints, it is less common that hint markers overlap, so the hint markers for the real clickables are less likely to be obscured by useless hint markers.

###### Make scrollable divs selectable

Here's an example (using filtered hints):

![snapshot](https://cloud.githubusercontent.com/assets/2641335/14071486/0cac67ec-f4ad-11e5-9754-1afe441f4cf9.png)

Fixes #425.
Fixes #2056.

(I intend to merge this directly; this PR is just for visibility.)