### PR TITLE
Add "swap" command option for marks.

### DIFF
--- a/content_scripts/marks.coffee
+++ b/content_scripts/marks.coffee
@@ -2,6 +2,7 @@
 Marks =
   previousPositionRegisters: [ "`", "'" ]
   localRegisters: {}
+  currentRegistryEntry: null
   mode: null
 
   exit: (continuation = null) ->
@@ -26,10 +27,14 @@ Marks =
   # If <Shift> is depressed, then it's a global mark, otherwise it's a local mark.  This is consistent
   # vim's [A-Z] for global marks and [a-z] for local marks.  However, it also admits other non-Latin
   # characters.  The exceptions are "`" and "'", which are always considered local marks.
+  # The "swap" command option inverts global and local marks.
   isGlobalMark: (event, keyChar) ->
-    event.shiftKey and keyChar not in @previousPositionRegisters
+    shiftKey = event.shiftKey
+    shiftKey = not shiftKey if @currentRegistryEntry.options.swap
+    shiftKey and keyChar not in @previousPositionRegisters
 
-  activateCreateMode: ->
+  activateCreateMode: (count, {registryEntry}) ->
+    @currentRegistryEntry = registryEntry
     @mode = new Mode
       name: "create-mark"
       indicator: "Create mark..."
@@ -52,7 +57,8 @@ Marks =
             localStorage[@getLocationKey keyChar] = @getMarkString()
             @showMessage "Created local mark", keyChar
 
-  activateGotoMode: ->
+  activateGotoMode: (count, {registryEntry}) ->
+    @currentRegistryEntry = registryEntry
     @mode = new Mode
       name: "goto-mark"
       indicator: "Go to mark..."


### PR DESCRIPTION
In a browser, I find global marks considerably more useful than local marks; for example, I use marks to quickly jump back to my email tab.

Unfortunately, inheriting vim's approach, global marks require capital letters, so the `<Shift>` key.

This PR implements:

    map m Marks.activateCreateMode swap
    map ' Marks.activateGotoMode swap

which inverts the `isGlobalMark()` test for the `<Shift>` key.

Edit: So, you can use lower-case letters for global marks, which is much more useful in practice. End edit.

Is the name `swap` the best one?  It could be `invert` instead, or perhaps there's something better.