### PR TITLE
Rework ui component focus handling

### DIFF
--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -25,12 +25,12 @@ HUD =
   show: (text) ->
     return unless @isReady()
     clearTimeout(@_showForDurationTimerId)
-    @hudUI.show {name: "show", text}
+    @hudUI.activate {name: "show", text}
     @tween.fade 1.0, 150
 
   showFindMode: (@findMode = null) ->
     return unless @isReady()
-    @hudUI.show {name: "showFindMode", text: ""}
+    @hudUI.activate name: "showFindMode", text: ""
     @tween.fade 1.0, 150
 
   search: (data) ->
@@ -50,9 +50,7 @@ HUD =
     clearTimeout(@_showForDurationTimerId)
     @tween.stop()
     if immediate
-      unless updateIndicator
-        @hudUI.hide()
-        @hudUI.postMessage {name: "hide"}
+      @hudUI.hide()
       Mode.setIndicator() if updateIndicator
     else
       @tween.fade 0, 150, => @hide true, updateIndicator
@@ -60,9 +58,9 @@ HUD =
   hideFindMode: (data) ->
     @findMode.checkReturnToViewPort()
 
-    # An element element won't receive a focus event if the search landed on it while we were in the HUD
-    # iframe. To end up with the correct modes active, we create a focus/blur event manually after refocusing
-    # this window.
+    # An element won't receive a focus event if the search landed on it while we were in the HUD iframe. To
+    # end up with the correct modes active, we create a focus/blur event manually after refocusing this
+    # window.
     window.focus()
 
     focusNode = DomUtils.getSelectionFocusElement()

--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -50,8 +50,7 @@ HUD =
     clearTimeout(@_showForDurationTimerId)
     @tween.stop()
     if immediate
-      @hudUI.hide()
-      Mode.setIndicator() if updateIndicator
+      if updateIndicator then Mode.setIndicator() else @hudUI.hide()
     else
       @tween.fade 0, 150, => @hide true, updateIndicator
 

--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -30,7 +30,7 @@ HUD =
 
   showFindMode: (@findMode = null) ->
     return unless @isReady()
-    @hudUI.activate name: "showFindMode", text: ""
+    @hudUI.activate name: "showFindMode"
     @tween.fade 1.0, 150
 
   search: (data) ->

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -334,7 +334,7 @@ class LinkHintsMode
         flashEl = DomUtils.addFlashRect linkMatched.rect
         HintCoordinator.onExit.push -> DomUtils.removeElement flashEl
 
-      if document.hasFocus()
+      if windowIsFocused()
         startKeyboardBlocker (isSuccess) -> HintCoordinator.sendMessage "exit", {isSuccess}
 
     # If we're using a keyboard blocker, then the frame with the focus sends the "exit" message, otherwise the
@@ -613,12 +613,12 @@ LocalHints =
         isClickable ||= element.control? and (@getVisibleClickable element.control).length == 0
       when "body"
         isClickable ||=
-          if element == document.body and not document.hasFocus() and
+          if element == document.body and not windowIsFocused() and
               window.innerWidth > 3 and window.innerHeight > 3 and
               document.body?.tagName.toLowerCase() != "frameset"
             reason = "Frame."
         isClickable ||=
-          if element == document.body and document.hasFocus() and Scroller.isScrollableElement element
+          if element == document.body and windowIsFocused() and Scroller.isScrollableElement element
             reason = "Scroll."
       when "div", "ol", "ul"
         isClickable ||=

--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -42,9 +42,9 @@ class KeyHandlerMode extends Mode
       @reset()
       @suppressEvent
     # If the help dialog loses the focus, then Escape should hide it; see point 2 in #2045.
-    else if isEscape and HelpDialog?.showing
+    else if isEscape and HelpDialog?.isShowing()
       @keydownEvents[event.keyCode] = true
-      HelpDialog.hide()
+      HelpDialog.toggle()
       @suppressEvent
     else if isEscape
       @continueBubbling

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -2,7 +2,8 @@ class UIComponent
   uiComponentIsReady: false
   iframeElement: null
   iframePort: null
