### PR TITLE
Minor fix: Use the appropriate handler for hashChange

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -224,7 +224,7 @@ onFocus = (event) ->
 # We install these listeners directly (that is, we don't use installListener) because we still need to receive
 # events when Vimium is not enabled.
 window.addEventListener "focus", onFocus
-window.addEventListener "hashchange", onFocus
+window.addEventListener "hashchange", checkEnabledAfterURLChange
 
 initializeOnDomReady = ->
   # Tell the background page we're in the domReady state.


### PR DESCRIPTION
The `hashchange` event should recheck whether the URL is enabled with `checkEnabledAfterURLChange`, not `onFocus`, otherwise we falsely notify the background page/UI components of a change of frame.