### PR TITLE
Rename handler stack constants, and rework logic for greater clarity

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -750,7 +750,6 @@ class WaitForEnter extends Mode
         else if KeyboardUtils.isEscape event
           @exit()
           callback false # false -> isSuccess.
-        DomUtils.suppressEvent event
 
 root = exports ? window
 root.LinkHints = LinkHints

--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -16,7 +16,7 @@ class InsertMode extends Mode
         new PassNextKeyMode
         return false
 
-      return @stopBubblingAndTrue unless event.type == 'keydown' and KeyboardUtils.isEscape event
+      return @passEventToPage unless event.type == 'keydown' and KeyboardUtils.isEscape event
       DomUtils.suppressKeyupAfterEscape handlerStack
       target = event.srcElement
       if target and DomUtils.isFocusable target
@@ -115,19 +115,19 @@ class PassNextKeyMode extends Mode
       # We exit on blur because, once we lose the focus, we can no longer track key events.
       exitOnBlur: window
       keypress: =>
-        @stopBubblingAndTrue
+        @passEventToPage
 
       keydown: =>
         seenKeyDown = true
         keyDownCount += 1
-        @stopBubblingAndTrue
+        @passEventToPage
 
       keyup: =>
         if seenKeyDown
           unless 0 < --keyDownCount
             unless 0 < --count
               @exit()
-        @stopBubblingAndTrue
+        @passEventToPage
 
 root = exports ? window
 root.InsertMode = InsertMode

--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -14,7 +14,7 @@ class InsertMode extends Mode
       # Check for a pass-next-key key.
       if KeyboardUtils.getKeyCharString(event) in Settings.get "passNextKeyKeys"
         new PassNextKeyMode
-        return false
+        return @suppressEvent
 
       return @passEventToPage unless event.type == 'keydown' and KeyboardUtils.isEscape event
       DomUtils.suppressKeyupAfterEscape handlerStack

--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -102,7 +102,7 @@ class KeyHandlerMode extends Mode
       bgLog "Call #{command.command}[#{count}] (#{@name})"
       @reset()
       @commandHandler {command, count}
-    false # Suppress event.
+    @suppressEvent
 
 root = exports ? window
 root.KeyHandlerMode = KeyHandlerMode

--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -56,8 +56,7 @@ class KeyHandlerMode extends Mode
       # We will possibly be handling a subsequent keypress event, so suppress propagation of this event to
       # prevent triggering page event listeners (e.g. Google instant Search).
       @keydownEvents[event.keyCode] = true
-      DomUtils.suppressPropagation event
-      @passEventToPage
+      @suppressPropagation
     else
       @continueBubbling
 
@@ -76,8 +75,7 @@ class KeyHandlerMode extends Mode
   onKeyup: (event) ->
     return @continueBubbling unless event.keyCode of @keydownEvents
     delete @keydownEvents[event.keyCode]
-    DomUtils.suppressPropagation event
-    @passEventToPage
+    @suppressPropagation
 
   # This tests whether there is a mapping of keyChar in the current key state (and accounts for pass keys).
   isMappedKey: (keyChar) ->

--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -40,12 +40,12 @@ class KeyHandlerMode extends Mode
     if isEscape and (@countPrefix != 0 or @keyState.length != 1)
       @keydownEvents[event.keyCode] = true
       @reset()
-      false # Suppress event.
+      @suppressEvent
     # If the help dialog loses the focus, then Escape should hide it; see point 2 in #2045.
     else if isEscape and HelpDialog?.showing
       @keydownEvents[event.keyCode] = true
       HelpDialog.hide()
-      false # Suppress event.
+      @suppressEvent
     else if isEscape
       @continueBubbling
     else if @isMappedKey keyChar
@@ -57,7 +57,7 @@ class KeyHandlerMode extends Mode
       # prevent triggering page event listeners (e.g. Google instant Search).
       @keydownEvents[event.keyCode] = true
       DomUtils.suppressPropagation event
-      @stopBubblingAndTrue
+      @passEventToPage
     else
       @continueBubbling
 
