### PR TITLE
Fix gF (mainFrame) command on Firefox

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -315,6 +315,9 @@ focusThisFrame = (request) ->
       chrome.runtime.sendMessage handler: "nextFrame"
       return
   window.focus()
+  # On Firefox, window.focus doesn't always draw focus back from a child frame (bug 554039).
+  # We blur the active element if it is an iframe, which gives the window back focus as intended.
+  document.activeElement.blur() if document.activeElement.tagName.toLowerCase() == "iframe"
   flashFrame() if request.highlight
 
 extend window,


### PR DESCRIPTION
This works around [FF issue 554039](https://bugzilla.mozilla.org/show_bug.cgi?id=554039), which prevents window.top.focus() from working in most cases.