### PR TITLE
use upper-case key names to represent shiftKey in <([acm]-)?.*> key mappings

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -66,13 +66,14 @@ Commands =
     namedKey = "(?:[a-z][a-z0-9]+)"                     # E.g. "left" or "f12" (always two characters or more).
     modifiedKey = "(?:#{modifier}+(?:.|#{namedKey}))"   # E.g. "c-*" or "c-left".
     specialKeyRegexp = new RegExp "^<(#{namedKey}|#{modifiedKey})>(.*)", "i"
+    lowerCaseRegexp = /[a-z]/
     (key) ->
       if key.length == 0
         []
       # Parse "<c-a>bcd" as "<c-a>" and "bcd".
       else if 0 == key.search specialKeyRegexp
         [modifiers..., keyChar] = RegExp.$1.split "-"
-        keyChar = keyChar.toLowerCase() unless keyChar.length == 1
+        keyChar = keyChar.toLowerCase() if keyChar.length > 1 and lowerCaseRegexp.test(keyChar)
         modifiers = (modifier.toLowerCase() for modifier in modifiers)
         modifiers.sort()
         ["<#{[modifiers..., keyChar].join '-'}>", @parseKeySequence(RegExp.$2)...]

--- a/tests/unit_tests/commands_test.coffee
+++ b/tests/unit_tests/commands_test.coffee
@@ -37,9 +37,10 @@ context "Key mappings",
   should "parse and normalize named keys", ->
     @testKeySequence "<space>", "<space>", 1
     @testKeySequence "<Space>", "<space>", 1
+    @testKeySequence "<SPACE>", "<SPACE>", 1
     @testKeySequence "<C-Space>", "<c-space>", 1
     @testKeySequence "<f12>", "<f12>", 1
-    @testKeySequence "<F12>", "<f12>", 1
+    @testKeySequence "<F12>", "<F12>", 1
 
   should "handle angle brackets which are part of not modifiers", ->
     @testKeySequence "<", "<", 1


### PR DESCRIPTION
This is another solution to #2388, and allows users to make such key mappings:
```
# press "Space"
map <space> scrollDown
# press "Shift+Space"
map <SPACE> scrollUp

# just treated as "<space>"
map <Space> scrollDown
```

The added logic is that if a `keyChar` (background_scripts/commands.coffee#L75) has only upper-case chars, then it means `Shift` should be pressed.

This does not influence most old mappings like `<Left>`, but will treat `<f1>` and `<F1>` differently.