### PR TITLE
Add escape command: 'map <c-c> exitMode' [WIP]

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -63,7 +63,9 @@ Commands =
               delete @keyToCommandRegistry[key]
 
           when "unmapAll"
-            @keyToCommandRegistry = {}
+            # We do not unmap "<c-[>" because it was previously hardwired into KeyboardUtils.isEscape(), and
+            # therefore unaffected by "unmapAll".
+            @keyToCommandRegistry = "<c-[>": {command: "exitMode"}
 
     # Push the key mapping for passNextKey into Settings so that it's available in the front end for insert
     # mode.  We exclude single-key mappings (that is, printable keys) because when users press printable keys
@@ -303,6 +305,9 @@ defaultKeyMappings =
 
   "m": "Marks.activateCreateMode"
   "`": "Marks.activateGotoMode"
+
+  # <c-[> is mapped to <Escape> in Vim by default.
+  "<c-[>": "exitMode"
 
 
 # This is a mapping of: commandIdentifier => [description, options].

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -73,13 +73,15 @@ Commands =
       (key for own key of @keyToCommandRegistry when @keyToCommandRegistry[key].command == "passNextKey" and 1 < key.length)
 
     # Push any key mappings for escape into Settings so that they are available in KeyboardUtils.isEscape(),
-    # and remove those bindings from the key-to-command registry (they're not needed).
+    # and remove those bindings from @keyToCommandRegistry (they're not needed).
     escapeKeyBindings =
       (key for own key of @keyToCommandRegistry when @keyToCommandRegistry[key].command == "escape")
-    for own key of escapeKeyBindings
-      delete @keyToCommandRegistry[key]
 
-    Settings.set "escapeKeyBindings", escapeKeyBindings
+    if 0 < escapeKeyBindings.length
+      delete @keyToCommandRegistry[key] for own key of escapeKeyBindings
+      Settings.set "escapeKeyBindings", escapeKeyBindings
+    else
+      Settings.clear "escapeKeyBindings"
 
   # Command options follow command mappings, and are of one of two forms:
   #   key=value     - a value
@@ -219,8 +221,7 @@ Commands =
     "enterVisualLineMode",
     "toggleViewSource",
     "passNextKey",
-    "escape"
-  ]
+    "escape"]
 
 defaultKeyMappings =
   "?": "showHelp"
@@ -337,7 +338,7 @@ commandDescriptions =
   enterVisualLineMode: ["Enter visual line mode", { noRepeat: true }]
 
   focusInput: ["Focus the first text input on the page"]
-  escape: ["Escape"]
+  escape: ["Escape (exit the current Vimium mode)"]
 
   "LinkHints.activateMode": ["Open a link in the current tab"]
   "LinkHints.activateModeToOpenInNewTab": ["Open a link in a new tab"]

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -343,7 +343,7 @@ commandDescriptions =
   enterVisualLineMode: ["Enter visual line mode", { noRepeat: true }]
 
   focusInput: ["Focus the first text input on the page"]
-  exitMode: ["exit the current Vimium mode (like Escape)"]
+  exitMode: ["Exit the current Vimium mode (like Escape)"]
 
   "LinkHints.activateMode": ["Open a link in the current tab"]
   "LinkHints.activateModeToOpenInNewTab": ["Open a link in a new tab"]

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -72,6 +72,15 @@ Commands =
     Settings.set "passNextKeyKeys",
       (key for own key of @keyToCommandRegistry when @keyToCommandRegistry[key].command == "passNextKey" and 1 < key.length)
 
+    # Push any key mappings for escape into Settings so that they are available in KeyboardUtils.isEscape(),
+    # and remove those bindings from the key-to-command registry (they're not needed).
+    escapeKeyBindings =
+      (key for own key of @keyToCommandRegistry when @keyToCommandRegistry[key].command == "escape")
+    for own key of escapeKeyBindings
+      delete @keyToCommandRegistry[key]
+
+    Settings.set "escapeKeyBindings", escapeKeyBindings
+
   # Command options follow command mappings, and are of one of two forms:
   #   key=value     - a value
   #   key           - a flag
