### PR TITLE
getViewportTopLeft: support zoomed static documentElement

### DIFF
--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -289,13 +289,14 @@ DomUtils =
     setTimeout((-> DomUtils.removeElement flashEl), 400)
 
   getViewportTopLeft: ->
-    style = getComputedStyle document.documentElement
+    box = document.documentElement
+    style = getComputedStyle box
     if style.position == "static" and not /content|paint|strict/.test(style.contain or "")
       zoom = +style.zoom || 1
       top: Math.ceil(window.scrollY / zoom), left: Math.ceil(window.scrollX / zoom)
     else
-      rect = document.documentElement.getBoundingClientRect()
-      top: -rect.top, left: -rect.left
+      rect = box.getBoundingClientRect()
+      top: -rect.top - box.clientTop, left: -rect.left - box.clientLeft
 
   suppressPropagation: (event) ->
     event.stopImmediatePropagation()

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -290,7 +290,7 @@ DomUtils =
 
   getViewportTopLeft: ->
     style = getComputedStyle document.documentElement
-    if style.position == "static"
+    if style.position == "static" and not /content|paint|strict/.test(style.contain or "")
       zoom = +style.zoom || 1
       top: Math.ceil(window.scrollY / zoom), left: Math.ceil(window.scrollX / zoom)
     else

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -289,8 +289,10 @@ DomUtils =
     setTimeout((-> DomUtils.removeElement flashEl), 400)
 
   getViewportTopLeft: ->
-    if getComputedStyle(document.documentElement).position == "static"
-      top: window.scrollY, left: window.scrollX
+    style = getComputedStyle document.documentElement
+    if style.position == "static"
+      zoom = +style.zoom || 1
+      top: Math.ceil(window.scrollY / zoom), left: Math.ceil(window.scrollX / zoom)
     else
       rect = document.documentElement.getBoundingClientRect()
       top: -rect.top, left: -rect.left


### PR DESCRIPTION
This is a completion of #2301. If `document.documentElement` is zoomed, Vimium's hints `<div>` are also zoomed, and then `scrollY` may be not equal with viewport client rect's `top`. Therefore the zoom level must be taken into consideration.

Example:
* make the tab zoom level is 1, `documentElement`'s `zoom` style is 2
* open a page, scroll to the top left corner
* press `f`, and all things are right
* exit LinkHints mode, scroll down for 100px, and then press `f`
* this time all hints has moved down 200px from the correct place

Comment: if `documentElement.style.position` is not `"static"`, then the old code works well.