### PR TITLE
Add command for copy the decoded current url

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -49,5 +49,6 @@ Contributors:
   Darryl Pogue <darryl@dpogue.ca> (github: dpogue)
   tobimensch
   Ramiro Araujo <rama.araujo@gmail.com> (github: ramiroaraujo)
+  Richard Li <aspirewit@gmail.com> (github: aspirewit)
 
 Feel free to add real names in addition to GitHub usernames.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Navigating the current page:
     gs      view source
     i       enter insert mode -- all commands will be ignored until you hit Esc to exit
     yy      copy the current url to the clipboard
+    yY      copy the decoded current url to the clipboard
     yf      copy a link url to the clipboard
     gf      cycle forward to the next frame
     gF      focus the main/top frame

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -148,6 +148,7 @@ Commands =
       "scrollToRight",
       "reload",
       "copyCurrentUrl",
+      "copyDecodedCurrentUrl",
       "openCopiedUrlInCurrentTab",
       "openCopiedUrlInNewTab",
       "goUp",
@@ -272,6 +273,7 @@ defaultKeyMappings =
   "]]": "goNext"
 
   "yy": "copyCurrentUrl"
+  "yY": "copyDecodedCurrentUrl"
 
   "p": "openCopiedUrlInCurrentTab"
   "P": "openCopiedUrlInNewTab"
@@ -337,6 +339,7 @@ commandDescriptions =
   toggleViewSource: ["View page source", { noRepeat: true }]
 
   copyCurrentUrl: ["Copy the current URL to the clipboard", { noRepeat: true }]
+  copyDecodedCurrentUrl: ["Copy the decoded current URL to the clipboard", { noRepeat: true }]
   openCopiedUrlInCurrentTab: ["Open the clipboard's URL in the current tab", { background: true, noRepeat: true }]
   openCopiedUrlInNewTab: ["Open the clipboard's URL in a new tab", { background: true, repeatLimit: 20 }]
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -367,14 +367,19 @@ extend window,
         url = "view-source:" + url
       chrome.runtime.sendMessage {handler: "openUrlInNewTab", url}
 
-  copyCurrentUrl: ->
+  copyCurrentUrl: (count, options) ->
     # TODO(ilya): When the following bug is fixed, revisit this approach of sending back to the background
     # page to copy.
     # http://code.google.com/p/chromium/issues/detail?id=55188
     chrome.runtime.sendMessage { handler: "getCurrentTabUrl" }, (url) ->
+      url = decodeURIComponent(url) if options.registryEntry.options.decoded
       chrome.runtime.sendMessage { handler: "copyToClipboard", data: url }
       url = url[0..25] + "...." if 28 < url.length
       HUD.showForDuration("Yanked #{url}", 2000)
+
+  copyDecodedCurrentUrl: (count, options) ->
+    options.registryEntry.options.decoded = true
+    copyCurrentUrl(count, options)
 
   enterInsertMode: ->
     # If a focusable element receives the focus, then we exit and leave the permanently-installed insert-mode


### PR DESCRIPTION
Command `yY` to yank (copy) the decoded current tab's url to the clipboard