-  showing: null
+  iframeFrameId: null
+  showing: false
   options: null
   shadowDOM: null
   styleSheetGetter: null
@@ -27,10 +28,8 @@ class UIComponent
     @shadowDOM = shadowWrapper.createShadowRoot?() ? shadowWrapper
     @shadowDOM.appendChild styleSheet
     @shadowDOM.appendChild @iframeElement
-
-    @showing = true # The iframe is visible now.
-    # Hide the iframe, but don't interfere with the focus.
-    @hide false
+    @iframeElement.classList.remove "vimiumUIComponentVisible"
+    @iframeElement.classList.add "vimiumUIComponentHidden"
 
     # Open a port and pass it to the iframe via window.postMessage.  We use an AsyncDataFetcher to handle
     # requests which arrive before the iframe (and its message handlers) have completed initialization.  See
@@ -45,74 +44,59 @@ class UIComponent
         # Get vimiumSecret so the iframe can determine that our message isn't the page impersonating us.
         chrome.storage.local.get "vimiumSecret", ({ vimiumSecret }) =>
           { port1, port2 } = new MessageChannel
-          port1.onmessage = (event) =>
-            if event?.data == "uiComponentIsReady" then @uiComponentIsReady = true else @handleMessage event
           @iframeElement.contentWindow.postMessage vimiumSecret, chrome.runtime.getURL(""), [ port2 ]
-          setIframePort port1
 
-    chrome.runtime.onMessage.addListener (request) =>
-      if @showing and request.name == "frameFocused" and request.focusFrameId != frameId
-        @postMessage name: "frameFocused", focusFrameId: request.focusFrameId
-      false # Free up the sendResponse handler.
+          port1.onmessage = (event) =>
+            switch event?.data?.name ? event?.data
+              when "uiComponentIsReady"
+                # If any other frame receives the focus, then hide the UI component.
+                chrome.runtime.onMessage.addListener ({name, focusFrameId}) =>
+                  if name == "frameFocused" and @options?.focus and focusFrameId not in [frameId, @iframeFrameId]
+                    @hide false
+                  false # We will not be calling sendResponse.
 
-  # Posts a message (if one is provided), then calls continuation (if provided).  The continuation is only
-  # ever called *after* the message has been posted.
+                # If this frame receives the focus, then hide the UI component.
+                window.addEventListener "focus", (event) =>
+                  if event.target == window and @options?.focus and not @options?.allowBlur
+                    @hide false
+                  true # Continue propagating the event.
+
+                @uiComponentIsReady = true
+                setIframePort port1
+
+              when "setIframeFrameId" then @iframeFrameId = event.data.iframeFrameId
+              when "hide" then @hide()
+              else @handleMessage event
+
+  # Post a message (if provided), then call continuation (if provided).
   postMessage: (message = null, continuation = null) ->
     @iframePort.use (port) =>
       port.postMessage message if message?
       continuation?()
 
-  activate: (@options) ->
+  activate: (@options = null) ->
     @postMessage @options, =>
-      @show() unless @showing
-      @iframeElement.focus()
-
-  show: (message) ->
-    @postMessage message, =>
       @iframeElement.classList.remove "vimiumUIComponentHidden"
       @iframeElement.classList.add "vimiumUIComponentVisible"
-      # The window may not have the focus.  We focus it now, to prevent the "focus" listener below from firing
-      # immediately.
-      window.focus()
-      window.addEventListener "focus", @onFocus = (event) =>
-        if event.target == window
-          window.removeEventListener "focus", @onFocus
-          @onFocus = null
-          @postMessage "frameFocused"
+      @iframeElement.focus() if @options?.focus
       @showing = true
 
