### PR TITLE
Filtered hints: better typed text handling.

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -465,15 +465,21 @@ class FilterHints
     linkSearchString = @linkTextKeystrokeQueue.join("").trim().toLowerCase()
     do (scoreFunction = @scoreLinkHint linkSearchString) ->
       linkMarker.score = scoreFunction linkMarker for linkMarker in hintMarkers
-    hintMarkers = hintMarkers[..].sort (a,b) ->
+    matchingHintMarkers = hintMarkers[..].sort (a,b) ->
       if b.score == a.score then b.stableSortCount - a.stableSortCount else b.score - a.score
 
-    linkHintNumber = 1
-    for linkMarker in hintMarkers
-      continue unless 0 < linkMarker.score
-      linkMarker.hintString = @generateHintString linkHintNumber++
-      @renderMarker linkMarker
-      linkMarker
+    matchingHintMarkers = (linkMarker for linkMarker in matchingHintMarkers when 0 < linkMarker.score)
+
+    if matchingHintMarkers.length == 0 and @hintKeystrokeQueue.length == 0 and 0 < @linkTextKeystrokeQueue.length
+      # We don't accept typed text which doesn't match any hints.
+      @linkTextKeystrokeQueue.pop()
+      @filterLinkHints hintMarkers
+    else
+      linkHintNumber = 1
+      for linkMarker in matchingHintMarkers
+        linkMarker.hintString = @generateHintString linkHintNumber++
+        @renderMarker linkMarker
+        linkMarker
 
   # Assign a score to a filter match (higher is better).  We assign a higher score for matches at the start of
   # a word, and a considerably higher score still for matches which are whole words.

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -282,6 +282,18 @@ context "Filtered link hints",
       sendKeyboardEvent "A"
       assert.equal "1", hintMarkers[3].hintString
 
+    # This test is the same as above, but with an extra non-matching character.
+    should "narrow the hints and ignore typing mistakes", ->
+      hintMarkers = getHintMarkers()
+      sendKeyboardEvent "T"
+      sendKeyboardEvent "R"
+      sendKeyboardEvent "X"
+      assert.equal "none", hintMarkers[0].style.display
+      assert.equal "3", hintMarkers[1].hintString
+      assert.equal "", hintMarkers[1].style.display
+      sendKeyboardEvent "A"
+      assert.equal "1", hintMarkers[3].hintString
+
   context "Image hints",
 
     setup ->


### PR DESCRIPTION
This makes two changes to the way filtered hints works:

1. When the user is typing a link's text and no link is matched, then simply reject the typed character.  (As opposed to the current behaviour which is to exit link-hints mode.)  Nearly always, this just means the user has mistyped something.  If the user really wants to exit, then they should use `Escape`.

2. Display the typed/matched characters in the HUD.  It looks like this (after typing `c` then `h`):

![snapshot](https://cloud.githubusercontent.com/assets/2641335/14379707/4fd569d2-fd73-11e5-8918-bd386014d894.png)

(Will merge pretty soon.  This PR is for better visibility.)