### PR TITLE
findAndFollowLink(): look at title and id of links

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -595,9 +595,14 @@ findAndFollowLink = (linkStrings) ->
       continue
 
     linkMatches = false
-    for linkString in linkStrings
-      if link.innerText.toLowerCase().indexOf(linkString) != -1 ||
-          0 <= link.value?.indexOf? linkString
+    for LS in linkStrings
+      # NOTE: the "0 <= a.b?.c?..." clasues need to be wrapped in parens,
+      # as if they aren't and the "a.b?.c?..." evalutes to undefined then
+      # the clauses after the "||" don't get handled properly
+      if link.innerText.toLowerCase().indexOf(LS) != -1 ||
+          (0 <= link.value?.indexOf? LS) ||
+          (0 <= link.attributes.title?.value.toLowerCase().indexOf(LS)) ||
+          (0 <= link.attributes.id?.value.toLowerCase().indexOf(LS))
         linkMatches = true
         break
     continue unless linkMatches
@@ -630,7 +635,11 @@ findAndFollowLink = (linkStrings) ->
         new RegExp linkString, "i"
     for candidateLink in candidateLinks
       if exactWordRegex.test(candidateLink.innerText) ||
-          (candidateLink.value && exactWordRegex.test(candidateLink.value))
+          (candidateLink.value && exactWordRegex.test(candidateLink.value)) ||
+          (candidateLink.attributes.title &&
+            exactWordRegex.test(candidateLink.attributes.title.value)) ||
+          (candidateLink.attributes.id &&
+            exactWordRegex.test(candidateLink.attributes.id.value))
         followLink(candidateLink)
         return true
   false


### PR DESCRIPTION
This patch makes it so that the commands `goNext` and `goPrevious` (`]]` and `[[`) will also examine the value of each link's `title` attribute and `id` attribute (if they exist) for the desired patterns.  The use case for this is pages where the next/previous links are images without a `rel` attribute.  An example is the [*Girl Genius*](http://www.girlgeniusonline.com/comic.php?date=20021104#.WVhYunUrKHs) webcomic.

Here is the [patch as a diff](https://github.com/philc/vimium/files/1117646/diff.txt).

[Here is the output of `cake test`](https://github.com/philc/vimium/files/1117648/test.txt), though I don't think those are due to me.
