### PR TITLE
Modernize help dialog styling

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -118,27 +118,26 @@ Commands =
     pageNavigation:
       ["scrollDown",
       "scrollUp",
-      "scrollLeft",
-      "scrollRight",
       "scrollToTop",
       "scrollToBottom",
-      "scrollToLeft",
-      "scrollToRight",
       "scrollPageDown",
       "scrollPageUp",
       "scrollFullPageUp",
       "scrollFullPageDown",
+      "scrollLeft",
+      "scrollRight",
+      "scrollToLeft",
+      "scrollToRight",
       "reload",
-      "toggleViewSource",
       "copyCurrentUrl",
       "openCopiedUrlInCurrentTab",
       "openCopiedUrlInNewTab",
       "goUp",
       "goToRoot",
       "enterInsertMode",
-      "passNextKey",
       "enterVisualMode",
       "enterVisualLineMode",
+      "passNextKey",
       "focusInput",
       "LinkHints.activateMode",
       "LinkHints.activateModeToOpenInNewTab",
@@ -156,32 +155,33 @@ Commands =
     vomnibarCommands:
       ["Vomnibar.activate",
       "Vomnibar.activateInNewTab",
-      "Vomnibar.activateTabSelection",
       "Vomnibar.activateBookmarks",
       "Vomnibar.activateBookmarksInNewTab",
+      "Vomnibar.activateTabSelection",
       "Vomnibar.activateEditUrl",
       "Vomnibar.activateEditUrlInNewTab"]
     findCommands: ["enterFindMode", "performFind", "performBackwardsFind"]
     historyNavigation:
       ["goBack", "goForward"]
     tabManipulation:
-      ["nextTab",
+      ["createTab",
       "previousTab",
+      "nextTab",
       "visitPreviousTab",
       "firstTab",
       "lastTab",
-      "createTab",
       "duplicateTab",
+      "togglePinTab",
       "removeTab",
       "restoreTab",
       "moveTabToNewWindow",
-      "togglePinTab",
       "closeTabsOnLeft","closeTabsOnRight",
       "closeOtherTabs",
       "moveTabLeft",
       "moveTabRight"]
     misc:
-      ["showHelp"]
+      ["showHelp",
+      "toggleViewSource"]
 
   # Rarely used commands are not shown by default in the help dialog or in the README. The goal is to present
   # a focused, high-signal set of commands to the new and casual user. Only those truly hungry for more power
@@ -192,12 +192,12 @@ Commands =
     "moveTabToNewWindow",
     "goUp",
     "goToRoot",
-    "focusInput",
     "LinkHints.activateModeWithQueue",
     "LinkHints.activateModeToDownloadLink",
     "Vomnibar.activateEditUrl",
     "Vomnibar.activateEditUrlInNewTab",
     "LinkHints.activateModeToOpenIncognito",
+    "LinkHints.activateModeToCopyLinkUrl",
     "goNext",
     "goPrevious",
     "Marks.activateCreateMode",
@@ -207,6 +207,8 @@ Commands =
     "closeTabsOnLeft",
     "closeTabsOnRight",
     "closeOtherTabs",
+    "enterVisualLineMode",
+    "toggleViewSource",
     "passNextKey"]
 
 defaultKeyMappings =
@@ -306,8 +308,8 @@ commandDescriptions =
   scrollToLeft: ["Scroll all the way to the left", { noRepeat: true }]
   scrollToRight: ["Scroll all the way to the right", { noRepeat: true }]
 
-  scrollPageDown: ["Scroll a page down"]
-  scrollPageUp: ["Scroll a page up"]
+  scrollPageDown: ["Scroll a half page down"]
+  scrollPageUp: ["Scroll a half page up"]
   scrollFullPageDown: ["Scroll a full page down"]
   scrollFullPageUp: ["Scroll a full page up"]
 
@@ -323,7 +325,7 @@ commandDescriptions =
   enterVisualMode: ["Enter visual mode", { noRepeat: true }]
   enterVisualLineMode: ["Enter visual line mode", { noRepeat: true }]
 
-  focusInput: ["Focus the first text box on the page. Cycle between them using tab"]
+  focusInput: ["Focus the first text input on the page"]
 
   "LinkHints.activateMode": ["Open a link in the current tab"]
   "LinkHints.activateModeToOpenInNewTab": ["Open a link in a new tab"]
@@ -370,16 +372,16 @@ commandDescriptions =
   moveTabLeft: ["Move tab to the left", { background: true }]
   moveTabRight: ["Move tab to the right", { background: true }]
 
-  "Vomnibar.activate": ["Open URL, bookmark, or history entry", { topFrame: true }]
-  "Vomnibar.activateInNewTab": ["Open URL, bookmark, history entry, in a new tab", { topFrame: true }]
+  "Vomnibar.activate": ["Open URL, bookmark or history entry", { topFrame: true }]
+  "Vomnibar.activateInNewTab": ["Open URL, bookmark or history entry in a new tab", { topFrame: true }]
   "Vomnibar.activateTabSelection": ["Search through your open tabs", { topFrame: true }]
   "Vomnibar.activateBookmarks": ["Open a bookmark", { topFrame: true }]
   "Vomnibar.activateBookmarksInNewTab": ["Open a bookmark in a new tab", { topFrame: true }]
   "Vomnibar.activateEditUrl": ["Edit the current URL", { topFrame: true }]
   "Vomnibar.activateEditUrlInNewTab": ["Edit the current URL and open in a new tab", { topFrame: true }]
 
-  nextFrame: ["Cycle forward to the next frame on the page", { background: true }]
-  mainFrame: ["Select the tab's main/top frame", { topFrame: true, noRepeat: true }]
+  nextFrame: ["Select the next frame on the page", { background: true }]
+  mainFrame: ["Select the page's main/top frame", { topFrame: true, noRepeat: true }]
 
   "Marks.activateCreateMode": ["Create a new mark", { noRepeat: true }]
   "Marks.activateGotoMode": ["Go to a mark", { noRepeat: true }]

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -366,10 +366,10 @@ HintCoordinator =
     for own frameId, port of @tabState[tabId].ports
       @postMessage tabId, parseInt(frameId), messageType, port, request
 
-  prepareToActivateMode: (tabId, originatingFrameId, {modeIndex}) ->
+  prepareToActivateMode: (tabId, originatingFrameId, {modeIndex, isVimiumHelpDialog}) ->
     @tabState[tabId] = {frameIds: frameIdsForTab[tabId][..], hintDescriptors: {}, originatingFrameId, modeIndex}
     @tabState[tabId].ports = extend {}, portsForTab[tabId]
-    @sendMessage "getHintDescriptors", tabId, {modeIndex}
+    @sendMessage "getHintDescriptors", tabId, {modeIndex, isVimiumHelpDialog}
 
   # Receive hint descriptors from all frames and activate link-hints mode when we have them all.
   postHintDescriptors: (tabId, frameId, {hintDescriptors}) ->

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -123,7 +123,7 @@ helpDialogHtmlForCommand = (html, isAdvanced, bindings, description, showCommand
   html.push "<tr class='vimiumReset #{"advanced" if isAdvanced}'>"
   if description
     html.push "<td class='vimiumReset'>", Utils.escapeHtml(bindings), "</td>"
-    html.push "<td class='vimiumReset'>#{if description and bindings then ':' else ''}</td><td class='vimiumReset'>", description
+    html.push "<td class='vimiumReset'>#{if description and bindings then ':' else ''}</td><td class='vimiumReset vimiumHelpDescription'>", description
     html.push("<span class='vimiumReset commandName'>(#{command})</span>") if showCommandNames
   else
     html.push "<td class='vimiumReset' colspan='3' style='text-align: left;'>", Utils.escapeHtml(bindings)

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -124,9 +124,8 @@ helpDialogHtmlForCommand = (html, isAdvanced, bindings, description, showCommand
   html.push "<tr class='vimiumReset #{"advanced" if isAdvanced}'>"
   if description
     html.push "<td class='vimiumReset'>#{bindings}</td>"
-    html.push "<td class='vimiumReset'></td><td class='vimiumReset vimiumHelpDescription'>",
-      "#{description}#{if showCommandNames then ":" else ""}"
-    html.push("<span class='vimiumReset commandName'>#{command}</span>") if showCommandNames
+    html.push "<td class='vimiumReset'></td><td class='vimiumReset vimiumHelpDescription'>", description
+    html.push("(<span class='vimiumReset commandName'>#{command}</span>)") if showCommandNames
   else
     html.push "<td class='vimiumReset' colspan='3' style='text-align: left;'>", bindings
   html.push("</td></tr>")

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -124,8 +124,9 @@ helpDialogHtmlForCommand = (html, isAdvanced, bindings, description, showCommand
   html.push "<tr class='vimiumReset #{"advanced" if isAdvanced}'>"
   if description
     html.push "<td class='vimiumReset'>#{bindings}</td>"
-    html.push "<td class='vimiumReset'></td><td class='vimiumReset vimiumHelpDescription'>", description
-    html.push("<span class='vimiumReset commandName'>(#{command})</span>") if showCommandNames
+    html.push "<td class='vimiumReset'></td><td class='vimiumReset vimiumHelpDescription'>",
+      "#{description}#{if showCommandNames then ":" else ""}"
+    html.push("<span class='vimiumReset commandName'>#{command}</span>") if showCommandNames
   else
     html.push "<td class='vimiumReset' colspan='3' style='text-align: left;'>", bindings
   html.push("</td></tr>")

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -106,11 +106,12 @@ helpDialogHtmlForCommandGroup = (group, commandsToKey, availableCommands,
     showUnboundCommands, showCommandNames) ->
   html = []
   for command in Commands.commandGroups[group]
-    bindings = (commandsToKey[command] || [""]).join(", ")
+    keys = commandsToKey[command] || []
+    bindings = ("<span class='vimiumHelpDialogKey'>#{Utils.escapeHtml key}</span>" for key in keys).join ", "
     if (showUnboundCommands || commandsToKey[command])
       isAdvanced = Commands.advancedCommands.indexOf(command) >= 0
       description = availableCommands[command].description
-      if bindings.length < 12
+      if keys.join(", ").length < 12
         helpDialogHtmlForCommand html, isAdvanced, bindings, description, showCommandNames, command
       else
         # If the length of the bindings is too long, then we display the bindings on a separate row from the
@@ -122,11 +123,11 @@ helpDialogHtmlForCommandGroup = (group, commandsToKey, availableCommands,
 helpDialogHtmlForCommand = (html, isAdvanced, bindings, description, showCommandNames, command) ->
   html.push "<tr class='vimiumReset #{"advanced" if isAdvanced}'>"
   if description
-    html.push "<td class='vimiumReset'>", Utils.escapeHtml(bindings), "</td>"
-    html.push "<td class='vimiumReset'>#{if description and bindings then ':' else ''}</td><td class='vimiumReset vimiumHelpDescription'>", description
+    html.push "<td class='vimiumReset'>#{bindings}</td>"
+    html.push "<td class='vimiumReset'></td><td class='vimiumReset vimiumHelpDescription'>", description
     html.push("<span class='vimiumReset commandName'>(#{command})</span>") if showCommandNames
   else
-    html.push "<td class='vimiumReset' colspan='3' style='text-align: left;'>", Utils.escapeHtml(bindings)
+    html.push "<td class='vimiumReset' colspan='3' style='text-align: left;'>", bindings
   html.push("</td></tr>")
 
 # Cache "content_scripts/vimium.css" in chrome.storage.local for UI components.

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -91,7 +91,7 @@ getHelpDialogHtml = ({showUnboundCommands, showCommandNames, customTitle}) ->
   replacementStrings =
     version: currentVersion
     title: customTitle || "Help"
-    tip: if showCommandNames then "Tip: click command names to yank them to the clipboard." else ""
+    tip: if showCommandNames then "Tip: click command names to yank them to the clipboard." else "&nbsp;"
 
   for own group of Commands.commandGroups
     replacementStrings[group] =

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -91,6 +91,7 @@ getHelpDialogHtml = ({showUnboundCommands, showCommandNames, customTitle}) ->
   replacementStrings =
     version: currentVersion
     title: customTitle || "Help"
+    tip: if showCommandNames then "Tip: click command names to yank them to the clipboard." else ""
 
   for own group of Commands.commandGroups
     replacementStrings[group] =

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -253,10 +253,10 @@ div#vimiumHelpDialog a.closeButton {
   font-weight:bold;
   color:#555;
   text-decoration:none;
-  font-size:20px;
+  font-size:24px;
   position: relative;
-  top: -12px;
-  right: -10px;
+  top: 3px;
+  padding-left: 5px;
 }
 div#vimiumHelpDialog a {
   text-decoration: underline;

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -138,25 +138,22 @@ div.vimiumHighlightedFrame {
 /* Help Dialog CSS */
 
 iframe.vimiumHelpDialogFrame {
-  background-color: transparent;
+  background-color: rgba(10,10,10,0.6);
   padding: 0px;
-  overflow: hidden;
-
-  display: block;
-  position: fixed;
+  top: 0px;
+  left: 0px;
   width: 100%;
   min-width: 400px;
   height: 100%;
-  top: 0px;
-  left: 0px;
+  display: block;
+  position: fixed;
   border: none;
-
-  /* One less than hint markers. */
-  z-index: 2147483645;
+  z-index: 2147483645; /* One less than hint markers. */
 }
 
 div#vimiumHelpDialog {
-  border:3px solid red;
+  border:3px solid;
+  -webkit-box-shadow: rgba(0, 0, 0, 0.4) 0px 0px 6px;
   opacity:0.92;
   background-color:#eee;
   position:fixed;
@@ -164,14 +161,11 @@ div#vimiumHelpDialog {
   border-radius:6px;
   padding:8px 12px;
   top:50px;
-  left:50%;
-  width:640px;
-  max-height: calc(100% - 100px - 16px); /* 100% - 2*top - 2*padding for top/bottom */
-  /* This needs to be 1/2 width to horizontally center the help dialog */
-  margin-left:-320px;
-  -webkit-box-shadow: rgba(0, 0, 0, 0.4) 0px 0px 6px;
-  overflow-x: auto;
-  overflow-y: auto;
+  left: 50%;
+  max-height: calc(100% - 100px - 12px);
+  width:      calc(840px + 24px + 4px + 12px);
+  margin-left:calc(0px - 420px - 12px - 2px - 6px); /* Minus half of the width, above. */
+  overflow: auto;
 }
 
 div#vimiumHelpDialog a { color:blue; }

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -213,14 +213,16 @@ span.vimiumHelpDialogKey {
   background-color: rgb(243,243,243);
   color: rgb(33,33,33);
   margin-left: 2px;
-  padding-top: 0px;
-  padding-bottom: 2px;
+  padding-top: 1px;
+  padding-bottom: 1px;
   padding-left: 4px;
   padding-right: 4px;
   border-radius: 3px;
   border: solid 1px #ccc;
   border-bottom-color: #bbb;
   box-shadow: inset 0 -1px 0 #bbb;
+  font-family: monospace;
+  font-size: 11px;
 }
 /* Make the description column as wide as it can be. */
 div#vimiumHelpDialog div.vimiumColumn tr > td:nth-of-type(3) { width:100%; }

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -212,12 +212,15 @@ div#vimiumHelpDialog div.vimiumColumn tr > td:first-of-type {
 span.vimiumHelpDialogKey {
   background-color: rgb(243,243,243);
   color: rgb(33,33,33);
-  margin: 2px;
-  padding-top: 1px;
-  padding-bottom: 1px;
+  margin-left: 2px;
+  padding-top: 0px;
+  padding-bottom: 2px;
   padding-left: 4px;
   padding-right: 4px;
-  border-radius: 4px;
+  border-radius: 3px;
+  border: solid 1px #ccc;
+  border-bottom-color: #bbb;
+  box-shadow: inset 0 -1px 0 #bbb;
 }
 /* Make the description column as wide as it can be. */
 div#vimiumHelpDialog div.vimiumColumn tr > td:nth-of-type(3) { width:100%; }

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -236,8 +236,9 @@ div#vimiumHelpDialog td.vimiumHelpDescription {
   font-size:14px;
 }
 div#vimiumHelpDialog span.commandName {
-  font-family:"courier new";
-  color: #555;
+  /* font-family:"courier new"; */
+  /* color: #555; */
+  font-style: italic;
 }
 /* Advanced commands are hidden by default until you show them. */
 div#vimiumHelpDialog tr.advanced { display: none; }

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -273,18 +273,19 @@ div#vimiumHelpDialogFooter {
   position: relative;
 }
 td.helpDialogBottomRight {
-   width: 100%;
-   text-align: right;
+  width:100%;
+  float:right;
+  text-align: right;
 }
 div#vimiumHelpDialogFooter * { font-size:10px; }
 a#toggleAdvancedCommands, span#help-dialog-tip {
   position: relative;
   top: 19px;
-  color: #555;
   white-space: nowrap;
+  font-size: 10px;
 }
