### PR TITLE
Use event argument instead of global event object

### DIFF
--- a/content_scripts/scroller.coffee
+++ b/content_scripts/scroller.coffee
@@ -143,11 +143,11 @@ CoreScroller =
           @keyIsDown = true
           @time += 1 unless event.repeat
           @lastEvent = event
-      keyup: =>
+      keyup: (event) =>
         handlerStack.alwaysContinueBubbling =>
           @keyIsDown = false
           @time += 1
-      blur: =>
+      blur: (event) =>
         handlerStack.alwaysContinueBubbling =>
           @time += 1 if event.target == window
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -248,9 +248,9 @@ Frame =
         window.removeEventListener "focus", focusHandler
         window.removeEventListener "resize", resizeHandler
         Frame.postMessage "registerFrame"
-      window.addEventListener "focus", focusHandler = ->
+      window.addEventListener "focus", focusHandler = (event) ->
         postRegisterFrame() if event.target == window
-      window.addEventListener "resize", resizeHandler = ->
+      window.addEventListener "resize", resizeHandler = (event) ->
         postRegisterFrame() unless DomUtils.windowIsTooSmall()
 
   init: ->


### PR DESCRIPTION
Cherry-picked as suggested by @gdh1995.

This should have no effect in Chrome/Edge, but fixes errors for undefined `window.event` in Firefox.