### PR TITLE
InsertMode should not handle key events if document.body is editable

### DIFF
--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -10,6 +10,7 @@ class InsertMode extends Mode
 
     handleKeyEvent = (event) =>
       return @continueBubbling unless @isActive event
+      return @passEventToPage if @insertModeLock is document.body
 
       # Check for a pass-next-key key.
       if KeyboardUtils.getKeyCharString(event) in Settings.get "passNextKeyKeys"


### PR DESCRIPTION
For example, the host JavaScript may create an "about:blank" iframe with a `content-editable` `body`, and then:
* the parent frame may handle `Escape` key events by itself
* but now, Vimium always grabs `Escape` events
  * and tries to exit `InsertMode`
  * although `document.body` is still current `activeElement` after `body.blur()`
* as a result, neither the parent can receive and handle wanted keyevents,
  nor Vimium will succeed in returing back to NormalMode