-  hide: (focusWindow = true)->
-    @refocusSourceFrame @options?.sourceFrameId if focusWindow
-    window.removeEventListener "focus", @onFocus if @onFocus
-    @onFocus = null
-    @iframeElement.classList.remove "vimiumUIComponentVisible"
-    @iframeElement.classList.add "vimiumUIComponentHidden"
-    @iframeElement.blur()
-    @options = null
-    @showing = false
-
-  # Refocus the frame from which the UI component was opened.  This may be different from the current frame.
-  # After hiding the UI component, Chrome refocuses the containing frame. To avoid a race condition, we need
-  # to wait until that frame first receives the focus, before then focusing the frame which should now have
-  # the focus.
-  refocusSourceFrame: (sourceFrameId) ->
-    if @showing and sourceFrameId? and sourceFrameId != frameId
-      refocusSourceFrame = ->
-        chrome.runtime.sendMessage
-          handler: "sendMessageToFrames"
-          message:
-            name: "focusFrame"
-            frameId: sourceFrameId
-
-      if windowIsFocused()
-        # We already have the focus.
-        refocusSourceFrame()
-      else
-        # We don't yet have the focus (but we'll be getting it soon).
-        window.addEventListener "focus", handler = (event) ->
-          if event.target == window
-            window.removeEventListener "focus", handler
-            refocusSourceFrame()
+  hide: (shouldRefocusOriginalFrame = true) ->
+    if @showing
+      @showing = false
+      @iframeElement.classList.remove "vimiumUIComponentVisible"
+      @iframeElement.classList.add "vimiumUIComponentHidden"
+      if @options?.focus and shouldRefocusOriginalFrame
+        @iframeElement.blur()
+        if @options?.sourceFrameId?
+          chrome.runtime.sendMessage
+            handler: "sendMessageToFrames",
+            message: name: "focusFrame", frameId: @options.sourceFrameId, forceFocusThisFrame: true
+        else
+          window.focus()
+      @options = null
+      # Inform the UI component that it is hidden.
+      Utils.nextTick => @postMessage "hidden"
 
   # Fetch a Vimium file/resource (such as "content_scripts/vimium.css").
   # We try making an XMLHttpRequest request.  That can fail (see #1817), in which case we fetch the
@@ -134,7 +118,6 @@ class UIComponent
 
     request.open "GET", (chrome.runtime.getURL file), true
     request.send()
-
 
 root = exports ? window
 root.UIComponent = UIComponent

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -2,8 +2,8 @@ class UIComponent
   uiComponentIsReady: false
   iframeElement: null
   iframePort: null
-  iframeFrameId: null
   showing: false
+  iframeFrameId: null
   options: null
   shadowDOM: null
   styleSheetGetter: null
@@ -118,6 +118,7 @@ class UIComponent
 
     request.open "GET", (chrome.runtime.getURL file), true
     request.send()
+
 
 root = exports ? window
 root.UIComponent = UIComponent

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -96,7 +96,7 @@ class UIComponent
           window.focus()
       @options = null
       # Inform the UI component that it is hidden.
-      Utils.nextTick => @postMessage "hidden"
+      @postMessage "hidden"
 
   # Fetch a Vimium file/resource (such as "content_scripts/vimium.css").
   # We try making an XMLHttpRequest request.  That can fail (see #1817), in which case we fetch the

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -95,8 +95,7 @@ class UIComponent
         else
           window.focus()
       @options = null
-      # Inform the UI component that it is hidden.
-      @postMessage "hidden"
+      @postMessage "hidden" # Inform the UI component that it is hidden.
 
   # Fetch a Vimium file/resource (such as "content_scripts/vimium.css").
   # We try making an XMLHttpRequest request.  That can fail (see #1817), in which case we fetch the
@@ -118,7 +117,6 @@ class UIComponent
 
     request.open "GET", (chrome.runtime.getURL file), true
     request.send()
-
 
 root = exports ? window
 root.UIComponent = UIComponent

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -8,7 +8,8 @@ normalMode = null
 
 # We track whther the current window has the focus or not.
 windowIsFocused = do ->
