### PR TITLE
Show help dialog only after it has rendered

### DIFF
--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -16,6 +16,7 @@ HUD =
   init: ->
     @hudUI ?= new UIComponent "pages/hud.html", "vimiumHUDFrame", ({data}) => this[data.name]? data
     @tween ?= new Tween "iframe.vimiumHUDFrame.vimiumUIComponentVisible", @hudUI.shadowDOM
+    @hudUI.show()
 
   showForDuration: (text, duration) ->
     @show(text)

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -63,6 +63,7 @@ class UIComponent
                   setIframePort port1
                 when "setIframeFrameId" then @iframeFrameId = event.data.iframeFrameId
                 when "hide" then @hide()
+                when "show" then @show()
                 else @handleMessage event
 
   # Post a message (if provided), then call continuation (if provided).  We wait for documentReady() to ensure
@@ -74,9 +75,11 @@ class UIComponent
 
   activate: (@options = null) ->
     @postMessage @options, =>
-      @toggleIframeElementClasses "vimiumUIComponentHidden", "vimiumUIComponentVisible"
       @iframeElement.focus() if @options?.focus
-      @showing = true
+
+  show: ->
+    @showing = true
+    @toggleIframeElementClasses "vimiumUIComponentHidden", "vimiumUIComponentVisible"
 
   hide: (shouldRefocusOriginalFrame = true) ->
     # We post a non-message (null) to ensure that hide() requests cannot overtake activate() requests.

--- a/pages/help_dialog.coffee
+++ b/pages/help_dialog.coffee
@@ -87,6 +87,7 @@ HelpDialog =
                 HUD.showForDuration("Yanked #{commandNameElement.textContent}.", 2000)
 
       @showAdvancedCommands(@getShowAdvancedCommands())
+      UIComponentServer.show()
 
       # "Click" the dialog element (so that it becomes scrollable).
       DomUtils.simulateClick @dialogElement

--- a/pages/ui_component_server.coffee
+++ b/pages/ui_component_server.coffee
@@ -20,6 +20,7 @@ UIComponentServer =
 
   postMessage: (message) -> @ownerPagePort?.postMessage message
   hide: -> @postMessage "hide"
+  show: -> @postMessage "show"
 
   # We require both that the DOM is ready and that the port has been opened before the UI component is ready.
   # These events can happen in either order.  We count them, and notify the content script when we've seen

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -31,6 +31,7 @@ Vomnibar =
     @vomnibarUI.setQuery options.query
     @vomnibarUI.setKeyword options.keyword
     @vomnibarUI.update true
+    @vomnibarUI.show()
 
   hide: -> @vomnibarUI?.hide()
   onHidden: -> @vomnibarUI?.onHidden()
@@ -41,6 +42,7 @@ class VomnibarUI
     @onHiddenCallback = null
     @initDom()
 
+  show: -> UIComponentServer.show()
   setQuery: (query) -> @input.value = query
   setKeyword: (keyword) -> @customSearchMode = keyword
   setInitialSelectionValue: (@initialSelectionValue) ->


### PR DESCRIPTION
This change makes sure the help dialog is only shown after it has rendered. It gets rid of the flicker that is seen during the first load of the help dialog.

Addresses #2141 