### PR TITLE
Add sendMessage command to message external components (version two)

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -210,7 +210,8 @@ Commands =
       "moveTabRight"]
     misc:
       ["showHelp",
-      "toggleViewSource"]
+      "toggleViewSource",
+      "sendMessage"]
 
   # Rarely used commands are not shown by default in the help dialog or in the README. The goal is to present
   # a focused, high-signal set of commands to the new and casual user. Only those truly hungry for more power
@@ -238,7 +239,8 @@ Commands =
     "closeOtherTabs",
     "enterVisualLineMode",
     "toggleViewSource",
-    "passNextKey"]
+    "passNextKey",
+    "sendMessage"]
 
 defaultKeyMappings =
   "?": "showHelp"
@@ -416,6 +418,8 @@ commandDescriptions =
 
   "Marks.activateCreateMode": ["Create a new mark", { noRepeat: true }]
   "Marks.activateGotoMode": ["Go to a mark", { noRepeat: true }]
+
+  sendMessage: ["Post a message to the page or another extension"]
 
 Commands.init()
 

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -391,9 +391,10 @@ HintCoordinator =
     for own frameId, port of @tabState[tabId].ports
       @postMessage tabId, parseInt(frameId), messageType, port, request
 
-  prepareToActivateMode: (tabId, originatingFrameId, {modeIndex, isVimiumHelpDialog}) ->
+  prepareToActivateMode: (tabId, originatingFrameId, {modeIndex, isVimiumHelpDialog, options}) ->
     @tabState[tabId] = {frameIds: frameIdsForTab[tabId][..], hintDescriptors: {}, originatingFrameId, modeIndex}
     @tabState[tabId].ports = extend {}, portsForTab[tabId]
+    @tabState[tabId].options = options
     @sendMessage "getHintDescriptors", tabId, {modeIndex, isVimiumHelpDialog}
 
   # Receive hint descriptors from all frames and activate link-hints mode when we have them all.
@@ -412,6 +413,7 @@ HintCoordinator =
               originatingFrameId: @tabState[tabId].originatingFrameId
               hintDescriptors: hintDescriptors
               modeIndex: @tabState[tabId].modeIndex
+              options: @tabState[tabId].options
 
   # If an unregistering frame is participating in link-hints mode, then we need to tidy up after it.
   unregisterFrame: (tabId, frameId) ->

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -473,7 +473,7 @@ extend window,
               indicator: false
 
   # We cannot use the name "postMessage", because window.postMessage() already exists.
-  sendMessage: (count, registryEntry) ->
+  sendMessage: (count, {registryEntry}) ->
     message = extend (extend {}, registryEntry.options ? {}), {count}
     if message.extension
       chrome.runtime.sendMessage message.extension, message

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -472,6 +472,14 @@ extend window,
               targetElement: document.activeElement
               indicator: false
 
+  # We cannot use the name "postMessage", because window.postMessage() already exists.
+  sendMessage: (count, registryEntry) ->
+    message = extend (extend {}, registryEntry.options ? {}), {count}
+    if message.extension
+      chrome.runtime.sendMessage message.extension, message
+    else
+      window.postMessage message, "*"
+
 # Checks if Vimium should be enabled or not in this frame.  As a side effect, it also informs the background
 # page whether this frame has the focus, allowing the background page to track the active frame's URL and set
 # the page icon.

--- a/examples/external-commands/README.md
+++ b/examples/external-commands/README.md
@@ -8,6 +8,7 @@ Examples:
     map eh sendMessage name=showAlert message=Message
     map el sendMessage name=hover hint
     map eu sendMessage name=unhover
