### PR TITLE
Update linear gradient syntax to avoid deprecation

### DIFF
--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -80,7 +80,7 @@ div.internalVimiumHintMarker {
   overflow: hidden;
   font-size: 11px;
   padding: 1px 3px 0px 3px;
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#FFF785), color-stop(100%,#FFC542));
+  background: linear-gradient(to bottom, #FFF785 0%,#FFC542 100%);
   border: solid 1px #C38A22;
   border-radius: 3px;
   box-shadow: 0px 3px 7px 0px rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
This updated syntax avoids the following deprecation warning in Chrome Canary v60.0.3090.0:
```
[Deprecation] -webkit-gradient is deprecated. Please use linear-gradient or radial-gradient instead.
```

This syntax is also supported in Firefox (and [all other modern browsers](https://caniuse.com/#feat=css-gradients)), which could help transitioning the Firefox version, which is in the works.