@@ -180,6 +189,7 @@ Commands =
       "moveTabRight"]
     misc:
       ["showHelp",
+      "escape",
       "toggleViewSource"]
 
   # Rarely used commands are not shown by default in the help dialog or in the README. The goal is to present
@@ -208,7 +218,9 @@ Commands =
     "closeOtherTabs",
     "enterVisualLineMode",
     "toggleViewSource",
-    "passNextKey"]
+    "passNextKey",
+    "escape"
+  ]
 
 defaultKeyMappings =
   "?": "showHelp"
@@ -325,6 +337,7 @@ commandDescriptions =
   enterVisualLineMode: ["Enter visual line mode", { noRepeat: true }]
 
   focusInput: ["Focus the first text input on the page"]
+  escape: ["Escape"]
 
   "LinkHints.activateMode": ["Open a link in the current tab"]
   "LinkHints.activateModeToOpenInNewTab": ["Open a link in a new tab"]

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -72,10 +72,10 @@ Commands =
     Settings.set "passNextKeyKeys",
       (key for own key of @keyToCommandRegistry when @keyToCommandRegistry[key].command == "passNextKey" and 1 < key.length)
 
-    # Push any key mappings for escape into Settings so that they are available in KeyboardUtils.isEscape(),
+    # Push any key mappings for exitMode into Settings so that they are available in KeyboardUtils.isEscape(),
     # and remove those bindings from @keyToCommandRegistry (they're not needed).
     escapeKeyBindings =
-      (key for own key of @keyToCommandRegistry when @keyToCommandRegistry[key].command == "escape")
+      (key for own key of @keyToCommandRegistry when @keyToCommandRegistry[key].command == "exitMode")
 
     if 0 < escapeKeyBindings.length
       delete @keyToCommandRegistry[key] for own key of escapeKeyBindings
@@ -191,7 +191,7 @@ Commands =
       "moveTabRight"]
     misc:
       ["showHelp",
-      "escape",
+      "exitMode",
       "toggleViewSource"]
 
   # Rarely used commands are not shown by default in the help dialog or in the README. The goal is to present
@@ -221,7 +221,7 @@ Commands =
     "enterVisualLineMode",
     "toggleViewSource",
     "passNextKey",
-    "escape"]
+    "exitMode"]
 
 defaultKeyMappings =
   "?": "showHelp"
@@ -338,7 +338,7 @@ commandDescriptions =
   enterVisualLineMode: ["Enter visual line mode", { noRepeat: true }]
 
   focusInput: ["Focus the first text input on the page"]
-  escape: ["Escape (exit the current Vimium mode)"]
+  exitMode: ["exit the current Vimium mode (like Escape)"]
 
   "LinkHints.activateMode": ["Open a link in the current tab"]
   "LinkHints.activateModeToOpenInNewTab": ["Open a link in a new tab"]

--- a/lib/chrome_stubs.coffee
+++ b/lib/chrome_stubs.coffee
@@ -1,16 +1,10 @@
 #
-# Mock the Chrome extension API.
+# Stub the Chrome extension API, if necessary.
 #
+# NOTE(smblott): This is loaded within the live HUD and Vomnibar windows; however, it has no effect there.
+# Within the tests, it provides stubs of various missing Chrome API functions.
 
-root = exports ? window
-root.chromeMessages = []
-
-document.hasFocus = -> true
-
-fakeManifest =
-  version: "1.51"
-
-root.chrome =
+window.chrome ?=
   runtime:
     connect: ->
       onMessage:
@@ -20,8 +14,8 @@ root.chrome =
       postMessage: ->
     onMessage:
       addListener: ->
-    sendMessage: (message) -> chromeMessages.unshift message
-    getManifest: -> fakeManifest
+    sendMessage: ->
+    getManifest: -> version: "1.51"
     getURL: (url) -> "../../#{url}"
   storage:
     local:

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -80,9 +80,14 @@ KeyboardUtils =
   isPrimaryModifierKey: (event) -> if (@platform == "Mac") then event.metaKey else event.ctrlKey
 
   isEscape: (event) ->
