### PR TITLE
Use image data for icons.

### DIFF
--- a/tests/unit_tests/test_chrome_stubs.coffee
+++ b/tests/unit_tests/test_chrome_stubs.coffee
@@ -16,6 +16,8 @@ global.document =
   addEventListener: ->
 
 exports.chrome =
+  areRunningVimiumTests: true
+
   runtime:
     getURL: ->
     getManifest: () ->


### PR DESCRIPTION
This uses image data (instead of a `path`) for the page icon.  It also only builds 19x19 and 38x38 icons, as per the `chrome.browserAction.setIcon()` documentation.

This appears to fix a memory leak related to a recent Chrome regression (versions 49+).

Fixes #2055.