### PR TITLE
Fix focus event handling within shadow DOM.

### DIFF
--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -70,11 +70,10 @@ class InsertMode extends Mode
 
           handlerStack.push
             _name: "shadow-DOM-input-mode"
-            blur: (event) ->
-              if event.target.shadowRoot == shadowRoot
-                handlerStack.remove()
-                for own type, listener of eventListeners
-                  shadowRoot.removeEventListener type, listener, true
+            blur: (event) => @alwaysContinueBubbling ->
+              handlerStack.remove()
+              for own type, listener of eventListeners
+                shadowRoot.removeEventListener type, listener, true
 
     # Only for tests.  This gives us a hook to test the status of the permanently-installed instance.
     InsertMode.permanentInstance = this if @permanent


### PR DESCRIPTION
Fixes #2504.

For some reason, the test removed here never fires.

However, it appears that *any* `blur` event has to result in an input
within the shadow DOM (which previously had the focus) losing the focus.
Therefore, we don't need this test.

Aside:

- This code is firing *twice*.  So, we add two handlers and remove two
  handlers each time.  This seems to be harmless.  I think what's
  happening is that we first see the event when it's bubbling down, so
  our newly-added handler on the shadow-DOM element fires again as the
  event continues bubbling down.