-td.helpDialogBottomLeft, td.helpDialogBottomRight {
-  font-size: 14px;
+a#toggleAdvancedCommands {
+  color: #555;
 }
 
 a:link.vimiumHelDialogLink, a:visited.vimiumHelDialogLink, a:hover.vimiumHelDialogLink, a:active.vimiumHelDialogLink{

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -182,7 +182,6 @@ td.vimiumHelpDialogTopButtons {
   font-size: 14px;
   padding-left: 5px;
   padding-right: 5px;
-  color:#555;
 }
 div.vimiumColumn {
   width:50%;
@@ -287,12 +286,9 @@ a#toggleAdvancedCommands, span#help-dialog-tip {
   white-space: nowrap;
   font-size: 10px;
 }
-a#toggleAdvancedCommands {
-  color: #555;
-}
-
-a:link.vimiumHelDialogLink, a:visited.vimiumHelDialogLink, a:hover.vimiumHelDialogLink, a:active.vimiumHelDialogLink{
-  color:#555;
+a:link.vimiumHelDialogLink, a:visited.vimiumHelDialogLink, a:hover.vimiumHelDialogLink, a:active.vimiumHelDialogLink {
+  color:blue;
+  text-decoration: underline;
 }
 
 /* Vimium HUD CSS */

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -168,7 +168,6 @@ div#vimiumHelpDialog {
   overflow: auto;
 }
 
