### PR TITLE
Move SearchEngines to bg-utils.coffee.

### DIFF
--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -4,22 +4,19 @@
 Vomnibar =
   vomnibarUI: null
 
-  # Parse any additional options from the command's registry entry.  Currently, this only includes a flag of
-  # the form "keyword=X", for direct activation of a custom search engine.
-  parseRegistryEntry: (registryEntry = { options: [] }, callback = null) ->
-    searchEngines = Settings.get("searchEngines") ? ""
-    SearchEngines.refreshAndUse searchEngines, (engines) ->
-      callback? registryEntry.options
+  # Extract any additional options from the command's registry entry.
+  extractOptionsFromRegistryEntry: (registryEntry, callback) ->
+    callback? extend {}, registryEntry.options
 
   # sourceFrameId here (and below) is the ID of the frame from which this request originates, which may be different
   # from the current frame.
 
   activate: (sourceFrameId, registryEntry) ->
-    @parseRegistryEntry registryEntry, (options) =>
+    @extractOptionsFromRegistryEntry registryEntry, (options) =>
       @open sourceFrameId, extend options, completer:"omni"
 
   activateInNewTab: (sourceFrameId, registryEntry) ->
-    @parseRegistryEntry registryEntry, (options) =>
+    @extractOptionsFromRegistryEntry registryEntry, (options) =>
       @open sourceFrameId, extend options, completer:"omni", newTab: true
 
   activateTabSelection: (sourceFrameId) -> @open sourceFrameId, {

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -216,39 +216,6 @@ Utils =
       chrome.storage.onChanged.addListener (changes, area) =>
         setter changes[key].newValue if changes[key]?.newValue?
 
-# Utility for parsing and using the custom search-engine configuration.  We re-use the previous parse if the
-# search-engine configuration is unchanged.
-SearchEngines =
-  previousSearchEngines: null
-  searchEngines: null
-
-  refresh: (searchEngines) ->
-    unless @previousSearchEngines? and searchEngines == @previousSearchEngines
-      @previousSearchEngines = searchEngines
-      @searchEngines = new AsyncDataFetcher (callback) ->
-        engines = {}
-        for line in searchEngines.split "\n"
-          line = line.trim()
-          continue if /^[#"]/.test line
-          tokens = line.split /\s+/
-          continue unless 2 <= tokens.length
-          keyword = tokens[0].split(":")[0]
-          searchUrl = tokens[1]
-          description = tokens[2..].join(" ") || "search (#{keyword})"
-          continue unless Utils.hasFullUrlPrefix searchUrl
-          engines[keyword] = { keyword, searchUrl, description }
-
-        callback engines
-
-  # Use the parsed search-engine configuration, possibly asynchronously.
-  use: (callback) ->
-    @searchEngines.use callback
-
-  # Both set (refresh) the search-engine configuration and use it at the same time.
-  refreshAndUse: (searchEngines, callback) ->
-    @refresh searchEngines
-    @use callback
-
 # This creates a new function out of an existing function, where the new function takes fewer arguments. This
 # allows us to pass around functions instead of functions + a partial list of arguments.
 Function::curry = ->
@@ -347,7 +314,6 @@ class JobRunner
 
 root = exports ? window
 root.Utils = Utils
-root.SearchEngines = SearchEngines
 root.SimpleCache = SimpleCache
 root.AsyncDataFetcher = AsyncDataFetcher
 root.JobRunner = JobRunner

--- a/tests/dom_tests/vomnibar_test.coffee
+++ b/tests/dom_tests/vomnibar_test.coffee
@@ -1,5 +1,4 @@
 vomnibarFrame = null
-SearchEngines.refresh ""
 Vomnibar.init()
 
 context "Keep selection within bounds",
@@ -30,7 +29,7 @@ context "Keep selection within bounds",
     Vomnibar.vomnibarUI.hide()
 
   should "set selection to position -1 for omni completion by default", ->
-    Vomnibar.activate()
+    Vomnibar.activate 0, options: {}
     ui = vomnibarFrame.Vomnibar.vomnibarUI
 
     @completions = []
@@ -62,7 +61,7 @@ context "Keep selection within bounds",
     assert.equal -1, ui.selection
 
   should "keep selection within bounds", ->
-    Vomnibar.activate()
+    Vomnibar.activate 0, options: {}
     ui = vomnibarFrame.Vomnibar.vomnibarUI
 
     @completions = []


### PR DESCRIPTION
`SearchEngines` was previously in `utils.coffee`, which means it was loaded in _every_ content frame. This is unnecessary, since it is only used on the background page.  So this PR moves it there.

Also:
- Simplify some unnecessarily complex logic in `vomnibar.coffee`.
- Re-use `Utils.parseLines()` to parse the custom search engine configuation text.  (So, we have the same logic for detecting comments, and the same logic for joining lines which end with `\`.)
