### PR TITLE
Rework UI component init sequence.

### DIFF
--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -45,7 +45,8 @@ class UIComponent
         # Get vimiumSecret so the iframe can determine that our message isn't the page impersonating us.
         chrome.storage.local.get "vimiumSecret", ({ vimiumSecret }) =>
           { port1, port2 } = new MessageChannel
-          port1.onmessage = (event) => @handleMessage event
+          port1.onmessage = (event) =>
+            if event?.data == "uiComponentIsReady" then @uiComponentIsReady = true else @handleMessage event
           @iframeElement.contentWindow.postMessage vimiumSecret, chrome.runtime.getURL(""), [ port2 ]
           setIframePort port1
 
@@ -53,8 +54,6 @@ class UIComponent
       if @showing and request.name == "frameFocused" and request.focusFrameId != frameId
         @postMessage name: "frameFocused", focusFrameId: request.focusFrameId
       false # Free up the sendResponse handler.
-
-    @styleSheetGetter.use => @iframePort.use => Utils.nextTick => @uiComponentIsReady = true
 
   # Posts a message (if one is provided), then calls continuation (if provided).  The continuation is only
   # ever called *after* the message has been posted.


### PR DESCRIPTION
In testing global link hints, it seems that UI components can be opened before they're actually ready, and Vimium hangs with a broken UI component displayed.  This issue seems to be in 1.54 too.

It's not clear what's causing this -- and it's hard to reproduce systematically.  However, it only seems to happen on navigation.  Therefore, it seems likely that there is an issue with the initialization sequence.

Here, we wait for:

- the DOM content to be ready, and
- the port to be provided

before registering the UI component as ready.

(Will merge pretty much directly.  Posting as a PR because this issue needs a little visibility... And it may not yet be fully resolved.)