### PR TITLE
With grab-back-focus, main frame keeps focus.

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -65,6 +65,11 @@ class GrabBackFocus extends Mode
   grabBackFocus: (element) ->
     return @continueBubbling unless DomUtils.isFocusable element
     element.blur()
+    # Do not let non-top frames acquire the focus (see #2303).
+    unless DomUtils.isTopFrame()
+      registryEntry = command: "mainFrame"
+      chrome.runtime.sendMessage
+        handler: "sendMessageToFrames", message: {name: "runInTopFrame", sourceFrameId: frameId, registryEntry}
     @suppressEvent
 
 # Pages can load new content dynamically and change the displayed URL using history.pushState. Since this can


### PR DESCRIPTION
If *grab-back-focus* is enabled, then also ensure that the focus stays in the main frame.  That is, if a non-top frame gets the focus, then ask the main frame to (re-)focus itself.

Fixes #2303.