### PR TITLE
Prime focus input on the Vimium options page.

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -393,9 +393,7 @@ extend window,
 
       # This is a hack to improve usability on the Vimium options page.  We prime the recently-focused input
       # to be the key-mappings input.  Arguably, this is the input that the user is most likely to use.
-      unless recentlyFocusedElement?
-        if window.isVimiumOptionsPage
-          recentlyFocusedElement = document.getElementById "keyMappings"
+      recentlyFocusedElement ?= document.getElementById "keyMappings" if window.isVimiumOptionsPage
 
       selectedInputIndex =
         if count == 1

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -391,6 +391,12 @@ extend window,
         HUD.showForDuration("There are no inputs to focus.", 1000)
         return
 
+      # This is a hack to improve usability on the Vimium options page.  We prime the recently-focused input
+      # to be the key-mappings input.  Arguably, this is the input that the user is most likely to use.
+      unless recentlyFocusedElement?
+        if window.isVimiumOptionsPage
+          recentlyFocusedElement = document.getElementById "keyMappings"
+
       selectedInputIndex =
         if count == 1
           # As the starting index, we pick that of the most recently focused input element (or 0).

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -324,4 +324,4 @@ document.addEventListener "DOMContentLoaded", ->
 
 # Exported for tests.
 root = exports ? window
-extend root, {Options}
+extend root, {Options, isVimiumOptionsPage: true}


### PR DESCRIPTION
This is a bit of a hack, and pertains to focusInput (`gf`).

The problem...  On the options page, there are *lots* of inputs (specifically, for every exclusion rule there are two inputs, so there can be several tens of inputs).  This makes `gf` almost unusable.  It's completely impractical to `Tab` through them all.

Here, on the options page, we prime the pre-selected input to be the key-mappings input:

- arguably, this is the most frequently used input, and
- other inputs (such as custom search engines) are just one `Tab` away.

I'm pushing this as a PR because it's a bit hacky.  Nevertheless, it does improve usability on the options page.  I'll merge this if there's no feedback.