### PR TITLE
Fix visual line mode line selection behavior

### DIFF
--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -879,6 +879,47 @@ context "Caret mode",
       sendKeyboardEvent key
       assert.equal "a", getSelection()
 
+context "Visual line mode",
+  setup ->
+    document.getElementById("test-div").innerHTML = """
+    <p><pre>
+      It is an ancient Mariner,
+      And he stoppeth one of three.
+      By thy long grey beard and glittering eye,
+      Now wherefore stopp'st thou me?
+    </pre></p>
+    """
+    initializeModeState()
+    @initialVisualMode = new VisualMode
+    # Enter visual line mode with the second line selected
+    sendKeyboardEvent "c"
+    sendKeyboardEvent "j"
+    sendKeyboardEvent "V"
+
+  tearDown ->
+    document.getElementById("test-div").innerHTML = ""
+
+  should "select lines with j and k", ->
+    assert.equal "  And he stoppeth one of three.", getSelection()
+    sendKeyboardEvent "j"
+    assert.equal "  And he stoppeth one of three.\n" +
+                 "  By thy long grey beard and glittering eye,", getSelection()
+    sendKeyboardEvent "k"
+    assert.equal "  And he stoppeth one of three.", getSelection()
+    sendKeyboardEvent "k"
+    assert.equal "  It is an ancient Mariner,\n" +
+                 "  And he stoppeth one of three.", getSelection()
+
+  should "select lines with j and k with a count", ->
+    assert.equal "  And he stoppeth one of three.", getSelection()
+    sendKeyboardEvent "2j"
+    assert.equal "  And he stoppeth one of three.\n" +
+                 "  By thy long grey beard and glittering eye,\n" +
+                 "  Now wherefore stopp'st thou me?", getSelection()
+    sendKeyboardEvent "3k"
+    assert.equal "  It is an ancient Mariner,\n" +
+                 "  And he stoppeth one of three.", getSelection()
+
 context "Visual mode",
   setup ->
     document.getElementById("test-div").innerHTML = """


### PR DESCRIPTION
The current line selection behavior in the visual line mode is not
the same as in vim, where we cannot select lines upwards.

Steps to reproduce:

- Press `v` and `c` to enter the caret mode.
- Press `k`.

This is because when only the base line (the line selected when we
enter the visual line mode) is selected, and its direction is different
from the direction of the command, that command will actually unselect
the base line.

Suppose we have the following page, and we enter the visual line mode from Line 3:

```
aaaaa
bbbbb
ccccc  <-- selected
ddddd
```

The current selection has `forward` direction. Now if we press `k`, the `commandHandler()` of the visual mode will be called, which executes a `backward line` command, unselecting the line. After that `extendSelection()` is called, Line 3 is selected again, but in fact the `k` command should reverse the direction of Line 3 and continue to select Line 2.

To fix this, when executing line selection commands, we check if the
base line is unselected. If so, we restore it and reverse its direction.

Test cases are added.