### PR TITLE
Guard against element.tagName not being a string.

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -626,7 +626,9 @@ LocalHints =
   # image), therefore we always return a array of element/rect pairs (which may also be a singleton or empty).
   #
   getVisibleClickable: (element) ->
-    tagName = element.tagName.toLowerCase()
+    # Get the tag name.  However, `element.tagName` can be an element (not a string, see #2305), so we guard
+    # against that.
+    tagName = element.tagName.toLowerCase?() ? ""
     isClickable = false
     onlyHasTabIndex = false
     possibleFalsePositive = false


### PR DESCRIPTION
Example page: http://codeforces.com/contest/752/problem/B; see #2035.

Here's what you get if you `console.log element.tagName`:

![snapshot](https://cloud.githubusercontent.com/assets/2641335/21476103/3eb9c4c2-cb2c-11e6-9068-2d95b13a10e7.png)


There, `element.tagName` is an element with `name` `tagName` (not a string).  Here, we guard against that case.

Fixes #2035.