### PR TITLE
hint a label only if its control is not disabled

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -621,7 +621,8 @@ LocalHints =
       when "button", "select"
         isClickable ||= not element.disabled
       when "label"
-        isClickable ||= element.control? and (@getVisibleClickable element.control).length == 0
+        isClickable ||= element.control? and not element.control.disabled and
+                        (@getVisibleClickable element.control).length == 0
       when "body"
         isClickable ||=
           if element == document.body and not windowIsFocused() and


### PR DESCRIPTION
example:
``` html
<label><input type=checkbox disabled />exlpanation</label>
```

This may occurs for some settings page which includes some settings not allowed to change:
* e.g. Fuel (OpenStack deploy tools) settings page