-  windowHasFocus = document.hasFocus()
+  windowHasFocus = null
+  DomUtils.documentReady -> windowHasFocus = document.hasFocus()
   window.addEventListener "focus", (event) -> windowHasFocus = true if event.target == window; true
   window.addEventListener "blur", (event) -> windowHasFocus = false if event.target == window; true
   -> windowHasFocus

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -159,8 +159,7 @@ initializePreDomReady = ->
     getScrollPosition: (ignoredA, ignoredB, sendResponse) ->
       sendResponse scrollX: window.scrollX, scrollY: window.scrollY if frameId == 0
     setScrollPosition: setScrollPosition
-    # A frame has received the focus.  We don't care here (UI components handle this).
-    frameFocused: ->
+    frameFocused: -> # A frame has received the focus; we don't care here (UI components handle this).
     checkEnabledAfterURLChange: checkEnabledAfterURLChange
     runInTopFrame: ({sourceFrameId, registryEntry}) ->
       Utils.invokeCommandString registryEntry.command, sourceFrameId, registryEntry if DomUtils.isTopFrame()
@@ -291,10 +290,9 @@ DomUtils.documentReady ->
 #
 focusThisFrame = (request) ->
   unless request.forceFocusThisFrame
-    skipThisFrame = DomUtils.windowIsTooSmall() # Frame is too small; see #1317.
-    skipThisFrame ||= document.body?.tagName.toLowerCase() == "frameset"
-    if skipThisFrame
-      # Cancel and tell the background page to focus the next frame instead.
+    if DomUtils.windowIsTooSmall() or document.body?.tagName.toLowerCase() == "frameset"
+      # This frame is too small to focus or it's a frameset. Cancel and tell the background page to focus the
+      # next frame instead.  This affects sites like Google Inbox, which have many tiny iframes. See #1317.
       chrome.runtime.sendMessage handler: "nextFrame"
       return
   window.focus()

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -121,7 +121,7 @@ class NormalMode extends KeyHandlerMode
 
     if registryEntry.topFrame
       # The Vomnibar (a top-frame command) cannot coexist with the help dialog (it causes focus issues).
-      sourceFrameId = if HelpDialog.isShowing() and window.isVimiumUIComponent then 0 else frameId
+      sourceFrameId = if window.isVimiumUIComponent then 0 else frameId
       HelpDialog.toggle() if HelpDialog.isShowing()
       chrome.runtime.sendMessage
         handler: "sendMessageToFrames", message: {name: "runInTopFrame", sourceFrameId, registryEntry}

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -293,7 +293,6 @@ focusThisFrame = (request) ->
   unless request.forceFocusThisFrame
     skipThisFrame = DomUtils.windowIsTooSmall() # Frame is too small; see #1317.
     skipThisFrame ||= document.body?.tagName.toLowerCase() == "frameset"