-div#vimiumHelpDialog a { color:blue; }
 div#vimiumTitle, div#vimiumTitle span,  div#vimiumTitle * { font-size:20px; }
 #vimiumTitle {
   display: block;
@@ -198,9 +197,19 @@ div#vimiumHelpDialog div.vimiumColumn tr > td:first-of-type {
   font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;
   font-size:14px;
   text-align:right;
-  font-weight:bold;
-  color:#2f508e;
+  /* font-weight:bold; */
+  /* color:#2f508e; */
   white-space:nowrap;
+}
+span.vimiumHelpDialogKey {
+  background-color: rgb(243,243,243);
+  color: rgb(33,33,33);
+  margin: 2px;
+  padding-top: 1px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  padding-right: 4px;
+  border-radius: 4px;
 }
 /* Make the description column as wide as it can be. */
 div#vimiumHelpDialog div.vimiumColumn tr > td:nth-of-type(3) { width:100%; }
@@ -228,8 +237,8 @@ div#vimiumHelpDialog.showAdvanced tr.advanced { display: table-row; }
 div#vimiumHelpDialog div.advanced td:nth-of-type(3) { color: #555; }
 div#vimiumHelpDialog a.closeButton {
   position:absolute;
-  right:7px;
-  top:5px;
+  right:4px;
+  top:2px;
   font-family:"courier new";
   font-weight:bold;
   color:#555;
