### PR TITLE
install the real selectionchange listener after window.find

### DIFF
--- a/content_scripts/mode_find.coffee
+++ b/content_scripts/mode_find.coffee
@@ -179,7 +179,7 @@ class FindMode extends Mode
 
     if options.colorSelection
       setTimeout(
-        -> document.addEventListener("selectionchange", @restoreDefaultSelectionHighlight, true)
+        => document.addEventListener("selectionchange", @restoreDefaultSelectionHighlight, true)
       , 0)
 
     # We are either in normal mode ("n"), or find mode ("/").  We are not in insert mode.  Nevertheless, if a


### PR DESCRIPTION
The old code would get `window` as `@`, whose `restoreDefaultSelectionHighlight` is `undefined`, so this commit fixes it.