-    # c-[ is mapped to ESC in Vim by default.
-    (event.keyCode == @keyCodes.ESC) ||
-    (event.ctrlKey && @getKeyChar(event) == '[' and not event.metaKey and not event.altKey)
+    event.keyCode == @keyCodes.ESC or
+      # c-[ is mapped to ESC in Vim by default.
+      (@getKeyChar(event) == "[" and event.ctrlKey and not event.metaKey and not event.altKey) or
+      # Handle custom mappings (the "escape" command).
+      do =>
+        keyChar = null
+        matchingEscapeKeyBindings = Settings.get("escapeKeyBindings").filter (k) => k == (keyChar ?= @getKeyCharString event)
+        0 < matchingEscapeKeyBindings.length
 
   # TODO. This is probably a poor way of detecting printable characters.  However, it shouldn't incorrectly
   # identify any of chrome's own keyboard shortcuts as printable.

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -81,13 +81,12 @@ KeyboardUtils =
 
   isEscape: (event) ->
     event.keyCode == @keyCodes.ESC or
-      # c-[ is mapped to ESC in Vim by default.
-      (@getKeyChar(event) == "[" and event.ctrlKey and not event.metaKey and not event.altKey) or
-      # Handle custom mappings (the "escape" command).
       do =>
-        keyChar = null
-        matchingEscapeKeyBindings = Settings.get("escapeKeyBindings").filter (k) => k == (keyChar ?= @getKeyCharString event)
-        0 < matchingEscapeKeyBindings.length
+        # Handle custom mappings (the "exitMode" command).
+        keyChar = @getKeyCharString event
+        for key in Settings.get "escapeKeyBindings"
+          return true if key == keyChar
+        false
 
   # TODO. This is probably a poor way of detecting printable characters.  However, it shouldn't incorrectly
   # identify any of chrome's own keyboard shortcuts as printable.

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -178,6 +178,7 @@ Settings =
     helpDialog_showAdvancedCommands: false
     optionsPage_showAdvancedOptions: false
     passNextKeyKeys: []
+    escapeKeyBindings: []
 
 Settings.init()
 

--- a/pages/hud.html
+++ b/pages/hud.html
@@ -2,7 +2,7 @@
   <head>
     <title>HUD</title>
     <link rel="stylesheet" type="text/css" href="../content_scripts/vimium.css" />
-    <!-- "../lib/dom_tests/chrome_stubs.js" is loaded here.  In a live Vimium instance, this has no effect.
+    <!-- "../lib/chrome_stubs.js" is loaded here.  In a live Vimium instance, this has no effect.
       However, it provides the necessary Chrome stubs for the tests. -->
     <script type="text/javascript" src="../lib/chrome_stubs.js"></script>
     <script type="text/javascript" src="../lib/utils.js"></script>

--- a/pages/hud.html
+++ b/pages/hud.html
@@ -2,6 +2,8 @@
   <head>
     <title>HUD</title>
     <link rel="stylesheet" type="text/css" href="../content_scripts/vimium.css" />
+    <script type="text/javascript" src="../lib/utils.js"></script>
+    <script type="text/javascript" src="../lib/settings.js"></script>
     <script type="text/javascript" src="../lib/dom_utils.js"></script>
     <script type="text/javascript" src="../lib/keyboard_utils.js"></script>
     <script type="text/javascript" src="../lib/find_mode_history.js"></script>

--- a/pages/hud.html
+++ b/pages/hud.html
@@ -2,6 +2,9 @@
   <head>
     <title>HUD</title>
     <link rel="stylesheet" type="text/css" href="../content_scripts/vimium.css" />
