### PR TITLE
Make global link hints optional (Vimium Labs)

### DIFF
--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -178,6 +178,7 @@ Settings =
     helpDialog_showAdvancedCommands: false
     optionsPage_showAdvancedOptions: false
     passNextKeyKeys: []
+    useGlobalLinkHints: false
 
 Settings.init()
 

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -199,6 +199,7 @@ Options =
   searchEngines: TextOption
   searchUrl: NonEmptyTextOption
   userDefinedLinkHintCss: TextOption
+  useGlobalLinkHints: CheckBoxOption
 
 initOptionsPage = ->
   onUpdated = ->

--- a/pages/options.html
+++ b/pages/options.html
@@ -250,9 +250,6 @@ b: http://b.com/?q=%s description
             </td>
           </tr>
 
-          <!-- Vimium Labs -->
-          <!--
-          Disabled.  But we leave this code here as a template for the next time we need to introduce "Vimium Labs".
           <tr>
             <td colspan="2"><header>Vimium Labs</header></td>
           </tr>
@@ -267,18 +264,17 @@ b: http://b.com/?q=%s description
             </td>
           </tr>
           <tr>
-            <td class="caption">Search weighting</td>
+            <td class="caption"></td>
             <td>
                 <div class="help">
                   <div class="example">
-                    How prominent should suggestions be in the vomnibar?
-                    <tt>0</tt> disables suggestions altogether.
+                    Use link hints to select links from all frames in the current tab
                   </div>
                 </div>
-              <input id="omniSearchWeight" type="number" min="0.0" max="1.0" step="0.05" />(0 to 1)
+                <input id="useGlobalLinkHints" type="checkbox"/>
+                Use global link hints
             </td>
           </tr>
-          -->
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
Add a Vimium-labs section to the options page where users can opt in to use global link hints.  Defaults to "no".

See this post:

- https://github.com/philc/vimium/issues/2081#issuecomment-210980903

On the options page, it looks like this:

![snapshot](https://cloud.githubusercontent.com/assets/2641335/14781931/82f50dc8-0add-11e6-89c3-cb9bafe4a8a1.png)

Some of the issues mentioned [here](https://github.com/philc/vimium/issues/2081#issuecomment-210980903) are quite concerning, and could break key Vimium features and  be disruptive to users.  On the other hand, just sitting on this feature won't help shake these issues out.  If we can get the code out there, then we might get feedback which provides a  better handle on how to fix them.