@@ -68,7 +68,7 @@ class KeyHandlerMode extends Mode
     else if @isCountKey keyChar
       digit = parseInt keyChar
       @reset if @keyState.length == 1 then @countPrefix * 10 + digit else digit
-      false # Suppress event.
+      @suppressEvent
     else
       @reset()
       @continueBubbling
@@ -77,7 +77,7 @@ class KeyHandlerMode extends Mode
     return @continueBubbling unless event.keyCode of @keydownEvents
     delete @keydownEvents[event.keyCode]
     DomUtils.suppressPropagation event
-    @stopBubblingAndTrue
+    @passEventToPage
 
   # This tests whether there is a mapping of keyChar in the current key state (and accounts for pass keys).
   isMappedKey: (keyChar) ->

--- a/lib/handler_stack.coffee
+++ b/lib/handler_stack.coffee
@@ -61,14 +61,14 @@ class HandlerStack
           return false
         else if result == @restartBubbling
           return @bubbleEvent type, event
-        else if result == @continueBubbling or result
-          true # Do nothing, but continue bubbling (for @continueBubbling and all truthy results).
+        else if result == @continueBubbling or (result and result != @suppressEvent)
+          true # Do nothing, but continue bubbling.
         else
           # result is @suppressEvent or falsy.
           DomUtils.suppressEvent event if @isChromeEvent event
           return false
 
-    # None of our handlers want to suppress the event, so pass it to the page.
+    # None of our handlers care about this event, so pass it to the page.
     true
 
   remove: (id = @currentId) ->

--- a/tests/unit_tests/handler_stack_test.coffee
+++ b/tests/unit_tests/handler_stack_test.coffee
@@ -5,6 +5,7 @@ context "handlerStack",
   setup ->
     stub global, "DomUtils", {}
     stub DomUtils, "suppressEvent", ->
+    stub DomUtils, "suppressPropagation", ->
     @handlerStack = new HandlerStack
     @handler1Called = false
     @handler2Called = false
@@ -23,16 +24,16 @@ context "handlerStack",
     assert.isTrue @handler2Called
     assert.isFalse @handler1Called
 
-  should "terminate bubbling on stopBubblingAndTrue, and be true", ->
+  should "terminate bubbling on passEventToPage, and be true", ->
     @handlerStack.push { keydown: => @handler1Called = true }
-    @handlerStack.push { keydown: => @handler2Called = true; @handlerStack.stopBubblingAndTrue  }
+    @handlerStack.push { keydown: => @handler2Called = true; @handlerStack.passEventToPage }
     assert.isTrue @handlerStack.bubbleEvent 'keydown', {}
     assert.isTrue @handler2Called
     assert.isFalse @handler1Called
 
-  should "terminate bubbling on stopBubblingAndTrue, and be false", ->
+  should "terminate bubbling on passEventToPage, and be false", ->
     @handlerStack.push { keydown: => @handler1Called = true }
-    @handlerStack.push { keydown: => @handler2Called = true; @handlerStack.stopBubblingAndFalse  }
+    @handlerStack.push { keydown: => @handler2Called = true; @handlerStack.suppressPropagation }
     assert.isFalse @handlerStack.bubbleEvent 'keydown', {}
     assert.isTrue @handler2Called
     assert.isFalse @handler1Called


### PR DESCRIPTION
Rename some constants and rework some logic for greater clarity:

- Rename `handlerStack` event-handler constants.  E.g. what does `stopBubblingAndTrue` mean?  Here, this becomes `passEventToPage`.
- Rename `Mode` constants to match those used in the `handlerStack`.
- The names used in `Mode` and the `handlerStack` now match the relevant `DomUtils` routines.  E.g., the `@suppressEvent` constant matches `DomUtils.suppressEvent()`.
- Rework the core of `handlerStack.bubbleEvent()` to make the various values handlers can return (and their effect) clearer.

Will merge pretty much directly.  This PR is just for visibility.  This is a no-op functionality wise.