+    map eo sendMessage name=openUrls extension=ohmajiahfhgmmijaombnjclabhjlbfon http://edition.cnn.com/ http://www.bbc.com/news
 
 If the `extension` command options is set, then `sendMessage` uses
 [cross-extension messaging](https://developer.chrome.com/extensions/messaging#external).

--- a/examples/external-commands/README.md
+++ b/examples/external-commands/README.md
@@ -1,0 +1,24 @@
+## External Commands
+
+This is a demo extension for the Vimium `sendMessage` command.
+
+Examples:
+
+    map ea sendMessage name=focusFirstAudibleTab extension=ohmajiahfhgmmijaombnjclabhjlbfon
+    map eh sendMessage name=showAlert message=Message
+    map el sendMessage name=hover hint
+    map eu sendMessage name=unhover
+
+If the `extension` command options is set, then `sendMessage` uses
+[cross-extension messaging](https://developer.chrome.com/extensions/messaging#external).
+Otherwise, `window.postMessage()` is used.
+
+If the `hint` command options is set, then Vimium first uses link-hints mode to
+identify an element, and then sends the message. The message then contains
+property `elementIndex` identifying the position of the element within the document:
+
+```coffeescript
+element = document.documentElement.getElementsByTagName("*")[message.elementIndex]
+```
+
+External commands can also be implemented in suitable TamperMonkey user scripts.

--- a/examples/external-commands/background.coffee
+++ b/examples/external-commands/background.coffee
@@ -8,6 +8,21 @@ Commands =
           chrome.tabs.update tab.id, active: true, ->
             chrome.windows.update tab.windowId, focused: true
 
+  openUrls:
+    description: "Open one or more URLs in new tabs."
+    command: (options) ->
+      chrome.windows.getLastFocused {populate: true}, (win) ->
+        tab = (tab for tab in win.tabs when tab.active)[0]
+        index = tab.index
+        for own key of options
+          if key[...7] == "http://" or key[...8] == "https://"
+            chrome.tabs.create
+              url: key
+              index: ++index
+              selected: true
+              windowId: tab.windowId
+              openerTabId: tab.id
+
 chrome.runtime.onMessageExternal.addListener (request) ->
   Commands[request.name]?.command request
 

--- a/examples/external-commands/background.coffee
+++ b/examples/external-commands/background.coffee
@@ -1,0 +1,18 @@
+Commands =
+  focusFirstAudibleTab:
+    description: "Focus the first audible tab."
+    command: (options) ->
+      chrome.tabs.query {audible: true}, (tabs) ->
+        if 0 < tabs.length
+          tab = tabs[0]
+          chrome.tabs.update tab.id, active: true, ->
+            chrome.windows.update tab.windowId, focused: true
+
+chrome.runtime.onMessageExternal.addListener (request) ->
+  Commands[request.name]?.command request
+
+# Show instructions on the background page.
+console.log "# Add (and tweak) one or more of the following on the Vimium options page."
+console.log "\n# Background-page commands:"
+for own name, command of Commands
+  console.log "# #{command.description}\n  map X sendMessage name=#{name} extension=#{chrome.runtime.id}"

--- a/examples/external-commands/commands.coffee
+++ b/examples/external-commands/commands.coffee
@@ -1,0 +1,18 @@
+
+documentReady = do ->
+  [isReady, callbacks] = [document.readyState != "loading", []]
+  unless isReady
+    window.addEventListener "DOMContentLoaded", onDOMContentLoaded = ->
+      window.removeEventListener "DOMContentLoaded", onDOMContentLoaded
+      isReady = true
+      callback() for callback in callbacks
+      callbacks = null
+
+  (callback) -> if isReady then callback() else callbacks.push callback
+
+documentReady ->
+  chrome.storage.local.get null, (items) ->
+    for id in ["contentBackground", "contentForeground"]
+      element = document.getElementById id
+      element.innerHTML = items[id]
+

--- a/examples/external-commands/commands.html
+++ b/examples/external-commands/commands.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html lang="en">
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <title>Vimium External Command Configuration (Demo)</title>
+    <script type="text/javascript" src="commands.js"></script>
+  </head>
+  <body>
+    <h2>Vimium External Command Configuration (Demo)</h2>
+    <div id="wrapper" style="margin-left: 25px">
+      <p style="padding: 5px;">
+      Add (and tweak) one or more of the following on the Vimium options page (under <i>Custom key mappings</i>).
+      </p>
+      <pre id="contentBackground" style="font-size: 12px; background-color: #f8f8f8; padding: 5px;"></pre>
+      <pre id="contentForeground" style="font-size: 12px; background-color: #f8f8f8; padding: 5px;"></pre>
+    </div>
+  </body>
+</html>

--- a/examples/external-commands/foreground.coffee
+++ b/examples/external-commands/foreground.coffee
@@ -3,51 +3,60 @@ hoverElement = null
 Commands =
   showAlert:
     description: "Pop up an alert."
+    extra: "message=Hello!"
     command: (options) ->
       alert options.message ? "Hello!"
 
   hover:
     description: "Hover on an element selected via link hints."
+    extra: "hint"
     command: ({elementIndex}) ->
       hoverElement = document.documentElement.getElementsByTagName("*")[elementIndex]
-      simulateMouseEvent "mouseover", hoverElement
+      DomUtils.simulateMouseEvent "mouseover", hoverElement
 
   unhover:
     description: "Unhover on a previously-hovered element."
     command: ({elementIndex}) ->
       if hoverElement?
-        simulateMouseEvent "mouseout", hoverElement
+        DomUtils.simulateMouseEvent "mouseout", hoverElement
         hoverElement = null
 
 if chrome?.extension?.getBackgroundPage?() != window
-  #  This is a content window; add listener.
+  #  This is a content window; install listener.
   window.addEventListener "message", (request) ->
     Commands[request.data?.name]?.command request.data
 
-else
-  # This is the background page; show some instructions.
-  console.log "\n# Content-page commands:"
+# Utility for simulating mouse events.
+DomUtils =
+  simulateMouseEvent: do ->
+    lastHoveredElement = undefined
+    (event, element, modifiers = {}) ->
+
+      if event == "mouseout"
+        element ?= lastHoveredElement # Allow unhovering the last hovered element by passing undefined.
+        lastHoveredElement = undefined
+        return unless element?
+
+      else if event == "mouseover"
+        # Simulate moving the mouse off the previous element first, as if we were a real mouse.
+        @simulateMouseEvent "mouseout", undefined, modifiers
+        lastHoveredElement = element
+
+      mouseEvent = document.createEvent("MouseEvents")
+      mouseEvent.initMouseEvent(event, true, true, window, 1, 0, 0, 0, 0, modifiers.ctrlKey, modifiers.altKey,
+      modifiers.shiftKey, modifiers.metaKey, 0, null)
+      # Debugging note: Firefox will not execute the element's default action if we dispatch this click event,
+      # but Webkit will. Dispatching a click on an input box does not seem to focus it; we do that separately
+      element.dispatchEvent(mouseEvent)
+
+if chrome?.extension?.getBackgroundPage?() == window
+  # This is the background page.  Store documentation in chrome.storage.local (for the options/help page).
+  helpLines = []
+  helpLines.push "# Content-page commands"
   for own name, command of Commands
-    console.log "# #{command.description}\n  map X sendMessage name=#{name}"
+    helpLines.push ""
+    helpLines.push "# #{command.description}"
+    helpLines.push "map X sendMessage name=#{name} #{command.extra ? ''}"
 
-simulateMouseEvent = do ->
-  lastHoveredElement = undefined
-  (event, element, modifiers = {}) ->
-
-    if event == "mouseout"
-      element ?= lastHoveredElement # Allow unhovering the last hovered element by passing undefined.
-      lastHoveredElement = undefined
-      return unless element?
-
-    else if event == "mouseover"
-      # Simulate moving the mouse off the previous element first, as if we were a real mouse.
-      simulateMouseEvent "mouseout", undefined, modifiers
-      lastHoveredElement = element
-
-    mouseEvent = document.createEvent("MouseEvents")
-    mouseEvent.initMouseEvent(event, true, true, window, 1, 0, 0, 0, 0, modifiers.ctrlKey, modifiers.altKey,
-    modifiers.shiftKey, modifiers.metaKey, 0, null)
-    # Debugging note: Firefox will not execute the element's default action if we dispatch this click event,
-    # but Webkit will. Dispatching a click on an input box does not seem to focus it; we do that separately
-    element.dispatchEvent(mouseEvent)
-
+  helpLines.push ""
+  chrome.storage.local.set "contentForeground": helpLines.join "\n"

--- a/examples/external-commands/foreground.coffee
+++ b/examples/external-commands/foreground.coffee
@@ -1,10 +1,10 @@
 hoverElement = null
 
 Commands =
-  sayHello:
-    description: "Say hello."
+  showAlert:
+    description: "Pop up an alert."
     command: (options) ->
-      alert "Hello!"
+      alert options.message ? "Hello!"
 
   hover:
     description: "Hover on an element selected via link hints."

--- a/examples/external-commands/foreground.coffee
+++ b/examples/external-commands/foreground.coffee
@@ -1,8 +1,23 @@
+hoverElement = null
+
 Commands =
   sayHello:
     description: "Say hello."
     command: (options) ->
       alert "Hello!"
+
+  hover:
+    description: "Hover on an element selected via link hints."
+    command: ({elementIndex}) ->
+      hoverElement = document.documentElement.getElementsByTagName("*")[elementIndex]
+      simulateMouseEvent "mouseover", hoverElement
+
+  unhover:
+    description: "Unhover on a previously-hovered element."
+    command: ({elementIndex}) ->
+      if hoverElement?
+        simulateMouseEvent "mouseout", hoverElement
+        hoverElement = null
 
 if chrome?.extension?.getBackgroundPage?() != window
   #  This is a content window; add listener.
@@ -14,3 +29,25 @@ else
   console.log "\n# Content-page commands:"
   for own name, command of Commands
     console.log "# #{command.description}\n  map X sendMessage name=#{name}"
+
+simulateMouseEvent = do ->
+  lastHoveredElement = undefined
+  (event, element, modifiers = {}) ->
+
+    if event == "mouseout"
+      element ?= lastHoveredElement # Allow unhovering the last hovered element by passing undefined.
+      lastHoveredElement = undefined
+      return unless element?
+
+    else if event == "mouseover"
+      # Simulate moving the mouse off the previous element first, as if we were a real mouse.
+      simulateMouseEvent "mouseout", undefined, modifiers
+      lastHoveredElement = element
+
+    mouseEvent = document.createEvent("MouseEvents")
+    mouseEvent.initMouseEvent(event, true, true, window, 1, 0, 0, 0, 0, modifiers.ctrlKey, modifiers.altKey,
+    modifiers.shiftKey, modifiers.metaKey, 0, null)
+    # Debugging note: Firefox will not execute the element's default action if we dispatch this click event,
+    # but Webkit will. Dispatching a click on an input box does not seem to focus it; we do that separately
+    element.dispatchEvent(mouseEvent)
+

--- a/examples/external-commands/foreground.coffee
+++ b/examples/external-commands/foreground.coffee
@@ -1,0 +1,16 @@
+Commands =
+  sayHello:
+    description: "Say hello."
+    command: (options) ->
+      alert "Hello!"
+
+if chrome?.extension?.getBackgroundPage?() != window
+  #  This is a content window; add listener.
+  window.addEventListener "message", (request) ->
+    Commands[request.data?.name]?.command request.data
+
+else
+  # This is the background page; show some instructions.
+  console.log "\n# Content-page commands:"
+  for own name, command of Commands
+    console.log "# #{command.description}\n  map X sendMessage name=#{name}"

--- a/examples/external-commands/manifest.json
+++ b/examples/external-commands/manifest.json
@@ -1,0 +1,26 @@
+{
+  "manifest_version": 2,
+  "name": "Vimium sendMessage-command demo",
+  "version": "1.01",
+  "description": "Demo of Vimium's sendMessage command.  See the background page's console for further instructions.",
+  "background": { "scripts": [ "background.js", "foreground.js"] },
+  "permissions": [
+    "tabs",
+    "bookmarks",
+    "history",
+    "clipboardRead",
+    "storage",
+    "sessions",
+    "notifications",
+    "webNavigation",
+    "<all_urls>"
+  ],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["foreground.js"],
+      "run_at": "document_start",
+      "all_frames": true
+    }
+  ]
+}

--- a/examples/external-commands/manifest.json
+++ b/examples/external-commands/manifest.json
@@ -15,6 +15,7 @@
     "webNavigation",
     "<all_urls>"
   ],
+  "options_page": "commands.html",
   "content_scripts": [
     {
       "matches": ["<all_urls>"],


### PR DESCRIPTION
This adds a new command `sendMessage` for implementing Vimium commands in external extensions of via TamperMonkey userscripts. 

See the explanation [here](https://github.com/smblott-github/vimium/blob/sendMessage-command-v2/examples/external-commands/README.md).

The most disruptive aspect of this PR is the plumbing through link-hints mode.  The `sendMessage` implementation itself is pretty much self contained.

Replaces #2109.
