### PR TITLE
New command option to enter normal mode

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -166,6 +166,7 @@ Commands =
       "enterVisualMode",
       "enterVisualLineMode",
       "passNextKey",
+      "enterNormalMode",
       "focusInput",
       "LinkHints.activateMode",
       "LinkHints.activateModeToOpenInNewTab",
@@ -238,6 +239,7 @@ Commands =
     "closeOtherTabs",
     "enterVisualLineMode",
     "toggleViewSource",
+    "enterNormalMode",
     "passNextKey"]
 
 defaultKeyMappings =
@@ -354,6 +356,7 @@ commandDescriptions =
   passNextKey: ["Pass the next key to Chrome"]
   enterVisualMode: ["Enter visual mode", { noRepeat: true }]
   enterVisualLineMode: ["Enter visual line mode", { noRepeat: true }]
+  enterNormalMode: ["Handle following key sequence in normal mode"]
 
   focusInput: ["Focus the first text input on the page"]
 

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -166,7 +166,6 @@ Commands =
       "enterVisualMode",
       "enterVisualLineMode",
       "passNextKey",
-      "enterNormalMode",
       "focusInput",
       "LinkHints.activateMode",
       "LinkHints.activateModeToOpenInNewTab",
@@ -239,7 +238,6 @@ Commands =
     "closeOtherTabs",
     "enterVisualLineMode",
     "toggleViewSource",
-    "enterNormalMode",
     "passNextKey"]
 
 defaultKeyMappings =
@@ -356,7 +354,6 @@ commandDescriptions =
   passNextKey: ["Pass the next key to Chrome"]
   enterVisualMode: ["Enter visual mode", { noRepeat: true }]
   enterVisualLineMode: ["Enter visual line mode", { noRepeat: true }]
-  enterNormalMode: ["Handle following key sequence in normal mode"]
 
   focusInput: ["Focus the first text input on the page"]
 

--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -81,9 +81,8 @@ class Mode
         _name: "mode-#{@id}/exitOnEscape"
         "keydown": (event) =>
           return @continueBubbling unless KeyboardUtils.isEscape event
-          DomUtils.suppressKeyupAfterEscape handlerStack
           @exit event, event.srcElement
-          @suppressEvent
+          DomUtils.suppressKeyupAfterEscape handlerStack
 
     # If @options.exitOnBlur is truthy, then it should be an element.  The mode will exit when that element
     # loses the focus.

--- a/content_scripts/mode_find.coffee
+++ b/content_scripts/mode_find.coffee
@@ -47,9 +47,8 @@ class PostFindMode extends SuppressPrintable
       _name: "mode-#{@id}/handle-escape"
       keydown: (event) =>
         if KeyboardUtils.isEscape event
-          DomUtils.suppressKeyupAfterEscape handlerStack
           @exit()
-          @suppressEvent
+          DomUtils.suppressKeyupAfterEscape handlerStack
         else
           handlerStack.remove()
           @continueBubbling

--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -17,7 +17,6 @@ class InsertMode extends Mode
         return @suppressEvent
 
       return @passEventToPage unless event.type == 'keydown' and KeyboardUtils.isEscape event
-      DomUtils.suppressKeyupAfterEscape handlerStack
       target = event.srcElement
       if target and DomUtils.isFocusable target
         # Remove the focus, so the user can't just get back into insert mode by typing in the same input box.
@@ -26,7 +25,7 @@ class InsertMode extends Mode
         # An editable element in a shadow DOM is focused; blur it.
         @insertModeLock.blur()
       @exit event, event.srcElement
-      @suppressEvent
+      DomUtils.suppressKeyupAfterEscape handlerStack
 
     defaults =
       name: "insert"

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -111,10 +111,12 @@ handlerStack.push
 
 class NormalMode extends KeyHandlerMode
   constructor: (options = {}) ->
-    super extend options,
+    defaults =
       name: "normal"
-      indicator: false # There is no mode indicator in normal mode.
+      indicator: false # There is normally no mode indicator in normal mode.
       commandHandler: @commandHandler.bind this