@@ -244,15 +253,16 @@ div#vimiumHelpDialog a {
 div#vimiumHelpDialog .wikiPage, div#vimiumHelpDialog .optionsPage {
   position: absolute;
   display: block;
-  font-size: 11px;
+  font-size: 14px;
   line-height: 130%;
-  top: 6px;
+  color:#555;
+  top: 11px;
 }
 div#vimiumHelpDialog .optionsPage {
   right: 40px;
 }
 div#vimiumHelpDialog .wikiPage {
-  right: 83px;
+  right: 100px;
 }
 div#vimiumHelpDialog a.closeButton:hover {
   color:black;
@@ -267,6 +277,12 @@ div#vimiumHelpDialogFooter .toggleAdvancedCommands {
   position: absolute;
   right: 2px;
   top: -34px;
+  font-size: 14px;
+  color:#555;
+}
+
+a:link.vimiumHelDialogLink, a:visited.vimiumHelDialogLink, a:hover.vimiumHelDialogLink, a:active.vimiumHelDialogLink{
+  color:#555;
 }
 
 /* Vimium HUD CSS */

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -150,17 +150,22 @@ iframe.vimiumHelpDialogFrame {
   z-index: 2147483645; /* One less than hint markers. */
 }
 
-div#vimiumHelpDialog {
+div#vimiumHelpDialogContainer {
   opacity:1.0;
   background-color:white;
   border:2px solid #b3b3b3;
   border-radius:6px;
-  padding:8px 12px;
   width: 840px;
   max-width: calc(100% - 100px);
   max-height: calc(100% - 100px);
   margin: 50px auto;
   overflow-y: auto;
+  overflow-x: auto;
+}
+
+div#vimiumHelpDialog {
+  min-width: 600px;
+  padding:8px 12px;
 }
 
 span#vimiumTitle, span#vimiumTitle span,  span#vimiumTitle * { font-size:20px; }

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -163,6 +163,7 @@ div#vimiumHelpDialog {
   top:50px;
   left: 50%;
   max-height: calc(100% - 100px - 12px);
+  max-width: calc(100% - 100px + 12px);
   width:      calc(840px + 24px + 4px + 12px);
   margin-left:calc(0px - 420px - 12px - 2px - 6px); /* Minus half of the width, above. */
   overflow: auto;

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -208,8 +208,6 @@ div#vimiumHelpDialog div.vimiumColumn tr > td:first-of-type {
   font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;
   font-size:14px;
   text-align:right;
-  /* font-weight:bold; */
-  /* color:#2f508e; */
   white-space:nowrap;
 }
 span.vimiumHelpDialogKey {
@@ -245,6 +243,7 @@ div#vimiumHelpDialog span.commandName {
   color: #555;
   font-style: italic;
   cursor: pointer;
+  font-size: 12px;
 }
 /* Advanced commands are hidden by default until you show them. */
 div#vimiumHelpDialog tr.advanced { display: none; }
@@ -271,11 +270,15 @@ div#vimiumHelpDialog a.closeButton:hover {
 div#vimiumHelpDialogFooter {
   display: block;
   position: relative;
+  margin-bottom: 37px;
 }
 td.helpDialogBottomRight {
   width:100%;
   float:right;
   text-align: right;
+}
+td.helpDialogBottomRight, td.helpDialogBottomLeft {
+  padding: 0px;
 }
 div#vimiumHelpDialogFooter * { font-size:10px; }
 a#toggleAdvancedCommands, span#help-dialog-tip {

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -151,26 +151,32 @@ iframe.vimiumHelpDialogFrame {
 }
 
 div#vimiumHelpDialog {
-  border:3px solid;
   opacity:1.0;
   background-color:white;
-  position:fixed;
   border:2px solid #b3b3b3;
   border-radius:6px;
   padding:8px 12px;
-  top:50px;
-  left: 50%;
   width: 840px;
-  height: calc(100% - 100px - 16px); /* 100% -top - 2*padding */
-  max-width: calc(100% - 100px - 12px);
-  margin-left:calc(-420px - 12px); /* -1/2*width - 1*padding */
-  overflow: auto;
+  max-width: calc(100% - 100px);
+  max-height: calc(100% - 100px);
+  margin: 50px auto;
+  overflow-y: auto;
 }
 
-div#vimiumTitle, div#vimiumTitle span,  div#vimiumTitle * { font-size:20px; }
+span#vimiumTitle, span#vimiumTitle span,  span#vimiumTitle * { font-size:20px; }
 #vimiumTitle {
   display: block;
   line-height: 130%;
+  white-space: nowrap;
+}
+td.vimiumHelpDialogTopButtons {
+  width: 100%;
+  text-align: right;
+}
+#helpDialogOptionsPage, #helpDialogWikiPage {
+  font-size: 14px;
+  padding-left: 5px;
+  padding-right: 5px;
 }
 div.vimiumColumn {
   width:50%;
@@ -238,34 +244,19 @@ div#vimiumHelpDialog tr.advanced { display: none; }
 div#vimiumHelpDialog.showAdvanced tr.advanced { display: table-row; }
 div#vimiumHelpDialog div.advanced td:nth-of-type(3) { color: #555; }
 div#vimiumHelpDialog a.closeButton {
-  position:absolute;
-  right:4px;
-  top:2px;
   font-family:"courier new";
   font-weight:bold;
   color:#555;
   text-decoration:none;
-  padding-left:10px;
   font-size:20px;
+  position: relative;
+  top: -12px;
+  right: -10px;
 }
 div#vimiumHelpDialog a {
   text-decoration: underline;
 }
 
