### PR TITLE
Adds single left/right angle quotation marks to next/previous patterns

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -45,5 +45,6 @@ Contributors:
   Utkarsh Upadhyay <musically.ut@gmail.com) (github: musically-ut)
   Michael Salihi <admin@prestance-informatique.fr> (github: PrestanceDesign)
   Dahan Gong <gdh1995@qq.com> (github: gdh1995)
+  Scott Pinkelman <scott@scottpinkelman.com> (github: sco-tt)
 
 Feel free to add real names in addition to GitHub usernames.

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -144,10 +144,10 @@ Settings =
     # "first/last page", so we put the single bracket first in the pattern string so that it gets searched
     # for first.
 
-    # "\bprev\b,\bprevious\b,\bback\b,<,←,«,≪,<<"
-    previousPatterns: "prev,previous,back,older,<,\u2190,\xab,\u226a,<<"
-    # "\bnext\b,\bmore\b,>,→,»,≫,>>"
-    nextPatterns: "next,more,newer,>,\u2192,\xbb,\u226b,>>"
+    # "\bprev\b,\bprevious\b,\bback\b,<,‹,←,«,≪,<<"
+    previousPatterns: "prev,previous,back,older,<,\u2039,\u2190,\xab,\u226a,<<"
+    # "\bnext\b,\bmore\b,>,›,→,»,≫,>>"
+    nextPatterns: "next,more,newer,>,\u203a,\u2192,\xbb,\u226b,>>"
     # default/fall back search engine
     searchUrl: "https://www.google.com/search?q="
     # put in an example search engine


### PR DESCRIPTION
[Original PR](https://github.com/philc/vimium/pull/2117) added <button> elements to the next/prev link shortcut, and this breaks homepage of reddit.com. It also made changes to settings.coffee to modify the next/prev string patterns.

This PR re-merges changes to lib/settings.coffee so that single angle left/right angle quotation marks are in the next/prev patterns. Example: http://codepen.io/rasx/full/xGadEB