### PR TITLE
Fix link-hints failing to launch.

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -301,10 +301,14 @@ Frames =
     (portsForTab[tabId] ?= {})[frameId] = port
 
   unregisterFrame: ({tabId, frameId}) ->
-    if tabId of frameIdsForTab
-      frameIdsForTab[tabId] = (fId for fId in frameIdsForTab[tabId] when fId != frameId)
-    if tabId of portsForTab
-      delete portsForTab[tabId][frameId]
+    # FrameId 0 is the top/main frame.  We never unregister that frame.  If the tab is closing, then we tidy
+    # up elsewhere.  If the tab is navigating to a new page, then a new top frame will be along soon.
+    # This mitigates against the unregister and register messages arriving in the "wrong" order.
+    if 0 < frameId
+      if tabId of frameIdsForTab
+        frameIdsForTab[tabId] = (fId for fId in frameIdsForTab[tabId] when fId != frameId)
+      if tabId of portsForTab
+        delete portsForTab[tabId][frameId]
     HintCoordinator.unregisterFrame tabId, frameId
 
   isEnabledForUrl: ({request, tabId, port}) ->


### PR DESCRIPTION
Sometimes, link-hints mode fails to launch.  See Issue 1 from this post: https://github.com/philc/vimium/issues/2081#issuecomment-210980903.

Here's a reproducible case:

- visit twitter
- using the vomnibar, visit any other page (in the same tab)
- hit `f` - the link hints fail to load.

What's happening is that the unregister/register frame messages for the main/top frame arrive in the wrong order (first register, then unregister).  Because these both have the same frame Id, the effect is that the main/top frame ends up not registered.  So there are no registered frames, so link hints mode doesn't launch.

Only the main/top frame has a re-usable frameId (`0`).  All other frames receive a unique frame Id (which is never re-used).

Here, we just never unregister the main/top frame.  That way, it doesn't matter which order the register/unregister messages arrive in.  If the tab is navigating to a new page, then there'll be a new main/top frame along soon.  If the tab is closing, then we tidy up in the `chrome.tabs.onRemoved` handler.