-div#vimiumHelpDialog .wikiPage, div#vimiumHelpDialog .optionsPage {
-  position: absolute;
-  display: block;
-  font-size: 14px;
-  line-height: 130%;
-  color:#555;
-  top: 11px;
-}
-div#vimiumHelpDialog .optionsPage {
-  right: 40px;
-}
-div#vimiumHelpDialog .wikiPage {
-  right: 100px;
-}
 div#vimiumHelpDialog a.closeButton:hover {
   color:black;
   -webkit-user-select:none;

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -177,6 +177,7 @@ td.vimiumHelpDialogTopButtons {
   font-size: 14px;
   padding-left: 5px;
   padding-right: 5px;
+  color:#555;
 }
 div.vimiumColumn {
   width:50%;

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -290,9 +290,10 @@ a#toggleAdvancedCommands, span#help-dialog-tip {
   white-space: nowrap;
   font-size: 10px;
 }
-a:link.vimiumHelDialogLink, a:visited.vimiumHelDialogLink, a:hover.vimiumHelDialogLink, a:active.vimiumHelDialogLink {
-  color:blue;
-  text-decoration: underline;
+a:link.vimiumHelDialogLink, a:visited.vimiumHelDialogLink,
+  a:hover.vimiumHelDialogLink, a:active.vimiumHelDialogLink, a#toggleAdvancedCommands {
+    color:#2f508e;
+    text-decoration: underline;
 }
 
 /* Vimium HUD CSS */

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -231,7 +231,10 @@ div#vimiumHelpDialog td.vimiumHelpDescription {
   font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;
   font-size:14px;
 }
-div#vimiumHelpDialog div.commandName { font-family:"courier new"; }
+div#vimiumHelpDialog span.commandName {
+  font-family:"courier new";
+  color: #555;
+}
 /* Advanced commands are hidden by default until you show them. */
 div#vimiumHelpDialog tr.advanced { display: none; }
 div#vimiumHelpDialog.showAdvanced tr.advanced { display: table-row; }

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -143,7 +143,6 @@ iframe.vimiumHelpDialogFrame {
   top: 0px;
   left: 0px;
   width: 100%;
-  min-width: 400px;
   height: 100%;
   display: block;
   position: fixed;
@@ -153,7 +152,6 @@ iframe.vimiumHelpDialogFrame {
 
 div#vimiumHelpDialog {
   border:3px solid;
-  -webkit-box-shadow: rgba(0, 0, 0, 0.4) 0px 0px 6px;
   opacity:1.0;
   background-color:white;
   position:fixed;
@@ -162,10 +160,10 @@ div#vimiumHelpDialog {
   padding:8px 12px;
   top:50px;
   left: 50%;
-  max-height: calc(100% - 100px - 12px);
-  max-width: calc(100% - 100px + 12px);
-  width:      calc(840px + 24px + 4px + 12px);
-  margin-left:calc(0px - 420px - 12px - 2px - 6px); /* Minus half of the width, above. */
+  width: 840px;
+  height: calc(100% - 100px - 16px); /* 100% -top - 2*padding */
+  max-width: calc(100% - 100px - 12px);
+  margin-left:calc(-420px - 12px); /* -1/2*width - 1*padding */
   overflow: auto;
 }
 

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -154,8 +154,8 @@ iframe.vimiumHelpDialogFrame {
 div#vimiumHelpDialog {
   border:3px solid;
   -webkit-box-shadow: rgba(0, 0, 0, 0.4) 0px 0px 6px;
-  opacity:0.92;
-  background-color:#eee;
+  opacity:1.0;
+  background-color:white;
   position:fixed;
   border:2px solid #b3b3b3;
   border-radius:6px;
@@ -194,6 +194,9 @@ div.vimiumColumn table, div.vimiumColumn td, div.vimiumColumn tr { padding:0; ma
 div.vimiumColumn table { width:100%; table-layout:auto; }
 div.vimiumColumn td { vertical-align:top; padding:1px; }
 div#vimiumHelpDialog div.vimiumColumn tr > td:first-of-type {
+  /* This is the "key" column, e.g. "j", "gg". */
+  font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-size:14px;
   text-align:right;
   font-weight:bold;
   color:#2f508e;
@@ -204,13 +207,19 @@ div#vimiumHelpDialog div.vimiumColumn tr > td:nth-of-type(3) { width:100%; }
 div#vimiumHelpDialog div.vimiumDivider {
   display: block;
   height:1px;
-  width:92%;
+  width:100%;
   margin:10px auto;
   background-color:#9a9a9a;
 }
 div#vimiumHelpDialog td.vimiumHelpSectionTitle {
-  font-weight:bold;
   padding-top:3px;
+  font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-size:16px;
+  font-weight:bold;
+}
+div#vimiumHelpDialog td.vimiumHelpDescription {
+  font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-size:14px;
 }
 div#vimiumHelpDialog div.commandName { font-family:"courier new"; }
 /* Advanced commands are hidden by default until you show them. */

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -237,9 +237,9 @@ div#vimiumHelpDialog td.vimiumHelpDescription {
   font-size:14px;
 }
 div#vimiumHelpDialog span.commandName {
-  /* font-family:"courier new"; */
-  /* color: #555; */
+  color: #555;
   font-style: italic;
+  cursor: pointer;
 }
 /* Advanced commands are hidden by default until you show them. */
 div#vimiumHelpDialog tr.advanced { display: none; }
@@ -267,13 +267,19 @@ div#vimiumHelpDialogFooter {
   display: block;
   position: relative;
 }
+td.helpDialogBottomRight {
+   width: 100%;
+   text-align: right;
+}
 div#vimiumHelpDialogFooter * { font-size:10px; }
-div#vimiumHelpDialogFooter .toggleAdvancedCommands {
-  position: absolute;
-  right: 2px;
-  top: -34px;
+a#toggleAdvancedCommands, span#help-dialog-tip {
+  position: relative;
+  top: 19px;
+  color: #555;
+  white-space: nowrap;
+}
+td.helpDialogBottomLeft, td.helpDialogBottomRight {
   font-size: 14px;
-  color:#555;
 }
 
 a:link.vimiumHelDialogLink, a:visited.vimiumHelDialogLink, a:hover.vimiumHelDialogLink, a:active.vimiumHelDialogLink{

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -242,7 +242,6 @@ div#vimiumHelpDialog td.vimiumHelpDescription {
   font-size:14px;
 }
 div#vimiumHelpDialog span.commandName {
-  color: #555;
   font-style: italic;
   cursor: pointer;
   font-size: 12px;

