### PR TITLE
Partial fix for selecting SELECT elements

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -48,5 +48,6 @@ Contributors:
   Scott Pinkelman <scott@scottpinkelman.com> (github: sco-tt)
   Darryl Pogue <darryl@dpogue.ca> (github: dpogue)
   tobimensch
+  Ramiro Araujo <rama.araujo@gmail.com> (github: ramiroaraujo)
 
 Feel free to add real names in addition to GitHub usernames.

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -394,7 +394,7 @@ class LinkHintsMode
             clickActivator = (modifiers) -> (link) -> DomUtils.simulateClick link, modifiers
             linkActivator = @mode.linkActivator ? clickActivator @mode.clickModifiers
             # TODO: Are there any other input elements which should not receive focus?
-            if clickEl.nodeName.toLowerCase() == "input" and clickEl.type not in ["button", "submit"]
+            if clickEl.nodeName.toLowerCase() in ["input", "select"] and clickEl.type not in ["button", "submit"]
               clickEl.focus()
             linkActivator clickEl
 

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -188,6 +188,11 @@ context "Test link hints for focusing input elements correctly",
       testDiv.appendChild input
       inputs.push input
 
+    # manually add the select element to test focus
+    input = document.createElement "select"
+    testDiv.appendChild input
+    inputs.push input
+
   tearDown ->
     document.getElementById("test-div").innerHTML = ""
 


### PR DESCRIPTION
This issue has been reported and verified in #2257 and #2287, and was introduced with Chrome v53.
It's been noted in #2257 that calling `focus()` on the `select` element could do the trick, and indeed it does. It doesn't expand the `select` as it used to be, but at least it's focused.

The fix treats the `select` elements the same as `input` elements, and simply focus on them.
I've also updated the test to verify the focus on the element.

I've been using this fix for a few days now, since I couldn't go by without hitting selects any more. Hope it helps!