### PR TITLE
Better line parsing (for custom key mappings)

### DIFF
--- a/background_scripts/bg_utils.coffee
+++ b/background_scripts/bg_utils.coffee
@@ -77,4 +77,18 @@ BgUtils =
             logElement.value += "#{dateString}: #{message}\n"
             logElement.scrollTop = 2000000000
 
+  # Remove comments from a list of lines and merge lines where the last character on the preceding line is "\".
+  parseLines: (lines) ->
+    previousText = []
+    for line in lines
+      line = line.replace /^\s+/g, ''
+      continue if line.length == 0
+      continue if line[0] in '#"'
+      if line[line.length-1] == "\\"
+        previousText.push line[...line.length-1]
+        continue
+      line = previousText.join(" ") + line
+      previousText = []
+      line
+
 root.BgUtils = BgUtils

--- a/background_scripts/bg_utils.coffee
+++ b/background_scripts/bg_utils.coffee
@@ -77,18 +77,12 @@ BgUtils =
             logElement.value += "#{dateString}: #{message}\n"
             logElement.scrollTop = 2000000000
 
-  # Remove comments from a list of lines and merge lines where the last character on the preceding line is "\".
-  parseLines: (lines) ->
-    previousText = []
-    for line in lines
-      line = line.replace /^\s+/g, ''
+  # Remove comments and leading/trailing whitespace from a list of lines, and merge lines where the last
+  # character on the preceding line is "\".
+  parseLines: (text) ->
+    for line in text.replace(/\\\n/g, "").split("\n").map((line) -> line.trim())
       continue if line.length == 0
       continue if line[0] in '#"'
-      if line[line.length-1] == "\\"
-        previousText.push line[...line.length-1]
-        continue
-      line = previousText.join(" ") + line
-      previousText = []
       line
 
 root.BgUtils = BgUtils

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -61,35 +61,34 @@ Commands =
         [key[0], @parseKeySequence(key[1..])...]
 
   parseCustomKeyMappings: (customKeyMappings) ->
-    for line in BgUtils.parseLines customKeyMappings.split "\n"
-      unless  line[0] == "\"" or line[0] == "#"
-        tokens = line.replace(/\s+$/, "").split /\s+/
-        switch tokens[0]
-          when "map"
-            [ _, key, command, optionList... ] = tokens
-            keySequence = @parseKeySequence key
-            if command? and @availableCommands[command]
-              key = keySequence.join ""
-              BgUtils.log "mapping [\"#{keySequence.join '", "'}\"] to #{command}"
-              @mapKeyToCommand { key, command, keySequence, options: @parseCommandOptions command, optionList }
-            else
-              BgUtils.log "skipping [\"#{keySequence.join '", "'}\"] for #{command} -- something is not right"
+    for line in BgUtils.parseLines customKeyMappings
+      tokens = line.split /\s+/
+      switch tokens[0]
+        when "map"
+          [ _, key, command, optionList... ] = tokens
+          keySequence = @parseKeySequence key
+          if command? and @availableCommands[command]
+            key = keySequence.join ""
+            BgUtils.log "mapping [\"#{keySequence.join '", "'}\"] to #{command}"
+            @mapKeyToCommand { key, command, keySequence, options: @parseCommandOptions command, optionList }
+          else
+            BgUtils.log "skipping [\"#{keySequence.join '", "'}\"] for #{command} -- something is not right"
 
-          when "unmap"
-            if tokens.length == 2
-              keySequence = @parseKeySequence tokens[1]
-              key = keySequence.join ""
-              BgUtils.log "Unmapping #{key}"
-              delete @keyToCommandRegistry[key]
+        when "unmap"
+          if tokens.length == 2
+            keySequence = @parseKeySequence tokens[1]
+            key = keySequence.join ""
+            BgUtils.log "Unmapping #{key}"
+            delete @keyToCommandRegistry[key]
 
-          when "unmapAll"
-            @keyToCommandRegistry = {}
+        when "unmapAll"
+          @keyToCommandRegistry = {}
 
-          when "mapkey"
-            if tokens.length == 3
-              fromChar = @parseKeySequence tokens[1]
-              toChar = @parseKeySequence tokens[2]
-              @mapKeyRegistry[fromChar[0]] = toChar[0] if fromChar.length == toChar.length == 1
+        when "mapkey"
+          if tokens.length == 3
+            fromChar = @parseKeySequence tokens[1]
+            toChar = @parseKeySequence tokens[2]
+            @mapKeyRegistry[fromChar[0]] = toChar[0] if fromChar.length == toChar.length == 1
 
     # Push the key mapping for passNextKey into Settings so that it's available in the front end for insert
     # mode.  We exclude single-key mappings (that is, printable keys) because when users press printable keys

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -61,7 +61,7 @@ Commands =
         [key[0], @parseKeySequence(key[1..])...]
 
   parseCustomKeyMappings: (customKeyMappings) ->
-    for line in customKeyMappings.split "\n"
+    for line in BgUtils.parseLines customKeyMappings.split "\n"
       unless  line[0] == "\"" or line[0] == "#"
         tokens = line.replace(/\s+$/, "").split /\s+/
         switch tokens[0]

--- a/tests/unit_tests/commands_test.coffee
+++ b/tests/unit_tests/commands_test.coffee
@@ -1,5 +1,6 @@
 require "./test_helper.js"
 extend global, require "./test_chrome_stubs.js"
+extend global, require "../../background_scripts/bg_utils.js"
 global.Settings = {postUpdateHooks: {}, get: (-> ""), set: ->}
 {Commands} = require "../../background_scripts/commands.js"
 

--- a/tests/unit_tests/commands_test.coffee
+++ b/tests/unit_tests/commands_test.coffee
@@ -98,6 +98,22 @@ context "Validate advanced commands",
     for command in Commands.advancedCommands
       assert.isTrue 0 <= @allCommands.indexOf command
 
+context "Parse commands",
+  should "omit whitespace", ->
+    assert.equal 0, BgUtils.parseLines("    \n    \n   ").length
+
+  should "omit comments", ->
+    assert.equal 0, BgUtils.parseLines(" # comment   \n \" comment   \n   ").length
+
+  should "join lines", ->
+    assert.equal 1, BgUtils.parseLines("a\\\nb").length
+    assert.equal "ab", BgUtils.parseLines("a\\\nb")[0]
+
+  should "trim lines", ->
+    assert.equal 2, BgUtils.parseLines("  a  \n  b").length
+    assert.equal "a", BgUtils.parseLines("  a  \n  b")[0]
+    assert.equal "b", BgUtils.parseLines("  a  \n  b")[1]
+
 # TODO (smblott) More tests:
 # - Ensure each background command has an implmentation in BackgroundCommands
 # - Ensure each foreground command has an implmentation in vimium_frontent.coffee


### PR DESCRIPTION
1. Explicitly remove comments.
2. A trailing backslash means the current line continues on the next line.

E.g.

    a \
      b \
      c

is a single line `a b c`.

This helps alleviate the fact that configuration lines can be quite long, whereas the *Custom key mappings* input is rather narrow.

TODO: We should use the same line parser in the custom-search-engines input.