--- a/pages/help_dialog.coffee
+++ b/pages/help_dialog.coffee
@@ -19,7 +19,7 @@ HelpDialog =
         clickEvent.preventDefault()
         chrome.runtime.sendMessage({handler: "openOptionsPageInNewTab"})
       false)
-    @dialogElement.getElementsByClassName("toggleAdvancedCommands")[0].addEventListener("click",
+    document.getElementById("toggleAdvancedCommands").addEventListener("click",
       HelpDialog.toggleAdvancedCommands, false)
 
     document.documentElement.addEventListener "click", (event) =>
@@ -58,7 +58,7 @@ HelpDialog =
     Settings.set("helpDialog_showAdvancedCommands", !showAdvanced)
 
   showAdvancedCommands: (visible) ->
-    HelpDialog.dialogElement.getElementsByClassName("toggleAdvancedCommands")[0].innerHTML =
+    document.getElementById("toggleAdvancedCommands").innerHTML =
       if visible then "Hide advanced commands" else "Show advanced commands"
 
     # Add/remove the showAdvanced class to show/hide advanced commands.

--- a/pages/help_dialog.coffee
+++ b/pages/help_dialog.coffee
@@ -15,7 +15,7 @@ HelpDialog =
         clickEvent.preventDefault()
         @hide()
       false)