+
+    super extend defaults, options
 
     chrome.storage.local.get "normalModeKeyStateMapping", (items) =>
       @setKeyMapping items.normalModeKeyStateMapping
@@ -122,10 +124,6 @@ class NormalMode extends KeyHandlerMode
     chrome.storage.onChanged.addListener (changes, area) =>
       if area == "local" and changes.normalModeKeyStateMapping?.newValue
         @setKeyMapping changes.normalModeKeyStateMapping.newValue
-
-    # Initialize components which normal mode depends upon.
-    Scroller.init()
-    FindModeHistory.init()
 
   commandHandler: ({command: registryEntry, count}) ->
     count *= registryEntry.options.count ? 1
@@ -150,6 +148,9 @@ installModes = ->
   # Install the permanent modes. The permanently-installed insert mode tracks focus/blur events, and
   # activates/deactivates itself accordingly.
   normalMode = new NormalMode
+  # Initialize components upon which normal mode depends.
+  Scroller.init()
+  FindModeHistory.init()
   new InsertMode permanent: true
   new GrabBackFocus if isEnabledForUrl
   normalMode # Return the normalMode object (for the tests).
@@ -385,6 +386,9 @@ extend window,
 
   passNextKey: (count) ->
     new PassNextKeyMode count
+
+  enterNormalMode: (count) ->
+    new NormalMode exitOnEscape: true, indicator: "Normal mode", count: count, singleton: "enterNormalMode"
 
   focusInput: do ->
     # Track the most recently focused input element.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -388,7 +388,11 @@ extend window,
     new PassNextKeyMode count
 
   enterNormalMode: (count) ->
-    new NormalMode exitOnEscape: true, indicator: "Normal mode", count: count, singleton: "enterNormalMode"
+    new NormalMode
+      indicator: "Normal mode (pass keys disabled)"
+      exitOnEscape: true
+      singleton: "enterNormalMode"
+      count: count
 
   focusInput: do ->
     # Track the most recently focused input element.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -386,7 +386,7 @@ extend window,
 
   passNextKey: (count, options) ->
     if options.registryEntry.options.normal
-      enterNormalMode count, options
+      enterNormalMode count
     else
       new PassNextKeyMode count
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -384,8 +384,11 @@ extend window,
   enterVisualLineMode: ->
     new VisualLineMode userLaunchedMode: true
 
-  passNextKey: (count) ->
-    new PassNextKeyMode count
+  passNextKey: (count, options) ->
+    if options.registryEntry.options.normal
+      enterNormalMode count, options
+    else
+      new PassNextKeyMode count
 
   enterNormalMode: (count) ->
     new NormalMode

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -310,6 +310,7 @@ DomUtils =
         return true unless KeyboardUtils.isEscape event
         @remove()
         false
+    handlerStack.suppressEvent
 
   # Adapted from: http://roysharon.com/blog/37.
   # This finds the element containing the selection focus.


### PR DESCRIPTION
Here's the problem...

Many sites define their own keyboard shortcuts, for example Google Play Music defines `gh` for "go home".

On such sites, it is normal to set up pass keys for `g` and `h`, but then Vimium bindings which begin with `g` are inaccessible.  And this can be frustrating.

Here, we add a new command `enterNormalMode` which installs a new normal-mode instance (without any pass keys).  This executes a single normal-mode command (or `count` commands) and then exits.

Examples:

```
map \ enterNormalMode
map | enterNormalMode count=999999
```

Assuming `g` and `o` are pass keys:
- `gh` or `o` - use the page's binding
- `\gg` - scroll to top
- `2\ggo` - scroll to the top and open the Vomnibar
- `\g<Escape>o` - open the Vomnibar
- `\<Escape>o` - use the page's bindings
- `\\\\\\<Escape>o` - use the page's bindings (new normal-mode instances
  displace previous ones, and `Escape` exits)

This required some changes to the scroller.  Previously, we only ever had one normal-mode instance, and could arrange statically that the scroller's key listeners were above normal-mode's key listeners in the handler stack.  Here, we fix this by adding and removing the scroller's listeners dynamically, so they're always at the top of the handler stack.

(This might be similar to what the poster of #1986 had in mind.)
