### PR TITLE
Extend createTab to open specific pages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Release Notes
 Changes since the previous release (not yet in the Chrome Store version)
 
 - Features:
+    - The `createTab` command can now open specific URLs (e.g, `map X createTab http://www.bbc.com/news`).
     - You can now map multi-modifier keys, for example: `<c-a-X>`.
     - Vimium can now do simple key mapping in some modes; see
       [here](https://github.com/philc/vimium/wiki/Tips-and-Tricks#key-mapping).

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -145,6 +145,9 @@ mkRepeatCommand = (command) -> (request) ->
 # These are commands which are bound to keystrokes which must be handled by the background page. They are
 # mapped in commands.coffee.
 BackgroundCommands =
+  # Create a new tab.  Also, with:
+  #     map X createTab http://www.bbc.com/news
+  # create a new tab with the given URL.
   createTab: mkRepeatCommand (request, callback) ->
     request.urls ?=
       if request.url

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -152,18 +152,18 @@ BackgroundCommands =
         [request.url]
       else
         # Otherwise, if we have a registryEntry containing URLs, then use them.
-        urlList = (opt for own opt of request.registryEntry?.options ? {} when Utils.isUrl opt)
+        urlList = (opt for opt in request.registryEntry.optionList when Utils.isUrl opt)
         if 0 < urlList.length
           urlList
         else
           # Otherwise, just create a new tab.
-          url = Settings.get "newTabUrl"
-          if url == "pages/blank.html"
+          newTabUrl = Settings.get "newTabUrl"
+          if newTabUrl == "pages/blank.html"
             # "pages/blank.html" does not work in incognito mode, so fall back to "chrome://newtab" instead.
             [if request.tab.incognito then "chrome://newtab" else chrome.runtime.getURL newTabUrl]
           else
-            [url]
-    urls = request.urls[..]
+            [newTabUrl]
+    urls = request.urls[..].reverse()
     do openNextUrl = (request) ->
       if 0 < urls.length
         TabOperations.openUrlInNewTab (extend request, {url: urls.pop()}), (tab) ->


### PR DESCRIPTION
Example:

```
map a createTab http://edition.cnn.com/ http://www.bbc.co.uk/news
```

which creates two new tabs, but preloaded with these specific URLs.

`2a` creates four new tabs, two copies of each.

Limitation:
- ~~We cannot control the order of the tabs, so we might get CNN then BBC, or BBC then CNN.  This happens because command options are stored in an object, and we cannot control the order of the keys.~~ Edit: Fixed in f490b85757656c2276dcb9faa6237ca8231f8046.

Also, with:

```
map a createTab http://www.bbc.co.uk/news http://www.bbc.co.uk/news
```

~~we only get one new tab (for the same reason).~~ Edit: Also fixed in f490b85757656c2276dcb9faa6237ca8231f8046.

Fixes #2298 (mostly).
