### PR TITLE
Add match-about-blank permission.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -60,7 +60,8 @@
             ],
       "css": ["content_scripts/vimium.css"],
       "run_at": "document_start",
-      "all_frames": true
+      "all_frames": true,
+      "match_about_blank": true
     },
     {
       "matches": ["file:///", "file:///*/"],


### PR DESCRIPTION
This allows Vimium to run in iframes with `about:blank` URLs.

Fixes #2360.