### PR TITLE
Add "mapkey" command for key mappings.

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -9,7 +9,7 @@ Commands =
     @clearKeyMappingsAndSetDefaults()
     @parseCustomKeyMappings customKeyMappings
     @generateKeyStateMapping()
-    chrome.storage.local.set keyTranslationRegistry: @keyTranslationRegistry
+    chrome.storage.local.set mapKeyRegistry: @mapKeyRegistry
 
   availableCommands: {}
   keyToCommandRegistry: {}
@@ -85,11 +85,11 @@ Commands =
           when "unmapAll"
             @keyToCommandRegistry = {}
 
-          when "translate"
+          when "mapkey"
             if tokens.length == 3
               fromChar = @parseKeySequence tokens[1]
               toChar = @parseKeySequence tokens[2]
-              @keyTranslationRegistry[fromChar[0]] = toChar[0] if fromChar.length == toChar.length == 1
+              @mapKeyRegistry[fromChar[0]] = toChar[0] if fromChar.length == toChar.length == 1
 
     # Push the key mapping for passNextKey into Settings so that it's available in the front end for insert
     # mode.  We exclude single-key mappings (that is, printable keys) because when users press printable keys
@@ -116,7 +116,7 @@ Commands =
 
   clearKeyMappingsAndSetDefaults: ->
     @keyToCommandRegistry = {}
-    @keyTranslationRegistry = {}
+    @mapKeyRegistry = {}
     for own key, command of defaultKeyMappings
       keySequence = @parseKeySequence key
       key = keySequence.join ""

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -9,6 +9,7 @@ Commands =
     @clearKeyMappingsAndSetDefaults()
     @parseCustomKeyMappings customKeyMappings
     @generateKeyStateMapping()
+    chrome.storage.local.set keyTranslationRegistry: @keyTranslationRegistry
 
   availableCommands: {}
   keyToCommandRegistry: {}
@@ -84,6 +85,12 @@ Commands =
           when "unmapAll"
             @keyToCommandRegistry = {}
 
+          when "translate"
+            if tokens.length == 3
+              fromChar = @parseKeySequence tokens[1]
+              toChar = @parseKeySequence tokens[2]
+              @keyTranslationRegistry[fromChar[0]] = toChar[0] if fromChar.length == toChar.length == 1
+
     # Push the key mapping for passNextKey into Settings so that it's available in the front end for insert
     # mode.  We exclude single-key mappings (that is, printable keys) because when users press printable keys
     # in insert mode they expect the character to be input, not to be droppped into some special Vimium
@@ -109,6 +116,7 @@ Commands =
 
   clearKeyMappingsAndSetDefaults: ->
     @keyToCommandRegistry = {}
+    @keyTranslationRegistry = {}
     for own key, command of defaultKeyMappings
       keySequence = @parseKeySequence key
       key = keySequence.join ""

--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -34,11 +34,7 @@ class KeyHandlerMode extends Mode
       blur: (event) => @alwaysContinueBubbling => @keydownEvents = {} if event.target == window
 
     @keyTranslationRegistry = {}
-    chrome.storage.local.get "keyTranslationRegistry", (obj) =>
-      @keyTranslationRegistry = obj.keyTranslationRegistry
-      chrome.storage.onChanged.addListener (changes, area) =>
-        if area == "local" and changes.keyTranslationRegistry?.newValue?
-          @keyTranslationRegistry = changes.keyTranslationRegistry.newValue
+    Utils.monitorChromeStorage "keyTranslationRegistry", (value) => @keyTranslationRegistry = value
 
   onKeydown: (event) ->
     keyChar = KeyboardUtils.getKeyCharString event

--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -33,12 +33,12 @@ class KeyHandlerMode extends Mode
       # We cannot track keyup events if we lose the focus.
       blur: (event) => @alwaysContinueBubbling => @keydownEvents = {} if event.target == window
 
-    @keyTranslationRegistry = {}
-    Utils.monitorChromeStorage "keyTranslationRegistry", (value) => @keyTranslationRegistry = value
+    @mapKeyRegistry = {}
+    Utils.monitorChromeStorage "mapKeyRegistry", (value) => @mapKeyRegistry = value
 
   onKeydown: (event) ->
     keyChar = KeyboardUtils.getKeyCharString event
-    keyChar = @keyTranslationRegistry[keyChar] ? keyChar
+    keyChar = @mapKeyRegistry[keyChar] ? keyChar
     isEscape = KeyboardUtils.isEscape event
     if isEscape and (@countPrefix != 0 or @keyState.length != 1)
       @keydownEvents[event.keyCode] = true
@@ -65,7 +65,7 @@ class KeyHandlerMode extends Mode
 
   onKeypress: (event) ->
     keyChar = KeyboardUtils.getKeyCharString event
-    keyChar = @keyTranslationRegistry[keyChar] ? keyChar
+    keyChar = @mapKeyRegistry[keyChar] ? keyChar
     if @isMappedKey keyChar
       @handleKeyChar keyChar
     else if @isCountKey keyChar

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -80,14 +80,14 @@ KeyboardUtils =
   isPrimaryModifierKey: (event) -> if (@platform == "Mac") then event.metaKey else event.ctrlKey
 
   isEscape: do ->
-    keyTranslationRegistry = {}
+    mapKeyRegistry = {}
     # NOTE: "?" here for the tests.
