### PR TITLE
Change keyEventSuppressor to a handler

### DIFF
--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -140,10 +140,10 @@ class Mode
           if event.repeat
             handlerStack.suppressEvent
           else
-            keyEventSuppressor.exit()
+            @remove()
             handlerStack.continueBubbling
 
-        keyEventSuppressor = new Mode
+        handlerStack.push
           name: "suppress-trailing-key-events"
           keydown: handler
           keypress: handler


### PR DESCRIPTION
There's no need for `keyEventSuppressor` to be a `Mode`, since it doesn't use any of its mechanisms beyond being a handler. This is a no-op.