### PR TITLE
Find mode can hang Vimium (fixed).

### DIFF
--- a/content_scripts/mode_find.coffee
+++ b/content_scripts/mode_find.coffee
@@ -71,6 +71,10 @@ class FindMode extends Mode
       name: "find"
       indicator: false
       exitOnClick: true
+      exitOnEscape: true
+      # This prevents further Vimium commands launching before the find-mode HUD receives the focus.
+      # E.g. "/" followed quickly by "i" should not leave us in insert mode.
+      suppressAllKeyboardEvents: true
 
     HUD.showFindMode this
 


### PR DESCRIPTION
`/` followed immediately by `i` can hang Vimium.

The problem is that launching find mode is asynchronous (we wait until the HUD is available). Because normal mode is still active, we can enter insert mode *before* the find-mode HUD receives the focus.

The result is that we end up in both find mode and insert mode, the HUD has the focus, but the HUD is in insert mode, so it ignores keyboard events (including `Escape`).

The only way out is to click the page's body and then type `Escape`.

This commit demonstrates the problem: 7d2b00411eae3293fa4c7b1f61b384c0c495b5a2.

Hanging does happen in practice, for example while a busy page is loading.

This commit fixes this by ensuring that find-mode blocks keyboard events immediately (and synchronously) on launch.

I'll merge this almost immediately.  It's here as a PR for visibility.