-    Utils?.monitorChromeStorage "keyTranslationRegistry", (value) => keyTranslationRegistry = value
+    Utils?.monitorChromeStorage "mapKeyRegistry", (value) => mapKeyRegistry = value
 
     (event) ->
       event.keyCode == @keyCodes.ESC || do =>
         keyChar = @getKeyCharString event, true
-        keyChar = keyTranslationRegistry[keyChar] ? keyChar
+        keyChar = mapKeyRegistry[keyChar] ? keyChar
         # <c-[> is mapped to Escape in Vim by default.
         keyChar == "<c-[>"
 

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -84,6 +84,7 @@ KeyboardUtils =
     # NOTE: "?" here for the tests.
     Utils?.monitorChromeStorage "mapKeyRegistry", (value) => mapKeyRegistry = value
 
+    # TODO(smblott) Change this to use event.key.
     (event) ->
       event.keyCode == @keyCodes.ESC || do =>
         keyChar = @getKeyCharString event, true

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -79,10 +79,18 @@ KeyboardUtils =
 
   isPrimaryModifierKey: (event) -> if (@platform == "Mac") then event.metaKey else event.ctrlKey
 
-  isEscape: (event) ->
-    # c-[ is mapped to ESC in Vim by default.
-    (event.keyCode == @keyCodes.ESC) ||
-    (event.ctrlKey && @getKeyChar(event) == '[' and not event.metaKey and not event.altKey)
+  isEscape: do ->
+    keyTranslationRegistry = {}
+    # NOTE: "?" here for the tests.
+    Utils?.monitorChromeStorage "keyTranslationRegistry", (value) => keyTranslationRegistry = value
+
+    (event) ->
+      event.keyCode == @keyCodes.ESC || do =>
+        keyChar = @getKeyChar event
+        keyChar.length == 1 and do =>
+          keyChar = @getModifiedKeyChar keyChar, event
+          keyChar = keyTranslationRegistry[keyChar] ? keyChar
+          keyChar == "<c-[>"
 
   # TODO. This is probably a poor way of detecting printable characters.  However, it shouldn't incorrectly
   # identify any of chrome's own keyboard shortcuts as printable.
@@ -108,16 +116,19 @@ KeyboardUtils =
         # Handle special keys and normal input keys with modifiers being pressed.
         keyChar = @getKeyChar event
         if 1 < keyChar.length or (keyChar.length == 1 and (event.metaKey or event.ctrlKey or event.altKey))
-          modifiers = []
+          @getModifiedKeyChar keyChar, event
 
-          keyChar = keyChar.toUpperCase() if event.shiftKey
-          # These must be in alphabetical order (to match the sorted modifier order in Commands.normalizeKey).
-          modifiers.push "a" if event.altKey
-          modifiers.push "c" if event.ctrlKey
-          modifiers.push "m" if event.metaKey
+  getModifiedKeyChar: (keyChar, event) ->
+    modifiers = []
 
-          keyChar = [modifiers..., keyChar].join "-"
-          if 1 < keyChar.length then "<#{keyChar}>" else keyChar
+    keyChar = keyChar.toUpperCase() if event.shiftKey
+    # These must be in alphabetical order (to match the sorted modifier order in Commands.normalizeKey).
+    modifiers.push "a" if event.altKey
+    modifiers.push "c" if event.ctrlKey
+    modifiers.push "m" if event.metaKey
+
+    keyChar = [modifiers..., keyChar].join "-"
+    if 1 < keyChar.length then "<#{keyChar}>" else keyChar
 
 KeyboardUtils.init()
 

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -209,6 +209,13 @@ Utils =
   makeIdempotent: (func) ->
     (args...) -> ([previousFunc, func] = [func, null])[0]? args...
 
+  monitorChromeStorage: (key, setter) ->
+    # NOTE: "?" here for the tests.
+    chrome?.storage.local.get key, (obj) =>
+      setter obj[key] if obj[key]?
+      chrome.storage.onChanged.addListener (changes, area) =>
+        setter changes[key].newValue if changes[key]?.newValue?
+
 # Utility for parsing and using the custom search-engine configuration.  We re-use the previous parse if the
 # search-engine configuration is unchanged.
 SearchEngines =


### PR DESCRIPTION
*Edit: The name "translate", here, has been replaced with "mapkey".*

Under *Custom key mappings* (on the options page), this implements:

    translate x y

Whenever the users types `x` in normal mode or in visual mode, the `x` is replaced by `y`.

For example:

    translate ç l

now, `ç` maps to `scrollRight` (which apparently would be helpful on Brazilian keyboards).

Issues:

- Is there an established vim name for this (to use instead of `translate`)?

- Do we want yet another hack like this?  This would be documented only on the wiki.

- With `translate <c-c> <c-[>` (and with `isEscape()` extended to use the translation), we'd get the `exitMode` command almost for free (#2253).

- Instead of adding a new directive called `translate`, we could alternatively overload the existing `map` directive.  Since these are single-key mappings, there's no ambiguity.  (Although, I guess there's a risk that some user has junk in their key mappings, and they would be taken somewhat by surprise).

Inspired by isssue posted by @vhoyer (#2305).

Fixes #2305.

**Edit...**

With 9c1012ad3a731b015b8a70b58828fbcd0acb7db0, `Escape` also uses `translate`, so you can say things like:

    translate <c-c> <c-[>

Also, to disable `<c-[>`:

    translate <c-[> <anyOldNonesense>