### PR TITLE
Always use keydown and event.key (partial PDF-tab fix)

### DIFF
--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -33,9 +33,6 @@ class KeyHandlerMode extends Mode
       # We cannot track keyup events if we lose the focus.
       blur: (event) => @alwaysContinueBubbling => @keydownEvents = {} if event.target == window
 
-    @mapKeyRegistry = {}
-    Utils.monitorChromeStorage "mapKeyRegistry", (value) => @mapKeyRegistry = value
-
     if options.exitOnEscape
       # If we're part way through a command's key sequence, then a first Escape should reset the key state,
       # and only a second Escape should actually exit this mode.
@@ -50,7 +47,6 @@ class KeyHandlerMode extends Mode
 
   onKeydown: (event) ->
     keyChar = KeyboardUtils.getKeyCharString event
-    keyChar = @mapKeyRegistry[keyChar] ? keyChar
     isEscape = KeyboardUtils.isEscape event
     if isEscape and (@countPrefix != 0 or @keyState.length != 1)
       @keydownEvents[event.keyCode] = true
@@ -77,7 +73,6 @@ class KeyHandlerMode extends Mode
 
   onKeypress: (event) ->
     keyChar = KeyboardUtils.getKeyCharString event
-    keyChar = @mapKeyRegistry[keyChar] ? keyChar
     if @isMappedKey keyChar
       @handleKeyChar keyChar
     else if @isCountKey keyChar

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -1,3 +1,7 @@
+mapKeyRegistry = {}
+# NOTE: "?" here for the tests.
+Utils?.monitorChromeStorage "mapKeyRegistry", (value) => mapKeyRegistry = value
+
 KeyboardUtils =
   keyCodes:
     { ESC: 27, backspace: 8, deleteKey: 46, enter: 13, ctrlEnter: 10, space: 32, shiftKey: 16, ctrlKey: 17, f1: 112,
@@ -83,9 +87,6 @@ KeyboardUtils =
   isPrimaryModifierKey: (event) -> if (@platform == "Mac") then event.metaKey else event.ctrlKey
 
   isEscape: do ->
-    mapKeyRegistry = {}
-    # NOTE: "?" here for the tests.
-    Utils?.monitorChromeStorage "mapKeyRegistry", (value) => mapKeyRegistry = value
 
     # TODO(smblott) Change this to use event.key.
     (event) ->

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -91,8 +91,7 @@ KeyboardUtils =
     # TODO(smblott) Change this to use event.key.
     (event) ->
       event.keyCode == @keyCodes.ESC || do =>
-        keyChar = @getKeyCharString event, true
-        keyChar = mapKeyRegistry[keyChar] ? keyChar
+        keyChar = @getKeyCharString event
         # <c-[> is mapped to Escape in Vim by default.
         keyChar == "<c-[>"
 
@@ -109,7 +108,7 @@ KeyboardUtils =
 
   # Return the Vimium key representation for this keyboard event. Return a falsy value (the empty string or
   # undefined) when no Vimium representation is appropriate.
-  getKeyCharString: (event, allKeydownEvents = false) ->
+  getKeyCharString: (event) ->
     switch event.type
       when "keypress"
         # Ignore modifier keys by themselves.
@@ -117,19 +116,19 @@ KeyboardUtils =
           String.fromCharCode event.charCode
 
       when "keydown"
-        # Handle special keys and normal input keys with modifiers being pressed.
-        keyChar = @getKeyChar event
-        if 1 < keyChar.length or (keyChar.length == 1 and (event.metaKey or event.ctrlKey or event.altKey)) or allKeydownEvents
+        if keyChar = @getKeyChar event
           modifiers = []
 
-          keyChar = keyChar.toUpperCase() if event.shiftKey
+          keyChar = keyChar.toUpperCase() if event.shiftKey and keyChar.length == 1
           # These must be in alphabetical order (to match the sorted modifier order in Commands.normalizeKey).
           modifiers.push "a" if event.altKey
           modifiers.push "c" if event.ctrlKey
           modifiers.push "m" if event.metaKey
 
           keyChar = [modifiers..., keyChar].join "-"
-          if 1 < keyChar.length then "<#{keyChar}>" else keyChar
+          keyChar = "<#{keyChar}>" if 1 < keyChar.length
+          keyChar = mapKeyRegistry[keyChar] ? keyChar
+          keyChar
 
 KeyboardUtils.init()
 

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -115,6 +115,10 @@ KeyboardUtils =
         if 31 < event.keyCode
           String.fromCharCode event.charCode
 
+      # TODO(smblott). Currently all (almost?) keyhandling is being done on keydown.  All legacy code related
+      # to key handling on keypress should be reviewed and probably removed.  This is not being done right now
+      # (2017-03-22) because it is better to wait until we've verified that the change to keydown is indeed
+      # correct and reliable.
       when "keydown"
         if keyChar = @getKeyChar event
           modifiers = []


### PR DESCRIPTION
This moves all (almost) key handling to `keydown`, and uses `event.key`.

This fixes a number of inconsistencies and makes Vimium's background-page and Vomnibar commands work on PDF tabs.

There is a possibility that there could be unintended consequences for some non-Latin, non-QUERTY keyboards.

Fixes #1243 (partly).

I will:

- Try this myself for a bit.
- If that seems ok, then I'll merge this and we'll see if anybody else identifies issued.

It would be great to get the PDF-tab issue fixed.