### PR TITLE
Improves next/previous links by targetting button elements and adding…

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -45,5 +45,6 @@ Contributors:
   Utkarsh Upadhyay <musically.ut@gmail.com) (github: musically-ut)
   Michael Salihi <admin@prestance-informatique.fr> (github: PrestanceDesign)
   Dahan Gong <gdh1995@qq.com> (github: gdh1995)
+  Scott Pinkelman <scott@scottpinkelman.com> (github: sco-tt)
 
 Feel free to add real names in addition to GitHub usernames.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -543,7 +543,7 @@ followLink = (linkElement) ->
 # next big thing', and 'more' over 'nextcompany', even if 'next' occurs before 'more' in :linkStrings.
 #
 findAndFollowLink = (linkStrings) ->
-  linksXPath = DomUtils.makeXPath(["a", "*[@onclick or @role='link' or contains(@class, 'button')]"])
+  linksXPath = DomUtils.makeXPath(["a", "button", "*[@onclick or @role='link' or contains(@class, 'button')]"])
   links = DomUtils.evaluateXPath(linksXPath, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE)
   candidateLinks = []
 

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -144,10 +144,10 @@ Settings =
     # "first/last page", so we put the single bracket first in the pattern string so that it gets searched
     # for first.
 
-    # "\bprev\b,\bprevious\b,\bback\b,<,←,«,≪,<<"
-    previousPatterns: "prev,previous,back,older,<,\u2190,\xab,\u226a,<<"
-    # "\bnext\b,\bmore\b,>,→,»,≫,>>"
-    nextPatterns: "next,more,newer,>,\u2192,\xbb,\u226b,>>"
+    # "\bprev\b,\bprevious\b,\bback\b,<,‹,←,«,≪,<<"
+    previousPatterns: "prev,previous,back,older,<,\u2039,\u2190,\xab,\u226a,<<"
+    # "\bnext\b,\bmore\b,>,›,→,»,≫,>>"
+    nextPatterns: "next,more,newer,>,\u203a,\u2192,\xbb,\u226b,>>"
     # default/fall back search engine
     searchUrl: "https://www.google.com/search?q="
     # put in an example search engine


### PR DESCRIPTION
I was attempting to address issue #1935 but I encountered two other issues with the previous/next shortcut.

1. Changes to vimium_frontend.coffee: previous/next don't work when the element is a `<button>`. See https://codepen.io/khilnani/pen/qEWojX as an example

2. Changes to settings.coffee: The previous/next patterns don't include single angle quotation marks, so on an example like this http://codepen.io/rasx/full/xGadEB the default behavior was going to the double angle quotation marks, usually first page/last page.