### PR TITLE
Simplify javascript: URLs in vomnibar.

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -217,9 +217,10 @@ class BookmarkCompleter
         queryTerms: @currentSearch.queryTerms
         type: "bookmark"
         url: bookmark.url
-        displayUrl: bookmark.displayUrl
         title: if usePathAndTitle then bookmark.pathAndTitle else bookmark.title
         relevancyFunction: @computeRelevancy
+        displayUrl: bookmark.displayUrl
+        deDuplicate: not bookmark.displayUrl?
     onComplete = @currentSearch.onComplete
     @currentSearch = null
     onComplete suggestions

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -66,10 +66,14 @@ class Suggestion
            <span class="vimiumReset vomnibarTitle">#{@highlightQueryTerms Utils.escapeHtml @title}</span>
          </div>
          <div class="vimiumReset vomnibarBottomHalf">
-          <span class="vimiumReset vomnibarSource vomnibarNoInsertText">#{insertTextIndicator}</span><span class="vimiumReset vomnibarUrl">#{@highlightUrlTerms Utils.escapeHtml @shortenUrl()}</span>
+          <span class="vimiumReset vomnibarSource vomnibarNoInsertText">#{insertTextIndicator}</span><span class="vimiumReset vomnibarUrl">#{@highlightUrlTerms Utils.escapeHtml @simplifyJavascriptUrls @shortenUrl()}</span>
           #{relevancyHtml}
         </div>
         """
+
+  # Simplify "javascript:" URLs; show them as "javascript:..."; see #961.
+  simplifyJavascriptUrls: (url) ->
+    if Utils.hasJavascriptPrefix(url) then "javascript:..." else url
 
   # Use neat trick to snatch a domain (http://stackoverflow.com/a/8498668).
   getUrlRoot: (url) ->

--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -146,8 +146,6 @@ class Suggestion
 
   # Simplify a suggestion's URL (by removing those parts which aren't useful for display or comparison).
   shortenUrl: () ->
-    # If we already have display URL, then use it.
-    @shortUrl ?= @displayUrl
     return @shortUrl if @shortUrl?
     # We get easier-to-read shortened URLs if we URI-decode them.
     url = (Utils.decodeURIByParts(@url) || @url).toLowerCase()
@@ -207,8 +205,8 @@ class BookmarkCompleter
         @bookmarks.filter (bookmark) =>
           suggestionTitle = if usePathAndTitle then bookmark.pathAndTitle else bookmark.title
           bookmark.hasJavascriptPrefix ?= Utils.hasJavascriptPrefix bookmark.url
-          bookmark.displayUrl ?= "javascript:..." if bookmark.hasJavascriptPrefix
-          suggestionUrl = bookmark.displayUrl ? bookmark.url
+          bookmark.shortUrl ?= "javascript:..." if bookmark.hasJavascriptPrefix
+          suggestionUrl = bookmark.shortUrl ? bookmark.url
           RankingUtils.matches(@currentSearch.queryTerms, suggestionUrl, suggestionTitle)
       else
         []
@@ -219,8 +217,8 @@ class BookmarkCompleter
         url: bookmark.url
         title: if usePathAndTitle then bookmark.pathAndTitle else bookmark.title
         relevancyFunction: @computeRelevancy
-        displayUrl: bookmark.displayUrl
-        deDuplicate: not bookmark.displayUrl?
+        shortUrl: bookmark.shortUrl
+        deDuplicate: not bookmark.shortUrl?
     onComplete = @currentSearch.onComplete
     @currentSearch = null
     onComplete suggestions
@@ -255,7 +253,7 @@ class BookmarkCompleter
     bookmark.children.forEach((child) => @traverseBookmarksRecursive child, results, bookmark) if bookmark.children
 
   computeRelevancy: (suggestion) ->
-    RankingUtils.wordRelevancy(suggestion.queryTerms, suggestion.displayUrl ? suggestion.url, suggestion.title)
+    RankingUtils.wordRelevancy(suggestion.queryTerms, suggestion.shortUrl ? suggestion.url, suggestion.title)
 
 class HistoryCompleter
   filter: ({ queryTerms, seenTabToOpenCompletionList }, onComplete) ->


### PR DESCRIPTION
Show `javascript:` URLs as `javascript:...` in the Vomnibar.

Fixes #961.