### PR TITLE
Alter search appearance

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -46,15 +46,13 @@ class Suggestion
   generateHtml: (request) ->
     return @html if @html
     relevancyHtml = if @showRelevancy then "<span class='relevancy'>#{@computeRelevancy()}</span>" else ""
-    insertTextClass = if @insertText then "vomnibarInsertText" else "vomnibarNoInsertText"
-    insertTextIndicator = "&#8618;" # A right hooked arrow.
     @title = @insertText if @insertText and request.isCustomSearch
     # NOTE(philc): We're using these vimium-specific class names so we don't collide with the page's CSS.
     @html =
       if request.isCustomSearch
         """
         <div class="vimiumReset vomnibarTopHalf">
-           <span class="vimiumReset vomnibarSource #{insertTextClass}">#{insertTextIndicator}</span><span class="vimiumReset vomnibarSource">#{@type}</span>
+           <span class="vimiumReset vomnibarSource">#{@type}</span>
            <span class="vimiumReset vomnibarTitle">#{@highlightQueryTerms Utils.escapeHtml @title}</span>
            #{relevancyHtml}
          </div>
@@ -62,11 +60,11 @@ class Suggestion
       else
         """
         <div class="vimiumReset vomnibarTopHalf">
-           <span class="vimiumReset vomnibarSource #{insertTextClass}">#{insertTextIndicator}</span><span class="vimiumReset vomnibarSource">#{@type}</span>
+           </span><span class="vimiumReset vomnibarSource">#{@type}</span>
            <span class="vimiumReset vomnibarTitle">#{@highlightQueryTerms Utils.escapeHtml @title}</span>
          </div>
          <div class="vimiumReset vomnibarBottomHalf">
-          <span class="vimiumReset vomnibarSource vomnibarNoInsertText">#{insertTextIndicator}</span><span class="vimiumReset vomnibarUrl">#{@highlightUrlTerms Utils.escapeHtml @shortenUrl()}</span>
+          <span class="vimiumReset vomnibarUrl">#{@highlightUrlTerms Utils.escapeHtml @shortenUrl()}</span>
           #{relevancyHtml}
         </div>
         """

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -370,7 +370,6 @@ iframe.vomnibarFrame {
   display: block;
   position: fixed;
   width: calc(80% + 20px); /* same adjustment as in pages/vomnibar.coffee */
-  min-width: 400px;
   height: calc(100% - 70px);
   top: 70px;
   left: 50%;

--- a/pages/vomnibar.css
+++ b/pages/vomnibar.css
@@ -48,7 +48,7 @@
   display: block;
   padding: 10px;
   background-color: #F1F1F1;
-  border-radius: 4px 4px 0 0;
+  border-radius: 3px;
   border-bottom: 1px solid #C6C9CE;
 }
 

--- a/pages/vomnibar.css
+++ b/pages/vomnibar.css
@@ -21,8 +21,8 @@
   background: #F1F1F1;
   text-align: left;
   border-radius: 4px;
-  box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.8);
-  border: 1px solid #aaa;
+  box-shadow: 0px 1px 4px 0px rgba(0,0,0,0.3);
+  border: 1px solid #888;
   /* One less than hint markers and the help dialog. */
   z-index: 2147483646;
 }

--- a/pages/vomnibar.css
+++ b/pages/vomnibar.css
@@ -33,7 +33,7 @@
   font-size: 20px;
   height: 34px;
   margin-bottom: 0;
-  padding: 4px;
+  padding: 4px 6px;
   background-color: white;
   border-radius: 3px;
   border: 1px solid #E8E8E8;

--- a/pages/vomnibar.css
+++ b/pages/vomnibar.css
@@ -36,8 +36,9 @@
   padding: 4px 6px;
   background-color: white;
   border-radius: 3px;
-  border: 1px solid #E8E8E8;
-  box-shadow: #444 0px 0px 1px;
+  border: 1px solid #b3b3b3;
+  border-top: 1px solid #777;
+  box-shadow: #fff 0px 1px 0px 0.1px;
   width: 100%;
   outline: none;
   box-sizing: border-box;


### PR DESCRIPTION
This is my first contribution to vimium. 

I wanted to open some discussion about the `vomnibar` and its appearance. I was hoping someone could clarify the usage of ↪  in the search results. From the source it looks like its suggestions that can be completed. This was unintuitive to me, and at the beginning of each suggestion it throws off the alignment with the input bar. In the demo below, I pulled out the arrow to demonstrate. I reduced the shadows and placed them more intentionally, if you zoom in on google's chrome search bar and the `after` gif, you'll see similar highlights. 
# Before:

![](http://g.recordit.co/iTdTwK7i0K.gif)
# After:

![](http://g.recordit.co/AClVMG6wYc.gif)
