### PR TITLE
add options to make global InsertMode more compatible with other tools

### DIFF
--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -8,6 +8,8 @@ class InsertMode extends Mode
     # If truthy, then we were activated by the user (with "i").
     @global = options.global
 
+    @passExitKey = options.passExitKey
+
     handleKeyEvent = (event) =>
       return @continueBubbling unless @isActive event
       return @passEventToPage if @insertModeLock is document.body
@@ -26,6 +28,8 @@ class InsertMode extends Mode
         # An editable element in a shadow DOM is focused; blur it.
         @insertModeLock.blur()
       @exit event, event.target
+      if @passExitKey
+        return @passEventToPage
       DomUtils.consumeKeyup event
 
     defaults =

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -376,10 +376,10 @@ extend window,
       url = url[0..25] + "...." if 28 < url.length
       HUD.showForDuration("Yanked #{url}", 2000)
 
-  enterInsertMode: ->
+  enterInsertMode: (count, { registryEntry: { options } }) ->
     # If a focusable element receives the focus, then we exit and leave the permanently-installed insert-mode
     # instance to take over.
-    new InsertMode global: true, exitOnFocus: true
+    new InsertMode global: true, exitOnFocus: !options.ignoreFocusEvents, passExitKey: options.passExitKey
 
   enterVisualMode: ->
     new VisualMode userLaunchedMode: true


### PR DESCRIPTION
This should fix #2542 .

All options are off by default, so this PR doesn't change old behaviors of `enterInsertMode`.