### PR TITLE
Add sendMessage command to message external components.

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -140,6 +140,7 @@ Commands =
       "enterVisualMode",
       "enterVisualLineMode",
       "focusInput",
+      "sendMessage",
       "LinkHints.activateMode",
       "LinkHints.activateModeToOpenInNewTab",
       "LinkHints.activateModeToOpenInNewForegroundTab",
@@ -207,7 +208,8 @@ Commands =
     "closeTabsOnLeft",
     "closeTabsOnRight",
     "closeOtherTabs",
-    "passNextKey"]
+    "passNextKey",
+    "sendMessage"]
 
 defaultKeyMappings =
   "?": "showHelp"
@@ -320,6 +322,7 @@ commandDescriptions =
 
   enterInsertMode: ["Enter insert mode", { noRepeat: true }]
   passNextKey: ["Pass the next key to Chrome"]
+  sendMessage: ["Post a message to the page or an extension"]
   enterVisualMode: ["Enter visual mode", { noRepeat: true }]
   enterVisualLineMode: ["Enter visual line mode", { noRepeat: true }]
 

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -364,10 +364,10 @@ HintCoordinator =
     for own frameId, port of @tabState[tabId].ports
       @postMessage tabId, parseInt(frameId), messageType, port, request
 
-  prepareToActivateMode: (tabId, originatingFrameId, {modeIndex}) ->
+  prepareToActivateMode: (tabId, originatingFrameId, {modeIndex, options}) ->
     @tabState[tabId] = {frameIds: frameIdsForTab[tabId][..], hintDescriptors: {}, originatingFrameId, modeIndex}
     @tabState[tabId].ports = extend {}, portsForTab[tabId]
-    @sendMessage "getHintDescriptors", tabId, {modeIndex}
+    @sendMessage "getHintDescriptors", tabId, {modeIndex, options}
 
   # Receive hint descriptors from all frames and activate link-hints mode when we have them all.
   postHintDescriptors: (tabId, frameId, {hintDescriptors}) ->

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -373,7 +373,9 @@ extend window,
   sendMessage: (count, registryEntry) ->
     message = extend {}, registryEntry.options ? {}
     message = extend message, {count}
-    if message.extension
+    if message.hints
+      LinkHints.activateModeToSendMessage count, message
+    else if message.extension
       chrome.runtime.sendMessage message.extension, message
     else
       window.postMessage message, "*"

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -128,7 +128,7 @@ class NormalMode extends KeyHandlerMode
     else if registryEntry.background
       chrome.runtime.sendMessage {handler: "runBackgroundCommand", registryEntry, count}
     else
-      Utils.invokeCommandString registryEntry.command, count
+      Utils.invokeCommandString registryEntry.command, count, registryEntry
 
 installModes = ->
   # Install the permanent modes. The permanently-installed insert mode tracks focus/blur events, and
@@ -368,6 +368,16 @@ extend window,
   passNextKey: (count) ->
     new PassNextKeyMode count
 
+  # We cannot use the name "postMessage", because window.postMessage() already exists.  So we use
+  # the name "sendMessage" instead; hopefully this is not too confusing.
+  sendMessage: (count, registryEntry) ->
+    message = extend {}, registryEntry.options ? {}
+    message = extend message, {count}
+    if message.extension
+      chrome.runtime.sendMessage message.extension, message
+    else
+      window.postMessage message, "*"
+
   focusInput: do ->
     # Track the most recently focused input element.
     recentlyFocusedElement = null
@@ -375,7 +385,8 @@ extend window,
       (event) -> recentlyFocusedElement = event.target if DomUtils.isEditable event.target
     , true
 
-    (count, mode = InsertMode) ->
+    (count) ->
+      mode = InsertMode
       # Focus the first input element on the page, and create overlays to highlight all the input elements, with
       # the currently-focused element highlighted specially. Tabbing will shift focus to the next input element.
       # Pressing any other key will remove the overlays and the special tab behavior.


### PR DESCRIPTION
This is a simpler alternative to #1980.

Example:

    map p sendMessage name=SomeName secret=SomeSecret

Now, `3p` invokes `window.PostMessage()` with the message:

    name: "SomeName"
    secret: "SomeSecret"
    count: 3

It is a simple matter to write a  TamperMonkey script to receive and handle the message.  And - of course - it would be relatively simple for users to share TamperMonkey commands.

The names `name` and `secret` have no special meaning to Vimium.

Another example:

    map p sendMessage name=SomeName secret=SomeSecret extension=abjmlgelklomcednhcplkfdfdbajhdbn

If the `extension` option is truthy, then we use `chrome.runtime.sendMessage()` instead, using the cross-extension messaging API.  In this case, users could share new commands by publishing chrome extensions.

A possible extension of this idea would be to have a new link-hints mode (not a command) which selects a link then posts it as above to the page.  We can identify (and communicate)  elements by their index within:

    document.documentElement.getElementsByTagName "*"