### PR TITLE
LinkHints: focus select elements, and elements with nonnegative tabIndex

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -394,7 +394,7 @@ class LinkHintsMode
             clickActivator = (modifiers) -> (link) -> DomUtils.simulateClick link, modifiers
             linkActivator = @mode.linkActivator ? clickActivator @mode.clickModifiers
             # TODO: Are there any other input elements which should not receive focus?
-            if clickEl.nodeName.toLowerCase() in ["input", "select"] and clickEl.type not in ["button", "submit"]
+            if clickEl.nodeName.toLowerCase() in ["input", "select"] or clickEl.tabIndex >= 0
               clickEl.focus()
             linkActivator clickEl
 

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -398,7 +398,7 @@ class LinkHintsMode
             #     focus it to let user press space to activate the popup menu
             # <object> & <embed>: for Flash games which have their own key event handlers
             #     since we have been able to blur them by pressing `Escape` 
-            if clickEl.nodeName.toLowerCase() in ["input", "select", "object", "embed"] or clickEl.tabIndex >= 0
+            if clickEl.nodeName.toLowerCase() in ["input", "select", "object", "embed"]
               clickEl.focus()
             linkActivator clickEl
 

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -737,8 +737,8 @@ LocalHints =
     # Elements with tabindex are sometimes useful, but usually not. We can treat them as second class
     # citizens when it improves UX, so take special note of them.
     tabIndexValue = element.getAttribute("tabindex")
-    tabIndex = if tabIndexValue == "" then 0 else parseInt tabIndexValue
-    unless isClickable or isNaN(tabIndex) or tabIndex < 0
+    tabIndex = if tabIndexValue then parseInt tabIndexValue else -1
+    unless isClickable or tabIndex < 0 or isNaN(tabIndex)
       isClickable = onlyHasTabIndex = true
 
     if isClickable

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -393,7 +393,9 @@ class LinkHintsMode
           else
             clickActivator = (modifiers) -> (link) -> DomUtils.simulateClick link, modifiers
             linkActivator = @mode.linkActivator ? clickActivator @mode.clickModifiers
-            # TODO: Are there any other input elements which should not receive focus?
+            # Note(gdh1995): Here we should allow special elements to get focus,
+            # <select>: latest Chrome refuses `mousedown` event, and we can only
+            #     focus it to let user press space to activate the popup menu
             if clickEl.nodeName.toLowerCase() in ["input", "select"] or clickEl.tabIndex >= 0
               clickEl.focus()
             linkActivator clickEl

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -396,7 +396,9 @@ class LinkHintsMode
             # Note(gdh1995): Here we should allow special elements to get focus,
             # <select>: latest Chrome refuses `mousedown` event, and we can only
             #     focus it to let user press space to activate the popup menu
-            if clickEl.nodeName.toLowerCase() in ["input", "select"] or clickEl.tabIndex >= 0
+            # <object> & <embed>: for Flash games which have their own key event handlers
+            #     since we have been able to blur them by pressing `Escape` 
+            if clickEl.nodeName.toLowerCase() in ["input", "select", "object", "embed"] or clickEl.tabIndex >= 0
               clickEl.focus()
             linkActivator clickEl
 
@@ -702,6 +704,8 @@ LocalHints =
                              (element.readOnly and DomUtils.isSelectable element))
       when "button", "select"
         isClickable ||= not element.disabled
+      when "object", "embed"
+        isClickable = true
       when "label"
         isClickable ||= element.control? and not element.control.disabled and
                         (@getVisibleClickable element.control).length == 0


### PR DESCRIPTION
Selectable (and also editable) `<input>`s have been handled on L390,
so here we just need to focus `<input>`s of other types
    and those whose tabIndex is nonnegative.

This PR is a complement of #2338 , and changes have been beyond what #2378 needs.