### PR TITLE
Better detection of elements that aren't visible

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -43,5 +43,6 @@ Contributors:
   Timo Sand <timo.j.sand@gmail.com> (github: deiga)
   Shiyong Chen <billbill290@gmail.com> (github: UncleBill)
   Utkarsh Upadhyay <musically.ut@gmail.com) (github: musically-ut)
+  Daniel Skogly <daniel@pnkt.no> (github: poacher2k)
 
 Feel free to add real names in addition to GitHub usernames.


### PR DESCRIPTION
Ref: [discussion in PR 1745](https://github.com/philc/vimium/pull/1745#issuecomment-150222798)

In my testing, the changes I made dramatically improves the detection of inactive/non-visible items.

In the case of partly covered elements, the next step would possibly be to place the hint labels at the visible area of the element.

Without vimium:
![no-vimium](https://cloud.githubusercontent.com/assets/2255960/16099745/425a7ec4-335a-11e6-9129-1af27ced7f2f.PNG)

Before changes:
![before](https://cloud.githubusercontent.com/assets/2255960/16099748/453bf4a6-335a-11e6-94c1-76eafd131624.PNG)

After changes:
![after](https://cloud.githubusercontent.com/assets/2255960/16099749/47d05798-335a-11e6-9530-953cadbc4ea7.PNG)

Test coverage remains the same.