+    <!-- "../lib/dom_tests/chrome_stubs.js" is loaded here.  In a live Vimium instance, this has no effect.
+      However, it provides the necessary Chrome stubs for the tests. -->
+    <script type="text/javascript" src="../lib/chrome_stubs.js"></script>
     <script type="text/javascript" src="../lib/utils.js"></script>
     <script type="text/javascript" src="../lib/settings.js"></script>
     <script type="text/javascript" src="../lib/dom_utils.js"></script>

--- a/pages/vomnibar.html
+++ b/pages/vomnibar.html
@@ -2,6 +2,7 @@
   <head>
     <title>Vomnibar</title>
     <script type="text/javascript" src="../lib/utils.js"></script>
+    <script type="text/javascript" src="../lib/settings.js"></script>
     <script type="text/javascript" src="../lib/keyboard_utils.js"></script>
     <script type="text/javascript" src="../lib/dom_utils.js"></script>
     <script type="text/javascript" src="../lib/handler_stack.js"></script>

--- a/pages/vomnibar.html
+++ b/pages/vomnibar.html
@@ -1,6 +1,9 @@
 <html>
   <head>
     <title>Vomnibar</title>
+    <!-- "../lib/dom_tests/chrome_stubs.js" is loaded here.  In a live Vimium instance, this has no effect.
+      However, it provides the necessary Chrome stubs for the tests. -->
+    <script type="text/javascript" src="../lib/chrome_stubs.js"></script>
     <script type="text/javascript" src="../lib/utils.js"></script>
     <script type="text/javascript" src="../lib/settings.js"></script>
     <script type="text/javascript" src="../lib/keyboard_utils.js"></script>

--- a/pages/vomnibar.html
+++ b/pages/vomnibar.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>Vomnibar</title>
-    <!-- "../lib/dom_tests/chrome_stubs.js" is loaded here.  In a live Vimium instance, this has no effect.
+    <!-- "../lib/chrome_stubs.js" is loaded here.  In a live Vimium instance, this has no effect.
       However, it provides the necessary Chrome stubs for the tests. -->
     <script type="text/javascript" src="../lib/chrome_stubs.js"></script>
     <script type="text/javascript" src="../lib/utils.js"></script>

--- a/tests/dom_tests/dom_tests.html
+++ b/tests/dom_tests/dom_tests.html
@@ -28,7 +28,7 @@
     </style>
     <link rel="stylesheet" type="text/css" href="../../content_scripts/vimium.css" />
     <script type="text/javascript" src="bind.js"></script>
-    <script type="text/javascript" src="chrome.js"></script>
+    <script type="text/javascript" src="../../lib/chrome_stubs.js"></script>
     <script type="text/javascript" src="../../lib/utils.js"></script>
     <script type="text/javascript" src="../../lib/keyboard_utils.js"></script>
     <script type="text/javascript" src="../../lib/dom_utils.js"></script>


### PR DESCRIPTION
This adds:

    map <c-c> exitMode

Any such mappings are used to exit Vimium's various modes (insert mode, visual mode, find mode, etc.)

Limitations:

- Only non-printable, **single-key** mappings are supported.

So, for example, the following **does not** work:

    map jk exitMode

Fixes #301.

**Edit**...

This doesn't allow mappings like `jk` for a number of reasons:

- With the current Vimium code base, we need to know that the key is to be treated as `Escape` on `keydown`, and we don't know the printable character at that point.

- Consider insert mode.  For multi-key mappings, what do we do with the first key (`j`, in the example) event?  We can't hold it back, because the underlying page might do something with it.  However, when we later see the second key (`k`, in the example), we cannot undo the effect of the first key.  (We've no idea what the page itself did with the `j`).  Similarly for other Vimium modes.  E.g., what if `jk` appears as the hint for a link hint?  Does `jk` mean activate the hint?  Or does it mean `Escape`?  Regardless, the logic becomes complex, and it's not obvious to users what is happening.

So, I don't think we should allow mappings like `jk`.  What we could do, however, is log a warning on the console if a user attempts to establish such a mapping.

**Edit**...

Changed new command name from `escape` to `exitMode`.