### PR TITLE
Show line breaks for newlines in the options page (FF)

### DIFF
--- a/pages/options.css
+++ b/pages/options.css
@@ -115,7 +115,7 @@ input#scrollStepSize {
 textarea#userDefinedLinkHintCss, textarea#keyMappings, textarea#searchEngines {
   width: 100%;;
   min-height: 140px;
-  white-space: nowrap;
+  white-space: pre;
 }
 input#previousPatterns, input#nextPatterns {
   width: 100%;


### PR DESCRIPTION
In Firefox, `white-space: nowrap` causes `<textarea>`s to collapse newlines into horizontal whitespace, as described in [the spec](https://drafts.csswg.org/css-text-3/#propdef-white-space).

![screenshot from 2017-04-13 16-03-47](https://cloud.githubusercontent.com/assets/1847343/25010714/d6c7049c-2062-11e7-867d-9f564a7e31ae.png)

`white-space: pre` gives the intended behaviour (no wrapping line breaks) in Firefox and Chrome.