-    skipThisFrame ||= window.isVimiumUIComponent and not HelpDialog.showing
     if skipThisFrame
       # Cancel and tell the background page to focus the next frame instead.
       chrome.runtime.sendMessage handler: "nextFrame"

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -119,12 +119,12 @@ class NormalMode extends KeyHandlerMode
         You have asked Vimium to perform #{count} repetitions of the command: #{registryEntry.description}.\n
         Are you sure you want to continue?"""
 
-    if registryEntry.topFrame and window.isVimiumUIComponent? and window.isVimiumUIComponent
-      # We cannot use "topFrame" commands, most notably the Vomnibar, from within a UI component.
-      HUD.showForDuration "#{registryEntry.command} cannot be used here.", 2000
-    else if registryEntry.topFrame
+    if registryEntry.topFrame
+      # The Vomnibar (a top-frame command) cannot coexist with the help dialog (it causes focus issues).
+      sourceFrameId = if HelpDialog.isShowing() and window.isVimiumUIComponent then 0 else frameId
+      HelpDialog.toggle() if HelpDialog.isShowing()
       chrome.runtime.sendMessage
-        handler: "sendMessageToFrames", message: {name: "runInTopFrame", sourceFrameId: frameId, registryEntry}
+        handler: "sendMessageToFrames", message: {name: "runInTopFrame", sourceFrameId, registryEntry}
     else if registryEntry.background
       chrome.runtime.sendMessage {handler: "runBackgroundCommand", registryEntry, count}
     else

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -291,9 +291,11 @@ DomUtils.documentReady ->
 #
 focusThisFrame = (request) ->
   unless request.forceFocusThisFrame
-    if DomUtils.windowIsTooSmall() or document.body?.tagName.toLowerCase() == "frameset"
-      # This frame is too small to focus or it's a frameset. Cancel and tell the background page to focus the
-      # next frame instead.  This affects sites like Google Inbox, which have many tiny iframes. See #1317.
+    skipThisFrame = DomUtils.windowIsTooSmall() # Frame is too small; see #1317.
+    skipThisFrame ||= document.body?.tagName.toLowerCase() == "frameset"
+    skipThisFrame ||= window.isVimiumUIComponent and not HelpDialog.showing
+    if skipThisFrame
+      # Cancel and tell the background page to focus the next frame instead.
       chrome.runtime.sendMessage handler: "nextFrame"
       return
   window.focus()

--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -51,10 +51,6 @@ Vomnibar =
     unless @vomnibarUI?
       @vomnibarUI = new UIComponent "pages/vomnibar.html", "vomnibarFrame", (event) =>
         @vomnibarUI.hide() if event.data == "hide"
-      # Whenever the window receives the focus, we tell the Vomnibar UI that it has been hidden (regardless of
-      # whether it was previously visible).
-      window.addEventListener "focus", (event) =>
-        @vomnibarUI.postMessage "hidden" if event.target == window; true
 
 
   # This function opens the vomnibar. It accepts options, a map with the values:
@@ -65,7 +61,7 @@ Vomnibar =
   open: (sourceFrameId, options) ->
     @init()
     if @vomnibarUI?.uiComponentIsReady
-      @vomnibarUI.activate extend options, { sourceFrameId }
+      @vomnibarUI.activate extend options, { name: "activate", sourceFrameId, focus: true }
 
 root = exports ? window
 root.Vomnibar = Vomnibar

--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -49,9 +49,7 @@ Vomnibar =
 
   init: ->
     unless @vomnibarUI?
-      @vomnibarUI = new UIComponent "pages/vomnibar.html", "vomnibarFrame", (event) =>
-        @vomnibarUI.hide() if event.data == "hide"
-
+      @vomnibarUI = new UIComponent "pages/vomnibar.html", "vomnibarFrame", ->
 
   # This function opens the vomnibar. It accepts options, a map with the values:
   #   completer   - The completer to fetch results from.

--- a/pages/help_dialog.coffee
+++ b/pages/help_dialog.coffee
@@ -6,8 +6,7 @@
 #   top-level frame), and then we don't need to be concerned about nested help dialog frames.
 HelpDialog =
   dialogElement: null
-  showing: false
-  isShowing: -> @showing
+  isShowing: -> true
 
   # This setting is pulled out of local storage. It's false by default.
   getShowAdvancedCommands: -> Settings.get("helpDialog_showAdvancedCommands")
@@ -70,11 +69,13 @@ HelpDialog =
 UIComponentServer.registerHandler (event) ->
   switch event.data.name ? event.data
     when "hide" then HelpDialog.hide()
-    when "hidden" then HelpDialog.showing = false
     when "activate"
       HelpDialog.init()
-      HelpDialog.showing = true
       HelpDialog.show event.data
+      Frame.postMessage "registerFrame"
+    when "hidden"
+      # Unregister the frame, so that it's not available for `gf` or linkk hints.
+      Frame.postMessage "unregisterFrame"
 
 root = exports ? window
 root.HelpDialog = HelpDialog

--- a/pages/help_dialog.coffee
+++ b/pages/help_dialog.coffee
@@ -48,7 +48,7 @@ HelpDialog =
           HUD.showForDuration("Yanked #{commandName}.", 2000)
 
   hide: -> UIComponentServer.hide()
-  toggle: (html) -> @hide()
+  toggle: -> @hide()
 
   #
   # Advanced commands are hidden by default so they don't overwhelm new and casual users.

--- a/pages/help_dialog.coffee
+++ b/pages/help_dialog.coffee
@@ -74,7 +74,7 @@ UIComponentServer.registerHandler (event) ->
       HelpDialog.show event.data
       Frame.postMessage "registerFrame"
     when "hidden"
-      # Unregister the frame, so that it's not available for `gf` or linkk hints.
+      # Unregister the frame, so that it's not available for `gf` or link hints.
       Frame.postMessage "unregisterFrame"
 
 root = exports ? window

--- a/pages/help_dialog.coffee
+++ b/pages/help_dialog.coffee
@@ -6,7 +6,8 @@
 #   top-level frame), and then we don't need to be concerned about nested help dialog frames.
 HelpDialog =
   dialogElement: null
-  isShowing: -> true
+  showing: false
+  isShowing: -> @showing
 
   # This setting is pulled out of local storage. It's false by default.
   getShowAdvancedCommands: -> Settings.get("helpDialog_showAdvancedCommands")
@@ -69,8 +70,10 @@ HelpDialog =
 UIComponentServer.registerHandler (event) ->
   switch event.data.name ? event.data
     when "hide" then HelpDialog.hide()
+    when "hidden" then HelpDialog.showing = false
     when "activate"
       HelpDialog.init()
+      HelpDialog.showing = true
       HelpDialog.show event.data
 
 root = exports ? window

--- a/pages/help_dialog.coffee
+++ b/pages/help_dialog.coffee
@@ -6,7 +6,7 @@
 #   top-level frame), and then we don't need to be concerned about nested help dialog frames.
 HelpDialog =
   dialogElement: null
-  showing: true
+  isShowing: -> true
 
   # This setting is pulled out of local storage. It's false by default.
   getShowAdvancedCommands: -> Settings.get("helpDialog_showAdvancedCommands")
@@ -30,9 +30,7 @@ HelpDialog =
       @hide() unless @dialogElement.contains event.target
     , false
 
-  isReady: -> true
-
-  show: (html) ->
+  show: ({html}) ->
     for own placeholder, htmlString of html
       @dialogElement.querySelector("#help-dialog-#{placeholder}").innerHTML = htmlString
 
@@ -48,15 +46,8 @@ HelpDialog =
           chrome.runtime.sendMessage handler: "copyToClipboard", data: commandName
           HUD.showForDuration("Yanked #{commandName}.", 2000)
 
-    @exitOnEscape = new Mode name: "help-page-escape", exitOnEscape: true
-    @exitOnEscape.onExit (event) => @hide() if event?.type == "keydown"
-
-  hide: ->
-    @exitOnEscape?.exit()
-    UIComponentServer.postMessage "hide"
-
-  toggle: (html) ->
-    if @showing then @hide() else @show html
+  hide: -> UIComponentServer.hide()
+  toggle: (html) -> @hide()
 
   #
   # Advanced commands are hidden by default so they don't overwhelm new and casual users.
@@ -77,13 +68,8 @@ HelpDialog =
 
 UIComponentServer.registerHandler (event) ->
   switch event.data.name ? event.data
-    when "frameFocused"
-      # We normally close when we lose the focus.  However, we do not close on the options page.  This allows
-      # users to view the help dialog while typing in the key-mappings input.
-      HelpDialog.hide() unless event.data.focusFrameId == frameId or try window.top.isVimiumOptionsPage
-    when "hide"
-      HelpDialog.hide()
-    else
+    when "hide" then HelpDialog.hide()
+    when "activate"
       HelpDialog.init()
       HelpDialog.show event.data
 

--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -50,7 +50,7 @@ handlers =
     document.getElementById("hud").innerText = data.text
     document.getElementById("hud").classList.add "vimiumUIComponentVisible"
     document.getElementById("hud").classList.remove "vimiumUIComponentHidden"
-  hide: ->
+  hidden: ->
     # We get a flicker when the HUD later becomes visible again (with new text) unless we reset its contents
     # here.
     document.getElementById("hud").innerText = ""
@@ -96,8 +96,7 @@ handlers =
       " (No matches)"
     countElement.textContent = if showMatchText then countText else ""
 
-UIComponentServer.registerHandler (event) ->
-  {data} = event
-  handlers[data.name]? data
+UIComponentServer.registerHandler ({data}) ->
+  handlers[data.name ? data]? data
 
 FindModeHistory.init()

--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -92,7 +92,5 @@ handlers =
       " (No matches)"
     countElement.textContent = if showMatchText then countText else ""
 
-UIComponentServer.registerHandler ({data}) ->
-  handlers[data.name ? data]? data
-
+UIComponentServer.registerHandler ({data}) -> handlers[data.name ? data]? data
 FindModeHistory.init()

--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -63,7 +63,6 @@ handlers =
 
     inputElement = document.createElement "span"
     inputElement.contentEditable = "plaintext-only"
-    setTextInInputElement inputElement, data.text if data.text
     inputElement.id = "hud-find-input"
     hud.appendChild inputElement
 
@@ -76,9 +75,6 @@ handlers =
     countElement.id = "hud-match-count"
     hud.appendChild countElement
     inputElement.focus()
-
-    # Replace \u00A0 (&nbsp;) with a normal space.
-    UIComponentServer.postMessage {name: "search", query: inputElement.textContent.replace "\u00A0", " "}
 
     findMode =
       historyIndex: -1

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -234,7 +234,7 @@ initOptionsPage = ->
     event.preventDefault()
 
   activateHelpDialog = ->
-    HelpDialog.show chrome.extension.getBackgroundPage().helpDialogHtml(true, true, "Command Listing"), frameId
+    HelpDialog.toggle chrome.extension.getBackgroundPage().helpDialogHtml true, true, "Command Listing"
 
   saveOptions = ->
     Option.saveOptions()

--- a/pages/ui_component_server.coffee
+++ b/pages/ui_component_server.coffee
@@ -18,11 +18,8 @@ UIComponentServer =
 
   registerHandler: (@handleMessage) ->
 
-  postMessage: (message) ->
-    @ownerPagePort?.postMessage message
-
-  hide: ->
-    @postMessage "hide"
+  postMessage: (message) -> @ownerPagePort?.postMessage message
+  hide: -> @postMessage "hide"
 
   # We require both that the DOM is ready and that the port has been opened before the UI component is ready.
   # These events can happen in either order.  We count them, and notify the content script when we've seen


### PR DESCRIPTION
The code around UI components (HUD, Vomnibar and help dialog) has become quite complicated (and brittle).  In particular, the issue is to do with focus handling.  That's one reason #2099 emerged.

This is a reworking of that code.  Basically, I removed all of the questionable bits of code (and stuff that has been added to patch previous issues) and started from scratch.  Hopefully, the model here should be clearer and easier to maintain.

**One big gotcha**

One problematic case is handling the focus when the Vomnibar is activated from within the help dialog.  Handling that case is tricky because the Vomnibar runs in the top frame, so the focus can change, and focus changes is what makes the UI components tricky.  As a compromise, the help dialog is closed here whenever the Vomnibar is activated.  That's not great.  But the additional complicated logic to handle all cases just doesn't seem worth it.

(On a more positive note, we do lose almost 50 LoC.)

I'll try this in my live browser for a few days, and then merge it if I can't find any issues.

Fixes #2099.

Edit:  Added ae1a54157291c0bcc69a6e8652bc15e69b72b4e4 to fix a pre-existing issue whereby a hidden help dialog was nevertheless selected by `gf`.