### PR TITLE
Add chrome.commands support for simple actions

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -74,6 +74,10 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) ->
   # Ensure the sendResponse callback is freed.
   return false)
 
+# Allow simple commands to be run from restricted tabs
+chrome.commands.onCommand.addListener (command) ->
+  chrome.tabs.getSelected null, (tab) -> BackgroundCommands[command] { count: 1, tab: tab }
+
 onURLChange = (details) ->
   chrome.tabs.sendMessage details.tabId, name: "checkEnabledAfterURLChange"
 

--- a/manifest.json
+++ b/manifest.json
@@ -71,6 +71,13 @@
     "default_icon": "icons/browser_action_disabled.png",
     "default_popup": "pages/popup.html"
   },
+  "commands": {
+    "nextTab": { "description": "Go one tab right" },
+    "previousTab": { "description": "Go one tab left" },
+    "visitPreviousTab": { "description": "Go to previously-visited tab" },
+    "firstTab": { "description": "Go to the first tab" },
+    "lastTab": { "description": "Go to the last tab" }
+  },
   "web_accessible_resources": [
     "pages/vomnibar.html",
     "content_scripts/vimium.css",

--- a/tests/unit_tests/test_chrome_stubs.coffee
+++ b/tests/unit_tests/test_chrome_stubs.coffee
@@ -74,6 +74,11 @@ exports.chrome =
 
   browserAction:
     setBadgeBackgroundColor: ->
+
+  commands:
+    onCommand:
+      addListener: () ->
+
   storage:
     # chrome.storage.local
     local:


### PR DESCRIPTION
Hello,

As awesome as Vimium is, it's very annoying to get stuck in certain tabs. *The Great Suspender*, for example, produces a lot of extension tabs, constantly breaking my flow to remember to use ctrl/cmd-tab.

While this patch requires user configuration, I think it far benefits those that go to that length. The chrome.commands API lets us register a set of commands for user-configurable keyboard shortcuts. Once they choose a key combination, it works across the browser (including `chrome-extension://` and `chrome://` pages). At +11 lines, it's also a very simple modification so I don't think it'll cause too much headache.

I'm unfamiliar with Vimium's codebase, so I've only added the obvious ones: `nextTab`, `previousTab`, `visitPreviousTab`, `firstTab` and `lastTab`. I'll gladly improve this, should you have any objections or additions.