### PR TITLE
Simplify rectsOverlap

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -321,7 +321,7 @@ class LinkHintsMode
   rotateHints: do ->
     markerOverlapsStack = (marker, stack) ->
       for otherMarker in stack
-        return true if Rect.intersectsStrict marker.markerRect, otherMarker.markerRect
+        return true if Rect.intersects marker.markerRect, otherMarker.markerRect
       false
 
     ->

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -321,7 +321,7 @@ class LinkHintsMode
   rotateHints: do ->
     markerOverlapsStack = (marker, stack) ->
       for otherMarker in stack
-        return true if Rect.rectsOverlap marker.markerRect, otherMarker.markerRect
+        return true if Rect.intersectsStrict marker.markerRect, otherMarker.markerRect
       false
 
     ->

--- a/lib/rect.coffee
+++ b/lib/rect.coffee
@@ -83,13 +83,9 @@ Rect =
         (Math.min rect1.right, rect2.right), (Math.min rect1.bottom, rect2.bottom)
 
   # Determine whether two rects overlap.
-  rectsOverlap: do ->
-    halfOverlapChecker = (rect1, rect2) ->
-      (rect1.left <= rect2.left <= rect1.right or rect1.left <= rect2.right <= rect1.right) and
-        (rect1.top <= rect2.top <= rect1.bottom or rect1.top <= rect2.bottom <= rect1.bottom)
-
-    (rect1, rect2) ->
-      halfOverlapChecker(rect1, rect2) or halfOverlapChecker rect2, rect1
+  rectsOverlap: (rect1, rect2) ->
+    rect1.right >= rect2.left and rect1.left <= rect2.right and
+    rect1.bottom >= rect2.top and rect1.top <= rect2.bottom
 
 root = exports ? (window.root ?= {})
 root.Rect = Rect

--- a/lib/rect.coffee
+++ b/lib/rect.coffee
@@ -67,7 +67,8 @@ Rect =
 
     rects.filter (rect) -> rect.height > 0 and rect.width > 0
 
-  contains: (rect1, rect2) ->
+  # Determine whether two rects overlap.
+  intersects: (rect1, rect2) ->
     rect1.right > rect2.left and
     rect1.left < rect2.right and
     rect1.bottom > rect2.top and

--- a/lib/rect.coffee
+++ b/lib/rect.coffee
@@ -74,6 +74,11 @@ Rect =
     rect1.bottom > rect2.top and
     rect1.top < rect2.bottom
 
+  # Determine whether two rects overlap, including 0-width intersections at borders.
+  intersectsStrict: (rect1, rect2) ->
+    rect1.right >= rect2.left and rect1.left <= rect2.right and
+    rect1.bottom >= rect2.top and rect1.top <= rect2.bottom
+
   equals: (rect1, rect2) ->
     for property in ["top", "bottom", "left", "right", "width", "height"]
       return false if rect1[property] != rect2[property]
@@ -82,11 +87,6 @@ Rect =
   intersect: (rect1, rect2) ->
     @create (Math.max rect1.left, rect2.left), (Math.max rect1.top, rect2.top),
         (Math.min rect1.right, rect2.right), (Math.min rect1.bottom, rect2.bottom)
-
-  # Determine whether two rects overlap.
-  rectsOverlap: (rect1, rect2) ->
-    rect1.right >= rect2.left and rect1.left <= rect2.right and
-    rect1.bottom >= rect2.top and rect1.top <= rect2.bottom
 
 root = exports ? (window.root ?= {})
 root.Rect = Rect

--- a/tests/unit_tests/rect_test.coffee
+++ b/tests/unit_tests/rect_test.coffee
@@ -234,55 +234,55 @@ context "Rect subtraction",
 context "Rect overlaps",
   should "detect that a rect overlaps itself", ->
     rect = Rect.create 2, 2, 4, 4
-    assert.isTrue Rect.rectsOverlap rect, rect
+    assert.isTrue Rect.intersectsStrict rect, rect
 
   should "detect that non-overlapping rectangles do not overlap on the left", ->
     rect1 = Rect.create 2, 2, 4, 4
     rect2 = Rect.create 0, 2, 1, 4
-    assert.isFalse Rect.rectsOverlap rect1, rect2
+    assert.isFalse Rect.intersectsStrict rect1, rect2
 
   should "detect that non-overlapping rectangles do not overlap on the right", ->
     rect1 = Rect.create 2, 2, 4, 4
     rect2 = Rect.create 5, 2, 6, 4
-    assert.isFalse Rect.rectsOverlap rect1, rect2
+    assert.isFalse Rect.intersectsStrict rect1, rect2
 
   should "detect that non-overlapping rectangles do not overlap on the top", ->
     rect1 = Rect.create 2, 2, 4, 4
     rect2 = Rect.create 2, 0, 2, 1
