### PR TITLE
Float find-mode matches to the right.

### DIFF
--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -69,6 +69,7 @@ handlers =
 
     countElement = document.createElement "span"
     countElement.id = "hud-match-count"
+    countElement.style.float = "right"
     hud.appendChild countElement
     inputElement.focus()
 


### PR DESCRIPTION
This floats the "5 Matches" text in the find-mode HUD to the right.

This looks nicer, because the "5 Matches" text doesn't move as you type.

As it happens, it also fixes an issue which arose a few months ago (for unknown reasons) with the positioning of the cursor in find mode.  The cursor position was becoming "jammed" after the first character as you type.

Before (with "jammed" cursor):

![161212-01-snapshot](https://cloud.githubusercontent.com/assets/2641335/21089719/50904176-c032-11e6-9b12-3e6cf1a1eb23.png)

After:

![snapshot](https://cloud.githubusercontent.com/assets/2641335/21089727/5c520508-c032-11e6-965b-90174346e4f1.png)
