### PR TITLE
Make findAndFollowLink look at element values so <input> can be used …

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -563,8 +563,8 @@ findAndFollowLink = (linkStrings) ->
 
     linkMatches = false
     for linkString in linkStrings
-      if (link.innerText.toLowerCase().indexOf(linkString) != -1 || link.value &&
-          link.value.indexOf(linkString) != -1)
+      if link.innerText.toLowerCase().indexOf(linkString) != -1 ||
+          link.value?.indexOf(linkString) != -1
         linkMatches = true
         break
     continue unless linkMatches
@@ -596,8 +596,8 @@ findAndFollowLink = (linkStrings) ->
       else
         new RegExp linkString, "i"
     for candidateLink in candidateLinks
-      if (exactWordRegex.test(candidateLink.innerText) || 
-          candidateLink.value && exactWordRegex.test(candidateLink.value))
+      if exactWordRegex.test(candidateLink.innerText) ||
+          (candidateLink.value && exactWordRegex.test(candidateLink.value))
         followLink(candidateLink)
         return true
   false

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -563,7 +563,8 @@ findAndFollowLink = (linkStrings) ->
 
     linkMatches = false
     for linkString in linkStrings
-      if (link.innerText.toLowerCase().indexOf(linkString) != -1)
+      if (link.innerText.toLowerCase().indexOf(linkString) != -1 || link.value &&
+          link.value.indexOf(linkString) != -1)
         linkMatches = true
         break
     continue unless linkMatches
@@ -595,7 +596,8 @@ findAndFollowLink = (linkStrings) ->
       else
         new RegExp linkString, "i"
     for candidateLink in candidateLinks
-      if (exactWordRegex.test(candidateLink.innerText))
+      if (exactWordRegex.test(candidateLink.innerText) || 
+          candidateLink.value && exactWordRegex.test(candidateLink.value))
         followLink(candidateLink)
         return true
   false


### PR DESCRIPTION
Fixes #1935 

In order to use <input> elements as next/prev links, you need to look at the <input> value because there is no innerText. This change change `findAndFollowLink` to add <input> values to `canidateLinks` if they exist. <a> elements that match a `linkString` are still preferred if both appear on the page.

Demos:

http://codepen.io/scott0/pen/MyzexY
<input> only, doesn't work on current master, works with these changes.

http://codepen.io/scott0/pen/grQMEj
<a> only, 'standard' situation, continues to work after changes

http://codepen.io/scott0/pen/reQLRx
<input> and <a>, current master ignores <input>; after changes <a> preferred in the event that there are both on a single page.