-    assert.isFalse Rect.rectsOverlap rect1, rect2
+    assert.isFalse Rect.intersectsStrict rect1, rect2
 
   should "detect that non-overlapping rectangles do not overlap on the bottom", ->
     rect1 = Rect.create 2, 2, 4, 4
     rect2 = Rect.create 2, 5, 2, 6
-    assert.isFalse Rect.rectsOverlap rect1, rect2
+    assert.isFalse Rect.intersectsStrict rect1, rect2
 
   should "detect overlapping rectangles on the left", ->
     rect1 = Rect.create 2, 2, 4, 4
     rect2 = Rect.create 0, 2, 2, 4
-    assert.isTrue Rect.rectsOverlap rect1, rect2
+    assert.isTrue Rect.intersectsStrict rect1, rect2
 
   should "detect overlapping rectangles on the right", ->
     rect1 = Rect.create 2, 2, 4, 4
     rect2 = Rect.create 4, 2, 5, 4
-    assert.isTrue Rect.rectsOverlap rect1, rect2
+    assert.isTrue Rect.intersectsStrict rect1, rect2
 
   should "detect overlapping rectangles on the top", ->
     rect1 = Rect.create 2, 2, 4, 4
     rect2 = Rect.create 2, 4, 4, 5
-    assert.isTrue Rect.rectsOverlap rect1, rect2
+    assert.isTrue Rect.intersectsStrict rect1, rect2
 
   should "detect overlapping rectangles on the bottom", ->
     rect1 = Rect.create 2, 2, 4, 4
     rect2 = Rect.create 2, 0, 4, 2
-    assert.isTrue Rect.rectsOverlap rect1, rect2
+    assert.isTrue Rect.intersectsStrict rect1, rect2
 
   should "detect overlapping rectangles when second rectangle is contained in first", ->
     rect1 = Rect.create 1, 1, 4, 4
     rect2 = Rect.create 2, 2, 3, 3
-    assert.isTrue Rect.rectsOverlap rect1, rect2
+    assert.isTrue Rect.intersectsStrict rect1, rect2
 
   should "detect overlapping rectangles when first rectangle is contained in second", ->
     rect1 = Rect.create 1, 1, 4, 4
     rect2 = Rect.create 2, 2, 3, 3
-    assert.isTrue Rect.rectsOverlap rect2, rect1
+    assert.isTrue Rect.intersectsStrict rect2, rect1
 

--- a/tests/unit_tests/rect_test.coffee
+++ b/tests/unit_tests/rect_test.coffee
@@ -201,7 +201,7 @@ context "Rect subtraction",
             subtractRect = Rect.create x, y, (x + width), (y + height)
             resultRects = Rect.subtract rect, subtractRect
             for resultRect in resultRects
-              assert.isFalse Rect.contains subtractRect, resultRect
+              assert.isFalse Rect.intersects subtractRect, resultRect
 
   should "be contained in original rect", ->
     rect = Rect.create 0, 0, 3, 3
@@ -212,7 +212,7 @@ context "Rect subtraction",
             subtractRect = Rect.create x, y, (x + width), (y + height)
             resultRects = Rect.subtract rect, subtractRect
             for resultRect in resultRects
-              assert.isTrue Rect.contains rect, resultRect
+              assert.isTrue Rect.intersects rect, resultRect
 
   should "contain the  subtracted rect in the original minus the results", ->
     rect = Rect.create 0, 0, 3, 3
@@ -229,7 +229,7 @@ context "Rect subtraction",
             assert.isTrue (resultComplement.length == 0 or resultComplement.length == 1)
             if resultComplement.length == 1
               complementRect = resultComplement[0]
-              assert.isTrue Rect.contains subtractRect, complementRect
+              assert.isTrue Rect.intersects subtractRect, complementRect
 
 context "Rect overlaps",
   should "detect that a rect overlaps itself", ->


### PR DESCRIPTION
This PR does several things (each its own commit):
* Simplifies the definition of `Rect.rectsOverlap` to 4 comparisons (the old one used 16).
* Rename `Rect.contains` to `Rect.intersects`
  - since `Rect.contains` is almost identical to (the reduced) `Rect.rectsOverlap`, poor naming must have motivated creating `Rect.rectsOverlap`
  - add a comment (actually the comment accompanying `Rect.rectsOverlap`) to make it more discoverable
* Rename `Rect.rectsOverlap` to `Rect.intersectsStrict`
  - I don't like the name `rectOverlaps`, and `intersectsStrict` gives a clearer impression of what it's doing and how it relates to `intersects`
  - change the comment to reflect that it considers boundary-only intersections (which `intersects` does not)
* Use `Rect.intersects` instead of `Rect.intersectsStrict` at the sole use-point
  - We don't care about boundary intersections in this situation, and so it is wasteful to consider them.

This should have no user-visible impact.