-    @dialogElement.getElementsByClassName("optionsPage")[0].addEventListener("click", (clickEvent) ->
+    document.getElementById("helpDialogOptionsPage").addEventListener("click", (clickEvent) ->
         clickEvent.preventDefault()
         chrome.runtime.sendMessage({handler: "openOptionsPageInNewTab"})
       false)

--- a/pages/help_dialog.coffee
+++ b/pages/help_dialog.coffee
@@ -38,7 +38,7 @@ HelpDialog =
       do (element) ->
         element.setAttribute "role", "link"
         element.addEventListener "click", ->
-          commandName = element.textContent.replace("(","").replace ")", ""
+          commandName = element.textContent
           chrome.runtime.sendMessage handler: "copyToClipboard", data: commandName
           HUD.showForDuration("Yanked #{commandName}.", 2000)
 
@@ -82,3 +82,4 @@ UIComponentServer.registerHandler (event) ->
 
 root = exports ? window
 root.HelpDialog = HelpDialog
+root.isVimiumHelpDialog = true

--- a/pages/help_dialog.html
+++ b/pages/help_dialog.html
@@ -65,11 +65,23 @@
         </table>
       </div>
 
+      <div>
+        <table>
+          <tr>
+            <td class="helpDialogBottomLeft">
+              <span id="help-dialog-tip"></span>
+            </td>
+            <td class="helpDialogBottomRight">
+              <a href="#" id="toggleAdvancedCommands">Show advanced commands</a>
+            </td>
+          </tr>
+        </table>
+      </div>
+
       <br clear="both"/>
       <div class="vimiumReset vimiumDivider"></div>
 
       <div id="vimiumHelpDialogFooter" class="vimiumReset">
-        <a href="#" class="vimiumReset toggleAdvancedCommands">Show advanced commands</a>
         <div class="vimiumReset vimiumColumn">
           Enjoying Vimium?
           <a class="vimiumHelDialogLink" target="_blank"

--- a/pages/help_dialog.html
+++ b/pages/help_dialog.html
@@ -70,17 +70,16 @@
 
       <div id="vimiumHelpDialogFooter" class="vimiumReset">
         <a href="#" class="vimiumReset toggleAdvancedCommands">Show advanced commands</a>
-          <div class="vimiumReset vimiumColumn">
-            Enjoying Vimium?
-            <a class="vimiumHelDialogLink" target="_blank"
-              href="https://chrome.google.com/webstore/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb/reviews">Leave us
-                  feedback</a>.<br/>
-            Found a bug? <a class="vimiumHelDialogLink" target="_blank" href="http://github.com/philc/vimium/issues">Report it here</a>.
-          </div>
-          <div class="vimiumReset vimiumColumn" style="text-align:right">
-            <span class="vimiumReset">Version <span id="help-dialog-version"></span></span><br/>
-            <a href="https://github.com/philc/vimium#release-notes" target="_blank" class="vimiumHelDialogLink">What's new?</a>
-          </div>
+        <div class="vimiumReset vimiumColumn">
+          Enjoying Vimium?
+          <a class="vimiumHelDialogLink" target="_blank"
+            href="https://chrome.google.com/webstore/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb/reviews">Leave us
+                feedback</a>.<br/>
+          Found a bug? <a class="vimiumHelDialogLink" target="_blank" href="http://github.com/philc/vimium/issues">Report it here</a>.
+        </div>
+        <div class="vimiumReset vimiumColumn" style="text-align:right">
+          <span class="vimiumReset">Version <span id="help-dialog-version"></span></span><br/>
+          <a href="https://github.com/philc/vimium#release-notes" target="_blank" class="vimiumHelDialogLink">What's new?</a>
         </div>
       </div>
     </div>

--- a/pages/help_dialog.html
+++ b/pages/help_dialog.html
@@ -24,8 +24,8 @@
                 <span id="vimiumTitle" class="vimiumReset"><span class="vimiumReset" style="color:#2f508e">Vim</span>ium <span id="help-dialog-title"></span></span>
               </td>
               <td class="vimiumHelpDialogTopButtons">
-                <a class="vimiumReset" id="helpDialogOptionsPage" href="#">Options</a>
-                <a class="vimiumReset" id="helpDialogWikiPage" href="https://github.com/philc/vimium/wiki" target="_blank">Wiki</a>
+                <a class="vimiumReset vimiumHelDialogLink" id="helpDialogOptionsPage" href="#">Options</a>
+                <a class="vimiumReset vimiumHelDialogLink" id="helpDialogWikiPage" href="https://github.com/philc/vimium/wiki" target="_blank">Wiki</a>
                 <a class="vimiumReset closeButton" href="#">&times;</a>
               </td>
             </tr>
@@ -72,7 +72,7 @@
               <td class="helpDialogBottomLeft">
                 <span id="help-dialog-tip"></span>
               </td>
-              <td class="helpDialogBottomRight">
+              <td class="helpDialogBottomRight vimiumHelDialogLink">
                 <a href="#" id="toggleAdvancedCommands">Show advanced commands</a>
               </td>
             </tr>

--- a/pages/help_dialog.html
+++ b/pages/help_dialog.html
@@ -15,11 +15,12 @@
 
   <!-- Note that the template placeholders (e.g. "pageNavigation") will be filled in by the background
        page with the up-to-date key bindings when the dialog is shown. -->
-    <div id="vimiumHelpDialog" class="vimiumReset">
+    <div id="vimiumHelpDialog">
       <a class="vimiumReset optionsPage" href="#">Options</a>
       <a class="vimiumReset wikiPage" href="https://github.com/philc/vimium/wiki" target="_blank">Wiki</a>
       <a class="vimiumReset closeButton" href="#">&times;</a>
       <div id="vimiumTitle" class="vimiumReset"><span class="vimiumReset" style="color:#2f508e">Vim</span>ium <span id="help-dialog-title"></span></div>
+      <div class="vimiumReset vimiumDivider"></div>
       <div class="vimiumReset vimiumColumn">
         <table class="vimiumReset">
           <thead class="vimiumReset">

--- a/pages/help_dialog.html
+++ b/pages/help_dialog.html
@@ -60,17 +60,17 @@
 
       <div id="vimiumHelpDialogFooter" class="vimiumReset">
         <a href="#" class="vimiumReset toggleAdvancedCommands">Show advanced commands</a>
-
-        <div class="vimiumReset vimiumColumn">
-          Enjoying Vimium?
-          <a class="vimiumReset" target="_blank"
-          href="https://chrome.google.com/webstore/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb/reviews">Leave us
-              feedback</a>.<br/>
-          Found a bug? <a class="vimiumReset" target="_blank" href="http://github.com/philc/vimium/issues">Report it here</a>.
-        </div>
-        <div class="vimiumReset vimiumColumn" style="text-align:right">
-          <span class="vimiumReset">Version <span id="help-dialog-version"></span></span><br/>
-          <a target="_blank" href="https://github.com/philc/vimium#release-notes" class="vimiumReset">What's new?</a>
+          <div class="vimiumReset vimiumColumn">
+            Enjoying Vimium?
+            <a class="vimiumHelDialogLink" target="_blank"
+              href="https://chrome.google.com/webstore/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb/reviews">Leave us
+                  feedback</a>.<br/>
+            Found a bug? <a class="vimiumHelDialogLink" target="_blank" href="http://github.com/philc/vimium/issues">Report it here</a>.
+          </div>
+          <div class="vimiumReset vimiumColumn" style="text-align:right">
+            <span class="vimiumReset">Version <span id="help-dialog-version"></span></span><br/>
+            <a href="https://github.com/philc/vimium#release-notes" target="_blank" class="vimiumHelDialogLink">What's new?</a>
+          </div>
         </div>
       </div>
     </div>

--- a/pages/help_dialog.html
+++ b/pages/help_dialog.html
@@ -15,83 +15,85 @@
 
   <!-- Note that the template placeholders (e.g. "pageNavigation") will be filled in by the background
        page with the up-to-date key bindings when the dialog is shown. -->
-    <div id="vimiumHelpDialog">
-      <div>
-        <table>
-          <tr>
-            <td>
-              <span id="vimiumTitle" class="vimiumReset"><span class="vimiumReset" style="color:#2f508e">Vim</span>ium <span id="help-dialog-title"></span></span>
-            </td>
-            <td class="vimiumHelpDialogTopButtons">
-              <a class="vimiumReset" id="helpDialogOptionsPage" href="#">Options</a>
-              <a class="vimiumReset" id="helpDialogWikiPage" href="https://github.com/philc/vimium/wiki" target="_blank">Wiki</a>
-              <a class="vimiumReset closeButton" href="#">&times;</a>
-            </td>
-          </tr>
-        </table>
-      </div>
-      <div class="vimiumReset vimiumDivider"></div>
-      <div class="vimiumReset vimiumColumn">
-        <table class="vimiumReset">
-          <thead class="vimiumReset">
-            <tr class="vimiumReset" ><td class="vimiumReset"></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Navigating the page</td></tr>
-          </thead>
-          <tbody id="help-dialog-pageNavigation" class="vimiumReset">
-          </tbody>
-        </table>
-      </div>
-      <div class="vimiumReset vimiumColumn">
-        <table class="vimiumReset" >
-          <thead class="vimiumReset">
-          <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Using the vomnibar</td></tr>
-          </thead>
-          <tbody class="vimiumReset" id="help-dialog-vomnibarCommands"></tbody>
-          <thead class="vimiumReset">
-          <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Using find</td></tr>
-          </thead>
-          <tbody class="vimiumReset" id="help-dialog-findCommands"></tbody>
-          <thead class="vimiumReset">
-          <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Navigating history</td></tr>
-          </thead>
-          <tbody class="vimiumReset" id="help-dialog-historyNavigation"></tbody>
-          <thead class="vimiumReset">
-          <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Manipulating tabs</td></tr>
-          </thead>
-          <tbody class="vimiumReset" id="help-dialog-tabManipulation"></tbody>
-          <thead class="vimiumReset">
-          <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Miscellaneous</td></tr>
-          </thead>
-          <tbody class="vimiumReset" id="help-dialog-misc"></tbody>
-        </table>
-      </div>
-
-      <div>
-        <table>
-          <tr>
-            <td class="helpDialogBottomLeft">
-              <span id="help-dialog-tip"></span>
-            </td>
-            <td class="helpDialogBottomRight">
-              <a href="#" id="toggleAdvancedCommands">Show advanced commands</a>
-            </td>
-          </tr>
-        </table>
-      </div>
-
-      <br clear="both"/>
-      <div class="vimiumReset vimiumDivider"></div>
-
-      <div id="vimiumHelpDialogFooter" class="vimiumReset">
-        <div class="vimiumReset vimiumColumn">
-          Enjoying Vimium?
-          <a class="vimiumHelDialogLink" target="_blank"
-            href="https://chrome.google.com/webstore/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb/reviews">Leave us
-                feedback</a>.<br/>
-          Found a bug? <a class="vimiumHelDialogLink" target="_blank" href="http://github.com/philc/vimium/issues">Report it here</a>.
+    <div id="vimiumHelpDialogContainer">
+      <div id="vimiumHelpDialog">
+        <div>
+          <table>
+            <tr>
+              <td>
+                <span id="vimiumTitle" class="vimiumReset"><span class="vimiumReset" style="color:#2f508e">Vim</span>ium <span id="help-dialog-title"></span></span>
+              </td>
+              <td class="vimiumHelpDialogTopButtons">
+                <a class="vimiumReset" id="helpDialogOptionsPage" href="#">Options</a>
+                <a class="vimiumReset" id="helpDialogWikiPage" href="https://github.com/philc/vimium/wiki" target="_blank">Wiki</a>
+                <a class="vimiumReset closeButton" href="#">&times;</a>
+              </td>
+            </tr>
+          </table>
         </div>
-        <div class="vimiumReset vimiumColumn" style="text-align:right">
-          <span class="vimiumReset">Version <span id="help-dialog-version"></span></span><br/>
-          <a href="https://github.com/philc/vimium#release-notes" target="_blank" class="vimiumHelDialogLink">What's new?</a>
+        <div class="vimiumReset vimiumDivider"></div>
+        <div class="vimiumReset vimiumColumn">
+          <table class="vimiumReset">
+            <thead class="vimiumReset">
+              <tr class="vimiumReset" ><td class="vimiumReset"></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Navigating the page</td></tr>
+            </thead>
+            <tbody id="help-dialog-pageNavigation" class="vimiumReset">
+            </tbody>
+          </table>
+        </div>
+        <div class="vimiumReset vimiumColumn">
+          <table class="vimiumReset" >
+            <thead class="vimiumReset">
+            <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Using the vomnibar</td></tr>
+            </thead>
+            <tbody class="vimiumReset" id="help-dialog-vomnibarCommands"></tbody>
+            <thead class="vimiumReset">
+            <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Using find</td></tr>
+            </thead>
+            <tbody class="vimiumReset" id="help-dialog-findCommands"></tbody>
+            <thead class="vimiumReset">
+            <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Navigating history</td></tr>
+            </thead>
+            <tbody class="vimiumReset" id="help-dialog-historyNavigation"></tbody>
+            <thead class="vimiumReset">
+            <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Manipulating tabs</td></tr>
+            </thead>
+            <tbody class="vimiumReset" id="help-dialog-tabManipulation"></tbody>
+            <thead class="vimiumReset">
+            <tr class="vimiumReset" ><td class="vimiumReset" ></td><td class="vimiumReset" ></td><td class="vimiumReset vimiumHelpSectionTitle">Miscellaneous</td></tr>
+            </thead>
+            <tbody class="vimiumReset" id="help-dialog-misc"></tbody>
+          </table>
+        </div>
+
+        <div>
+          <table>
+            <tr>
+              <td class="helpDialogBottomLeft">
+                <span id="help-dialog-tip"></span>
+              </td>
+              <td class="helpDialogBottomRight">
+                <a href="#" id="toggleAdvancedCommands">Show advanced commands</a>
+              </td>
+            </tr>
+          </table>
+        </div>
+
+        <br clear="both"/>
+        <div class="vimiumReset vimiumDivider"></div>
+
+        <div id="vimiumHelpDialogFooter" class="vimiumReset">
+          <div class="vimiumReset vimiumColumn">
+            Enjoying Vimium?
+            <a class="vimiumHelDialogLink" target="_blank"
+              href="https://chrome.google.com/webstore/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb/reviews">Leave us
+                  feedback</a>.<br/>
+            Found a bug? <a class="vimiumHelDialogLink" target="_blank" href="http://github.com/philc/vimium/issues">Report it here</a>.
+          </div>
+          <div class="vimiumReset vimiumColumn" style="text-align:right">
+            <span class="vimiumReset">Version <span id="help-dialog-version"></span></span><br/>
+            <a href="https://github.com/philc/vimium#release-notes" target="_blank" class="vimiumHelDialogLink">What's new?</a>
+          </div>
         </div>
       </div>
     </div>

--- a/pages/help_dialog.html
+++ b/pages/help_dialog.html
@@ -16,10 +16,20 @@
   <!-- Note that the template placeholders (e.g. "pageNavigation") will be filled in by the background
        page with the up-to-date key bindings when the dialog is shown. -->
     <div id="vimiumHelpDialog">
-      <a class="vimiumReset optionsPage" href="#">Options</a>
-      <a class="vimiumReset wikiPage" href="https://github.com/philc/vimium/wiki" target="_blank">Wiki</a>
-      <a class="vimiumReset closeButton" href="#">&times;</a>
-      <div id="vimiumTitle" class="vimiumReset"><span class="vimiumReset" style="color:#2f508e">Vim</span>ium <span id="help-dialog-title"></span></div>
+      <div>
+        <table>
+          <tr>
+            <td>
+              <span id="vimiumTitle" class="vimiumReset"><span class="vimiumReset" style="color:#2f508e">Vim</span>ium <span id="help-dialog-title"></span></span>
+            </td>
+            <td class="vimiumHelpDialogTopButtons">
+              <a class="vimiumReset" id="helpDialogOptionsPage" href="#">Options</a>
+              <a class="vimiumReset" id="helpDialogWikiPage" href="https://github.com/philc/vimium/wiki" target="_blank">Wiki</a>
+              <a class="vimiumReset closeButton" href="#">&times;</a>
+            </td>
+          </tr>
+        </table>
+      </div>
       <div class="vimiumReset vimiumDivider"></div>
       <div class="vimiumReset vimiumColumn">
         <table class="vimiumReset">


### PR DESCRIPTION
Calling @philc...

The current help dialog styling is a bit cramped, and doesn't match the approach used by sites Google Inbox, GMail or Github.

This is a proposal for modernising the help dialog.  Here's what it looks like currently...

![snapshot](https://cloud.githubusercontent.com/assets/2641335/14639254/80f7651a-0633-11e6-946a-cf3f1d724bd1.png)
 
The changes are:

- When the dialog is showing, the background page is darkened.  The color and opacity are taken from Google inbox.

- The background is white and the fonts are larger.

- The links, ("Wiki", "Options", etc) are all in a dark font. (They were blue before.)
- The dialog window in 200px wider (but still seems to work ok on narrower screens).

- The keys are no longer blue, but instead use a grey background like this: `j`.  The background color was taken from either Google Inbox or Github (can't remember).

- When command names are shown, they use a fixed-width font.  See below.  It looks like this was originally intended, just somebody got the CSS wrong.

- When the help dialog is showing, link hints only select links from within the help dialog.  This is a big win when selecting command names on the options page.  (Because the hint dialog isn't polluted with useless hints from the options page itself.)

On the options page, clicking *Show available commands*, it looks like this...

![snapshot](https://cloud.githubusercontent.com/assets/2641335/14639458/dc180d2c-0634-11e6-85ae-3fa70cd76fe5.png)
