### PR TITLE
handle documentElement's top/left margin correctly

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -811,9 +811,16 @@ LocalHints =
         nonOverlappingElements.push visibleElement unless visibleElement.secondClassCitizen
 
     # Position the rects within the window.
+    if getComputedStyle(document.documentElement).position == "static"
+      top = window.scrollY
+      left = window.scrollX
+    else
+      rect = document.documentElement.getBoundingClientRect()
+      top = -rect.top
+      left = -rect.left
     for hint in nonOverlappingElements
-      hint.rect.top += window.scrollY
-      hint.rect.left += window.scrollX
+      hint.rect.top += top
+      hint.rect.left += left
 
     if Settings.get "filterLinkHints"
       @withLabelMap (labelMap) =>


### PR DESCRIPTION
This PR fixes #2291 .

`document.documentElement` will be the offset parent of Vimium's divs if its `.style.position` is not `"static"`, but others (like `"absolute", "relative"`).