### PR TITLE
Fix event.key error

### DIFF
--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -41,6 +41,7 @@ KeyboardUtils =
       @getKeyCharUsingKey event
 
   getKeyCharUsingKey: (event) ->
+    return unless event.key?  # Avoid error if event.key is undefined
     if event.keyCode of @keyNames
       @keyNames[event.keyCode]
     else if event.key.length == 1


### PR DESCRIPTION
In certain websites, the error `event.key.length` is undefined and throws an error. Example: https://www.dropbox.com/s/9bwdey1cfos9xfs/Screenshot%202016-10-20%2016.45.36.png?dl=0

Second screenshot: https://www.dropbox.com/s/9bwdey1cfos9xfs/Screenshot%202016-10-20%2016.45.36.png?dl=0

This prevents that error from occurring.
