### PR TITLE
Key mappings for Shift + [non-printable char key]

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -62,7 +62,7 @@ Commands =
   # We sort modifiers here to match the order used in keyboard_utils.coffee.
   # The return value is a sequence of keys: e.g. "<Space><c-A>b" -> ["<space>", "<c-A>", "b"].
   parseKeySequence: do ->
-    modifier = "(?:[acms]-)"                             # E.g. "a-", "c-", "m-".
+    modifier = "(?:[acms]-)"                            # E.g. "a-", "c-", "m-".
     namedKey = "(?:[a-z][a-z0-9]+)"                     # E.g. "left" or "f12" (always two characters or more).
     modifiedKey = "(?:#{modifier}+(?:.|#{namedKey}))"   # E.g. "c-*" or "c-left".
     specialKeyRegexp = new RegExp "^<(#{namedKey}|#{modifiedKey})>(.*)", "i"

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -62,7 +62,7 @@ Commands =
   # We sort modifiers here to match the order used in keyboard_utils.coffee.
   # The return value is a sequence of keys: e.g. "<Space><c-A>b" -> ["<space>", "<c-A>", "b"].
   parseKeySequence: do ->
-    modifier = "(?:[acm]-)"                             # E.g. "a-", "c-", "m-".
+    modifier = "(?:[acms]-)"                             # E.g. "a-", "c-", "m-".
     namedKey = "(?:[a-z][a-z0-9]+)"                     # E.g. "left" or "f12" (always two characters or more).
     modifiedKey = "(?:#{modifier}+(?:.|#{namedKey}))"   # E.g. "c-*" or "c-left".
     specialKeyRegexp = new RegExp "^<(#{namedKey}|#{modifiedKey})>(.*)", "i"

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -118,11 +118,12 @@ KeyboardUtils =
         if 1 < keyChar.length or (keyChar.length == 1 and (event.metaKey or event.ctrlKey or event.altKey)) or allKeydownEvents
           modifiers = []
 
-          keyChar = keyChar.toUpperCase() if event.shiftKey
+          keyChar = keyChar.toUpperCase() if event.shiftKey and keyChar.length == 1
           # These must be in alphabetical order (to match the sorted modifier order in Commands.normalizeKey).
           modifiers.push "a" if event.altKey
           modifiers.push "c" if event.ctrlKey
           modifiers.push "m" if event.metaKey
+          modifiers.push "s" if event.shiftKey and keyChar.length > 1
 
           keyChar = [modifiers..., keyChar].join "-"
           if 1 < keyChar.length then "<#{keyChar}>" else keyChar


### PR DESCRIPTION
Currently it is impossible to create a key mapping for combinations like `Shift + Left` or `Shift + F1`.

Proposed changes make it possible using `<s-left>` syntax.