### PR TITLE
Make vomnibar suggestions clickable

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -53,21 +53,29 @@ class Suggestion
     @html =
       if request.isCustomSearch
         """
-        <div class="vimiumReset vomnibarTopHalf">
-           <span class="vimiumReset vomnibarSource #{insertTextClass}">#{insertTextIndicator}</span><span class="vimiumReset vomnibarSource">#{@type}</span>
-           <span class="vimiumReset vomnibarTitle">#{@highlightQueryTerms Utils.escapeHtml @title}</span>
-           #{relevancyHtml}
-         </div>
+        <div class="vimiumReset">
+          <div class="vomnibarSuggestion">
+            <div class="vomnibarTopHalf">
+              <span class="vomnibarSource #{insertTextClass}">#{insertTextIndicator}</span><span class="vomnibarSource">#{@type}</span>
+              <span class="vomnibarTitle">#{@highlightQueryTerms Utils.escapeHtml @title}</span>
+              #{relevancyHtml}
+            </div>
+          </div>
+        </div>
         """
       else
         """
-        <div class="vimiumReset vomnibarTopHalf">
-           <span class="vimiumReset vomnibarSource #{insertTextClass}">#{insertTextIndicator}</span><span class="vimiumReset vomnibarSource">#{@type}</span>
-           <span class="vimiumReset vomnibarTitle">#{@highlightQueryTerms Utils.escapeHtml @title}</span>
-         </div>
-         <div class="vimiumReset vomnibarBottomHalf">
-          <span class="vimiumReset vomnibarSource vomnibarNoInsertText">#{insertTextIndicator}</span><span class="vimiumReset vomnibarUrl">#{@highlightUrlTerms Utils.escapeHtml @shortenUrl()}</span>
-          #{relevancyHtml}
+        <div class="vimiumReset">
+          <div class="vomnibarSuggestion">
+            <div class="vomnibarTopHalf">
+              <span class="vomnibarSource #{insertTextClass}">#{insertTextIndicator}</span><span class="vomnibarSource">#{@type}</span>
+              <span class="vomnibarTitle">#{@highlightQueryTerms Utils.escapeHtml @title}</span>
+             </div>
+             <div class="vomnibarBottomHalf">
+              <span class="vomnibarSource vomnibarNoInsertText">#{insertTextIndicator}</span><span class="vomnibarUrl">#{@highlightUrlTerms Utils.escapeHtml @shortenUrl()}</span>
+              #{relevancyHtml}
+            </div>
+          </div>
         </div>
         """
 

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -202,7 +202,16 @@ class VomnibarUI
         @completions = results
         @selection = if @completions[0]?.autoSelect then 0 else @initialSelectionValue
         # Update completion list with the new suggestions.
-        @completionList.innerHTML = @completions.map((completion) -> "<li>#{completion.html}</li>").join("")
+        @completionList.innerHTML = @completions.map(
+          (completion, index) -> "<li data-index=\"#{index}\">#{completion.html}</li>"
+        ).join("")
+        # Add click listeners for each completion.
+        for element in @completionList.childNodes
+          do (element) =>
+            element.addEventListener "click", (event) =>
+              openInNewTab = event.shiftKey or event.ctrlKey or event.altKey or KeyboardUtils.isPrimaryModifierKey event
+              completion = @completions[parseInt element.dataset.index]
+              @hide -> completion.performAction openInNewTab
         @completionList.style.display = if @completions.length > 0 then "block" else ""
         @selection = Math.min @completions.length - 1, Math.max @initialSelectionValue, @selection
         @updateSelection()

--- a/pages/vomnibar.css
+++ b/pages/vomnibar.css
@@ -85,6 +85,10 @@
   padding: 2px 0;
 }
 
+.vomnibarSuggestion {
+  cursor: pointer;
+}
+
 #vomnibar li .vomnibarIcon {
   background-position-y: center;
   background-size: 16px;


### PR DESCRIPTION
This makes Vomnibar suggestions clickable with the mouse.

It would be nice to also make them selectable with the keyboard (without having to `Tab` all the way down.  The most obvious bind for that would be `<c-N>` (e.g. `<c-7>`).  However, unfortunately Chrome already uses those bindings.

Fixes #615.