### PR TITLE
Use prefix matching for global marks.

### DIFF
--- a/background_scripts/marks.coffee
+++ b/background_scripts/marks.coffee
@@ -66,7 +66,7 @@ Marks =
     # If we're not going to be scrolling to a particular position in the tab, then we choose all tabs with a
     # matching URL prefix.  Otherwise, we require an exact match.
     query = if markInfo.scrollX == markInfo.scrollY == 0 then "#{markInfo.url}*" else markInfo.url
-    chrome.tabs.query { url: "#{markInfo.url}*" }, (tabs) =>
+    chrome.tabs.query { url: query }, (tabs) =>
       if 0 < tabs.length
         # We have at least one matching tab.  Pick one and go to it.
         @pickTab tabs, (tab) =>

--- a/background_scripts/marks.coffee
+++ b/background_scripts/marks.coffee
@@ -64,7 +64,8 @@ Marks =
   # or we create a new tab.
   focusOrLaunch: (markInfo, req) ->
     # If we're not going to be scrolling to a particular position in the tab, then we choose all tabs with a
-    # matching URL prefix.  Otherwise, we require an exact match.
+    # matching URL prefix.  Otherwise, we require an exact match (because it doesn't make sense to scroll
+    # unless there's an exact URL match).
     query = if markInfo.scrollX == markInfo.scrollY == 0 then "#{markInfo.url}*" else markInfo.url
     chrome.tabs.query { url: query }, (tabs) =>
       if 0 < tabs.length
@@ -85,7 +86,8 @@ Marks =
       # Prefer tabs in the current window, if there are any.
       tabsInWindow = tabs.filter (tab) -> tab.windowId == id
       tabs = tabsInWindow if 0 < tabsInWindow.length
-      # If more than one tab remains and the current tab remains a conadidate, then pick another one.
+      # If more than one tab remains and the current tab is still a candidate, then don't pick the current
+      # tab (because jumping to it does nothing).
       tabs = (tab for tab in tabs when not tab.active) if 1 < tabs.length
       # Prefer shorter URLs.
       tabs.sort (a,b) -> a.url.length - b.url.length

--- a/background_scripts/marks.coffee
+++ b/background_scripts/marks.coffee
@@ -63,10 +63,10 @@ Marks =
   # The tab we're trying to find no longer exists.  We either find another tab with a matching URL and use it,
   # or we create a new tab.
   focusOrLaunch: (markInfo, req) ->
-    chrome.tabs.query { url: markInfo.url }, (tabs) =>
+    chrome.tabs.query { url: "#{markInfo.url}*" }, (tabs) =>
       if 0 < tabs.length
-        # We have a matching tab: use it (prefering, if there are more than one, one in the current window).
-        @pickTabInWindow tabs, (tab) =>
+        # We have at least one matching tab.  Pick one and go to it.
+        @pickTab tabs, (tab) =>
           @gotoPositionInTab extend markInfo, tabId: tab.id
       else
         # There is no existing matching tab, we'll have to create one.
@@ -75,11 +75,18 @@ Marks =
           # is loaded, its DOM is ready and it registers with the background page.
           tabLoadedHandlers[tab.id] = => @gotoPositionInTab extend markInfo, tabId: tab.id
 
-  # Given a list of tabs, pick one in the current window, if possible, otherwise just pick any.
-  pickTabInWindow: (tabs, continuation) ->
+  # Given a list of tabs candidate tabs, pick one.  Prefer tabs in the current window and tabs with shorter
+  # (matching) URLs.
+  pickTab: (tabs, callback) ->
     chrome.windows.getCurrent ({ id }) ->
+      # Prefer tabs in the current window, if there are any.
       tabsInWindow = tabs.filter (tab) -> tab.windowId == id
-      continuation tabsInWindow[0] ? tabs[0]
+      tabs = tabsInWindow if 0 < tabsInWindow.length
+      # If more than one tab remains and the current tab remains a conadidate, then pick another one.
+      tabs = (tab for tab in tabs when not tab.active) if 1 < tabs.length
+      # Prefer shorter URLs.
+      tabs.sort (a,b) -> a.url.length - b.url.length
+      callback tabs[0]
 
 root = exports ? window
 root.Marks = Marks

--- a/background_scripts/marks.coffee
+++ b/background_scripts/marks.coffee
@@ -63,6 +63,9 @@ Marks =
   # The tab we're trying to find no longer exists.  We either find another tab with a matching URL and use it,
   # or we create a new tab.
   focusOrLaunch: (markInfo, req) ->
+    # If we're not going to be scrolling to a particular position in the tab, then we choose all tabs with a
+    # matching URL prefix.  Otherwise, we require an exact match.
+    query = if markInfo.scrollX == markInfo.scrollY == 0 then "#{markInfo.url}*" else markInfo.url
     chrome.tabs.query { url: "#{markInfo.url}*" }, (tabs) =>
       if 0 < tabs.length
         # We have at least one matching tab.  Pick one and go to it.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -257,8 +257,8 @@ Frame =
     window.removeEventListener "hashchange", onFocus
 
 setScrollPosition = ({ scrollX, scrollY }) ->
-  if DomUtils.isTopFrame()
-    DomUtils.documentReady ->
+  DomUtils.documentReady ->
+    if DomUtils.isTopFrame()
       window.focus()
       document.body.focus()
       if 0 < scrollX or 0 < scrollY


### PR DESCRIPTION
This changes the logic for selecting an existing tab when using global marks.

Previously, an exact URL match was required.  Here, we only require a prefix match.

For example, if the global-mark URL is:

    https://inbox.google.com/u/0/

Then a tab with the URL

    https://inbox.google.com/u/0/sent

will be selected.

This is a more usable approach when the user uses global marks to visit important sites like gmail, Facebook or Twitter.  On these sites, the URL changes, but the user still thinks of the tab as their "gmail tab", for example.

Also, when choosing between multiple candidate tabs:

- If there is at least one candidate in the current window, then only consider candidates in the current window.
- If there are more than one candidates, then don't select the current tab.
- Finally, select the remaining candidate with the shortest URL.

Closes #2248.