### PR TITLE
Fix Travis builds (lock down Coffeescript version)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js: 0.12
 before_install:
-  - "npm install -g coffee-script"
+  - "npm install -g coffee-script@1.10.0"
   - "npm install path@0.11"
   - "npm install util"
   - "cake build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js: 0.12
 before_install:
+  # We need to use coffee-script@1.10.0.  See #2273.
   - "npm install -g coffee-script@1.10.0"
   - "npm install path@0.11"
   - "npm install util"


### PR DESCRIPTION
We need to lock down the Coffeescript version.  See [this comment](https://github.com/philc/vimium/issues/2273#issuecomment-249778448).

Courtesy of @yandavid.

Fixes #2273.

(Once I see this works, I'll add a comment to the YAML explaining why it's needed.)