### PR TITLE
Enable silent/patch releases.

### DIFF
--- a/tests/unit_tests/utils_test.coffee
+++ b/tests/unit_tests/utils_test.coffee
@@ -99,9 +99,14 @@ context "Function currying",
 context "compare versions",
   should "compare correctly", ->
     assert.equal 0, Utils.compareVersions("1.40.1", "1.40.1")
+    assert.equal 0, Utils.compareVersions("1.40", "1.40.0")
+    assert.equal 0, Utils.compareVersions("1.40.0", "1.40")
     assert.equal -1, Utils.compareVersions("1.40.1", "1.40.2")
     assert.equal -1, Utils.compareVersions("1.40.1", "1.41")
+    assert.equal -1, Utils.compareVersions("1.40", "1.40.1")
     assert.equal 1, Utils.compareVersions("1.41", "1.40")
+    assert.equal 1, Utils.compareVersions("1.41.0", "1.40")
+    assert.equal 1, Utils.compareVersions("1.41.1", "1.41")
 
 context "makeIdempotent",
   setup ->


### PR DESCRIPTION
Currently, all new releases trigger a notification.

This changes that behaviour such that if the previous and current releases have the same major and minor release numbers, then no notification is shown.

We could then push bug-fix and minor releases without bugging the user.

Such releases would have a number like `1.56.1`.

Edit.  Most of the diff is just an indentation change; the real change is just the logic starting [here](https://github.com/philc/vimium/pull/2284/files#diff-eb68fda05b0a59fbd1482418fd0223e8R481).