### PR TITLE
Add support for opening details elements

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -326,6 +326,8 @@ class LinkHintsMode
           else if localHintDescriptor.reason == "Scroll."
             # Tell the scroller that this is the activated element.
             handlerStack.bubbleEvent "DOMActivate", target: clickEl
+          else if localHintDescriptor.reason == "Open."
+            clickEl.open = !clickEl.open
           else if DomUtils.isSelectable clickEl
             window.focus()
             DomUtils.simulateSelect clickEl
@@ -637,6 +639,9 @@ LocalHints =
         isClickable ||=
           if element.clientHeight < element.scrollHeight and Scroller.isScrollableElement element
             reason = "Scroll."
+      when "details"
+        isClickable = true
+        reason = "Open."
 
     # An element with a class name containing the text "button" might be clickable.  However, real clickables
     # are often wrapped in elements with such class names.  So, when we find clickables based only on their


### PR DESCRIPTION
Hey @philc, thanks for Vimium! Super helpful in combating RSI

There's a fancy HTML elements called `details`, which allows you to hide details under a clickable thingie. It's even supported on Github:

<details>
<summary>Click me!</summary>
NEAT!
</details>

This PR adds support for opening those through the link hints. I couldn't figure out how to get the tests to work (just had random failures locally) so I'll need some direction for those