### PR TITLE
[WIP] Faster link hints with caching

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -627,7 +627,8 @@ class RenderCache
     cssStyles[property] ?= @getComputedStyle(element).getPropertyValue property
 
   inViewport: (element) ->
-    DomUtils.inViewport @getBoundingClientRect element
+    Rect.rectsOverlap (@getBoundingClientRect element),
+      {left: 0, right: window.innerWidth, top: 0, bottom: window.innerHeight}
 
   _getComputedStyle: (element) -> window.getComputedStyle element, null
   _getClientRects: (element) -> element.getClientRects()

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -617,7 +617,9 @@ class RenderCache
     # Bind functions for cached getters.
     @getClientRects = cachedGet.bind(this, @_getClientRects.bind(this), new WeakMap())
     @getVisibleClientRect = cachedGet.bind(this, @_getVisibleClientRect.bind(this), new WeakMap())
+    @getComputedStyle = cachedGet.bind(this, @_getComputedStyle.bind(this), new WeakMap())
 
+  _getComputedStyle: (element) -> window.getComputedStyle element, null
   _getClientRects: (element) -> element.getClientRects()
 
   _getVisibleClientRect: (element) ->
@@ -627,7 +629,7 @@ class RenderCache
     # Inline elements with font-size: 0px; will declare a height of zero, even if a child with non-zero
     # font-size contains text.
     isInlineZeroHeight = ->
-      elementComputedStyle = window.getComputedStyle element, null
+      elementComputedStyle = @getComputedStyle element
       isInlineZeroFontSize = (0 == elementComputedStyle.getPropertyValue("display").indexOf "inline") and
         (elementComputedStyle.getPropertyValue("font-size") == "0px")
       # Override the function to return this value for the rest of this context.
@@ -638,7 +640,7 @@ class RenderCache
       # If the link has zero dimensions, it may be wrapping visible but floated elements. Check for this.
       if clientRect.width == 0 or clientRect.height == 0
         for child in element.children
-          computedStyle = window.getComputedStyle(child, null)
+          computedStyle = @getComputedStyle child
           # Ignore child elements which are not floated and not absolutely positioned for parent elements
           # with zero width/height, as long as the case described at isInlineZeroHeight does not apply.
           # NOTE(mrmr1993): This ignores floated/absolutely positioned descendants nested within inline
@@ -657,7 +659,7 @@ class RenderCache
         continue if clientRect == null or clientRect.width < 3 or clientRect.height < 3
 
         # eliminate invisible elements (see test_harnesses/visibility_test.html)
-        computedStyle = window.getComputedStyle(element, null)
+        computedStyle = @getComputedStyle element
         continue if computedStyle.getPropertyValue('visibility') != 'visible'
 
         return clientRect

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -622,6 +622,7 @@ class RenderCache
     @getVisibleClientRect = cachedGet.bind(this, @getVisibleClientRect, new WeakMap())
     @isInlineZeroHeight = cachedGet.bind(this, @isInlineZeroHeight, new WeakMap())
     @ariaHiddenOrDisabled = cachedGet.bind(this, @ariaHiddenOrDisabled, new WeakMap())
+    @hasButtonClass = cachedGet.bind(this, @hasButtonClass, new WeakMap())
     @hasClickableTabIndex = cachedGet.bind(this, @hasClickableTabIndex, new WeakMap())
 
   getCssStyle: (element, property) ->
@@ -694,6 +695,9 @@ class RenderCache
     else
       element.getAttribute("aria-hidden")?.toLowerCase() in ["", "true"] or
       element.getAttribute("aria-disabled")?.toLowerCase() in ["", "true"]
+
+  hasButtonClass: (element) ->
+    0 <= element.getAttribute("class")?.toLowerCase().indexOf "button"
 
   hasClickableTabIndex: (element) ->
     tabIndexValue = element.getAttribute "tabindex"
@@ -827,7 +831,7 @@ LocalHints =
     # An element with a class name containing the text "button" might be clickable.  However, real clickables
     # are often wrapped in elements with such class names.  So, when we find clickables based only on their
     # class name, we mark them as unreliable.
-    if not isClickable and 0 <= element.getAttribute("class")?.toLowerCase().indexOf "button"
+    if not isClickable and renderCache.hasButtonClass element
       possibleFalsePositive = isClickable = true
 
     # Elements with tabindex are sometimes useful, but usually not. We can treat them as second class

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -624,6 +624,8 @@ LocalHints =
     possibleFalsePositive = false
     visibleElements = []
     reason = null
+    imgClientRects = []
+    imgMap = null
 
     # Insert area elements that provide click functionality to an img.
     if tagName == "img"
@@ -631,9 +633,9 @@ LocalHints =
       if mapName
         imgClientRects = element.getClientRects()
         mapName = mapName.replace(/^#/, "").replace("\"", "\\\"")
-        map = document.querySelector "map[name=\"#{mapName}\"]"
-        if map and imgClientRects.length > 0
-          areas = map.getElementsByTagName "area"
+        imgMap = document.querySelector "map[name=\"#{mapName}\"]"
+        if imgMap and imgClientRects.length > 0
+          areas = imgMap.getElementsByTagName "area"
           areasAndRects = DomUtils.getClientRectsForAreas imgClientRects[0], areas
           visibleElements.push areasAndRects...
 

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -637,9 +637,6 @@ class RenderCache
     isInlineZeroHeight = =>
       isInlineZeroFontSize = (0 == @getCssStyle(element, "display").indexOf "inline") and
         (@getCssStyle(element, "font-size") == "0px")
-      # Override the function to return this value for the rest of this context.
-      isInlineZeroHeight = -> isInlineZeroFontSize
-      isInlineZeroFontSize
 
     for clientRect in clientRects
       # If the link has zero dimensions, it may be wrapping visible but floated elements. Check for this.

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -615,14 +615,21 @@ LocalHints =
 
     return isClickable unless clickableProps
 
-    {imgClientRects, imgMap} = clickableProps
+    visibleElements = []
+
+    {imgClientRects, imgMap, secondClassCitizen, possibleFalsePositive, reason} = clickableProps
     isClickable.shift() unless clickableProps.element? # Remove placeholder if we added one
     if imgMap and imgClientRects.length > 0
       areas = imgMap.getElementsByTagName "area"
       areasAndRects = DomUtils.getClientRectsForAreas imgClientRects[0], areas
-      isClickable = areasAndRects.append isClickable
+      visibleElements.push areasAndRects...
 
-    isClickable
+    if clickableProps.isClickable
+      clientRect = DomUtils.getVisibleClientRect element, true
+      if clientRect != null
+        visibleElements.push {element, rect: clientRect, secondClassCitizen, possibleFalsePositive, reason}
+
+    visibleElements
 
   #
   # Determine whether the element is clickable.
@@ -735,14 +742,9 @@ LocalHints =
     unless isClickable or isNaN(tabIndex) or tabIndex < 0
       isClickable = onlyHasTabIndex = true
 
-    if isClickable
-      clientRect = DomUtils.getVisibleClientRect element, true
-      if clientRect != null
-        visibleElements.push {element: element, rect: clientRect, secondClassCitizen: onlyHasTabIndex,
-          possibleFalsePositive, reason}
-
-    clickableProps = visibleElements[0] ? {}
-    extend clickableProps, {imgClientRects, imgMap}
+    if isClickable or imgMap
+      visibleElements.push {isClickable, element, secondClassCitizen: onlyHasTabIndex, possibleFalsePositive,
+        reason, imgClientRects, imgMap}
 
     visibleElements
 

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -322,7 +322,7 @@ class LinkHintsMode
   rotateHints: do ->
     markerOverlapsStack = (marker, stack) ->
       for otherMarker in stack
-        return true if Rect.intersectsStrict marker.markerRect, otherMarker.markerRect
+        return true if Rect.intersects marker.markerRect, otherMarker.markerRect
       false
 
     ->

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -698,13 +698,9 @@ LocalHints =
     clickableProps = @isClickable element, renderCache
     return [] unless clickableProps
 
-    visibleElements = []
 
     {imgClientRects, imgMap, secondClassCitizen, possibleFalsePositive, reason} = clickableProps
-    if imgMap and imgClientRects.length > 0
-      areas = imgMap.getElementsByTagName "area"
-      areasAndRects = DomUtils.getClientRectsForAreas imgClientRects[0], areas
-      visibleElements.push areasAndRects...
+    visibleElements = @getImageAreaRects element, imgMap, imgClientRects
 
     if clickableProps.isClickable
       clientRect = renderCache.getVisibleClientRect element
@@ -712,6 +708,13 @@ LocalHints =
         visibleElements.push {element, rect: clientRect, secondClassCitizen, possibleFalsePositive, reason}
 
     visibleElements
+
+  getImageAreaRects: (element, imgMap, imgClientRects) ->
+    if imgMap and imgClientRects.length > 0
+      areas = imgMap.getElementsByTagName "area"
+      DomUtils.getClientRectsForAreas imgClientRects[0], areas
+    else
+      []
 
   #
   # Determine whether the element is clickable. Returns false when an element is not clickable, or a dict

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -699,8 +699,8 @@ LocalHints =
     return [] unless clickableProps
 
 
-    {imgClientRects, imgMap, secondClassCitizen, possibleFalsePositive, reason} = clickableProps
-    visibleElements = @getImageAreaRects element, imgMap, imgClientRects
+    {imgMap, secondClassCitizen, possibleFalsePositive, reason} = clickableProps
+    visibleElements = @getImageAreaRects element, imgMap
 
     if clickableProps.isClickable
       clientRect = renderCache.getVisibleClientRect element
@@ -709,7 +709,8 @@ LocalHints =
 
     visibleElements
 
-  getImageAreaRects: (element, imgMap, imgClientRects) ->
+  getImageAreaRects: (element, imgMap) ->
+    imgClientRects = element.getClientRects()
     if imgMap and imgClientRects.length > 0
       areas = imgMap.getElementsByTagName "area"
       DomUtils.getClientRectsForAreas imgClientRects[0], areas
@@ -728,14 +729,12 @@ LocalHints =
     onlyHasTabIndex = false
     possibleFalsePositive = false
     reason = null
-    imgClientRects = []
     imgMap = null
 
     # Insert area elements that provide click functionality to an img.
     if tagName == "img"
       mapName = element.getAttribute "usemap"
       if mapName
-        imgClientRects = element.getClientRects()
         mapName = mapName.replace(/^#/, "").replace("\"", "\\\"")
         imgMap = document.querySelector "map[name=\"#{mapName}\"]"
 
@@ -828,8 +827,7 @@ LocalHints =
       isClickable = onlyHasTabIndex = true
 
     if isClickable or imgMap
-      {isClickable, element, secondClassCitizen: onlyHasTabIndex, possibleFalsePositive, reason,
-        imgClientRects, imgMap}
+      {isClickable, element, secondClassCitizen: onlyHasTabIndex, possibleFalsePositive, reason, imgMap}
     else
       false
 

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -322,7 +322,7 @@ class LinkHintsMode
   rotateHints: do ->
     markerOverlapsStack = (marker, stack) ->
       for otherMarker in stack
-        return true if Rect.rectsOverlap marker.markerRect, otherMarker.markerRect
+        return true if Rect.intersectsStrict marker.markerRect, otherMarker.markerRect
       false
 
     ->
@@ -628,7 +628,7 @@ class RenderCache
     cssStyles[property] ?= @getComputedStyle(element).getPropertyValue property
 
   inViewport: (element) ->
-    Rect.rectsOverlap (@getBoundingClientRect element),
+    Rect.intersectsStrict (@getBoundingClientRect element),
       {left: 0, right: window.innerWidth, top: 0, bottom: window.innerHeight}
 
   _getComputedStyle: (element) -> window.getComputedStyle element, null

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -642,19 +642,8 @@ class RenderCache
     for clientRect in clientRects
       # If the link has zero dimensions, it may be wrapping visible but floated elements. Check for this.
       if clientRect.width == 0 or clientRect.height == 0
-        for child in element.children
-          # Ignore child elements which are not floated and not absolutely positioned for parent elements
-          # with zero width/height, as long as the case described at isInlineZeroHeight does not apply.
-          # NOTE(mrmr1993): This ignores floated/absolutely positioned descendants nested within inline
-          # children.
-          continue if (@getCssStyle(child, "float") == "none" and
-            not (@getCssStyle(child, "position") in ["absolute", "fixed"]) and
-            not (clientRect.height == 0 and @isInlineZeroHeight(element) and
-              0 == @getCssStyle(child, "display").indexOf "inline"))
-          childClientRect = @getVisibleClientRect child
-          continue if childClientRect == null or childClientRect.width < 3 or childClientRect.height < 3
-          return childClientRect
-
+        childRect = @zeroDimensionHasVisibleChildren element, clientRect
+        return childRect if childRect?
       else
         clientRect = DomUtils.cropRectToVisible clientRect
 
@@ -672,6 +661,20 @@ class RenderCache
   _isInlineZeroHeight: (element) ->
     (0 == @getCssStyle(element, "display").indexOf "inline") and
       (@getCssStyle(element, "font-size") == "0px")
+
+  zeroDimensionHasVisibleChildren: (element, clientRect) ->
+    for child in element.children
+      # Ignore child elements which are not floated and not absolutely positioned for parent elements with
+      # zero width/height, as long as the case described at isInlineZeroHeight does not apply.
+      # NOTE(mrmr1993): This ignores floated/absolutely positioned descendants nested within inline children.
+      continue if (@getCssStyle(child, "float") == "none" and
+        not (@getCssStyle(child, "position") in ["absolute", "fixed"]) and
+        not (clientRect.height == 0 and @isInlineZeroHeight(element) and
+          0 == @getCssStyle(child, "display").indexOf "inline"))
+      childClientRect = @getVisibleClientRect child
+      continue if childClientRect == null or childClientRect.width < 3 or childClientRect.height < 3
+      return childClientRect
+    null
 
 
 LocalHints =

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -709,8 +709,6 @@ LocalHints =
     visibleElements
 
   getImageAreaRects: (element) ->
-    imgMap = null
-
     # Insert area elements that provide click functionality to an img.
     if element.tagName.toLowerCase?() == "img"
       mapName = element.getAttribute "usemap"
@@ -718,12 +716,11 @@ LocalHints =
         mapName = mapName.replace(/^#/, "").replace("\"", "\\\"")
         imgMap = document.querySelector "map[name=\"#{mapName}\"]"
 
-    imgClientRects = element.getClientRects()
-    if imgMap and imgClientRects.length > 0
-      areas = imgMap.getElementsByTagName "area"
-      DomUtils.getClientRectsForAreas imgClientRects[0], areas
-    else
-      []
+        imgClientRects = element.getClientRects()
+        if imgMap and imgClientRects.length > 0
+          areas = imgMap.getElementsByTagName "area"
+          return DomUtils.getClientRectsForAreas imgClientRects[0], areas
+    []
 
   #
   # Determine whether the element is clickable. Returns false when an element is not clickable, or a dict

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -616,13 +616,13 @@ class RenderCache
     @cssStyles = new WeakMap()
 
     # Bind functions for cached getters.
-    @getComputedStyle = cachedGet.bind(this, @_getComputedStyle, new WeakMap())
-    @getClientRects = cachedGet.bind(this, @_getClientRects, new WeakMap())
-    @getBoundingClientRect = cachedGet.bind(this, @_getBoundingClientRect, new WeakMap())
-    @getVisibleClientRect = cachedGet.bind(this, @_getVisibleClientRect, new WeakMap())
-    @isInlineZeroHeight = cachedGet.bind(this, @_isInlineZeroHeight, new WeakMap())
-    @ariaHiddenOrDisabled = cachedGet.bind(this, @_ariaHiddenOrDisabled, new WeakMap())
-    @hasClickableTabIndex = cachedGet.bind(this, @_hasClickableTabIndex, new WeakMap())
+    @getComputedStyle = cachedGet.bind(this, @getComputedStyle, new WeakMap())
+    @getClientRects = cachedGet.bind(this, @getClientRects, new WeakMap())
+    @getBoundingClientRect = cachedGet.bind(this, @getBoundingClientRect, new WeakMap())
+    @getVisibleClientRect = cachedGet.bind(this, @getVisibleClientRect, new WeakMap())
+    @isInlineZeroHeight = cachedGet.bind(this, @isInlineZeroHeight, new WeakMap())
+    @ariaHiddenOrDisabled = cachedGet.bind(this, @ariaHiddenOrDisabled, new WeakMap())
+    @hasClickableTabIndex = cachedGet.bind(this, @hasClickableTabIndex, new WeakMap())
 
   getCssStyle: (element, property) ->
     cssStyles = cachedGet (-> {}), @cssStyles, element
@@ -632,11 +632,11 @@ class RenderCache
     Rect.intersectsStrict (@getBoundingClientRect element),
       {left: 0, right: window.innerWidth, top: 0, bottom: window.innerHeight}
 
-  _getComputedStyle: (element) -> window.getComputedStyle element, null
-  _getClientRects: (element) -> element.getClientRects()
-  _getBoundingClientRect: (element) -> element.getBoundingClientRect()
+  getComputedStyle: (element) -> window.getComputedStyle element, null
+  getClientRects: (element) -> element.getClientRects()
+  getBoundingClientRect: (element) -> element.getBoundingClientRect()
 
-  _getVisibleClientRect: (element) ->
+  getVisibleClientRect: (element) ->
     boundingClientRect = @getBoundingClientRect element
 
     if boundingClientRect.width == 0 or boundingClientRect.height == 0
@@ -669,7 +669,7 @@ class RenderCache
 
   # Inline elements with font-size: 0px; will declare a height of zero, even if a child with non-zero
   # font-size contains text.
-  _isInlineZeroHeight: (element) ->
+  isInlineZeroHeight: (element) ->
     (0 == @getCssStyle(element, "display").indexOf "inline") and
       (@getCssStyle(element, "font-size") == "0px")
 
@@ -688,14 +688,14 @@ class RenderCache
       return childClientRect
     null
 
-  _ariaHiddenOrDisabled: (element) ->
+  ariaHiddenOrDisabled: (element) ->
     if element.parentElement? and @ariaHiddenOrDisabled element.parentElement
       true
     else
       element.getAttribute("aria-hidden")?.toLowerCase() in ["", "true"] or
       element.getAttribute("aria-disabled")?.toLowerCase() in ["", "true"]
 
-  _hasClickableTabIndex: (element) ->
+  hasClickableTabIndex: (element) ->
     tabIndexValue = element.getAttribute "tabindex"
     if tabIndexValue == ""
       true

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -604,7 +604,7 @@ spanWrap = (hintString) ->
     innerHTML.push("<span class='vimiumReset'>" + char + "</span>")
   innerHTML.join("")
 
-cachedGet = (key, getter, cache) ->
+cachedGet = (getter, cache, key) ->
   unless cache.has key
     cache.set key, getter key
   cache.get key
@@ -614,17 +614,9 @@ class RenderCache
   visibleClientRectCache: null
   clientRectsCache: null
   constructor: ->
-    @visibleClientRectCache = new WeakMap()
-    @clientRectsCache = new WeakMap()
-
-  getClientRects: (element) ->
-    cachedGet element,
-      @_getClientRects.bind(this),
-      @clientRectsCache
-  getVisibleClientRect: (element) ->
-    cachedGet element,
-      @_getVisibleClientRect.bind(this),
-      @visibleClientRectCache
+    # Bind functions for cached getters.
+    @getClientRects = cachedGet.bind(this, @_getClientRects.bind(this), new WeakMap())
+    @getVisibleClientRect = cachedGet.bind(this, @_getVisibleClientRect.bind(this), new WeakMap())
 
   _getClientRects: (element) -> element.getClientRects()
 

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -604,9 +604,10 @@ spanWrap = (hintString) ->
     innerHTML.push("<span class='vimiumReset'>" + char + "</span>")
   innerHTML.join("")
 
-cachedGet = (getter, cache, key) ->
+cachedGet = (getter, cache, args...) ->
+  [key] = args
   unless cache.has key
-    cache.set key, getter key
+    cache.set key, getter.apply this, args
   cache.get key
 
 
@@ -615,9 +616,9 @@ class RenderCache
   clientRectsCache: null
   constructor: ->
     # Bind functions for cached getters.
-    @getClientRects = cachedGet.bind(this, @_getClientRects.bind(this), new WeakMap())
-    @getVisibleClientRect = cachedGet.bind(this, @_getVisibleClientRect.bind(this), new WeakMap())
-    @getComputedStyle = cachedGet.bind(this, @_getComputedStyle.bind(this), new WeakMap())
+    @getClientRects = cachedGet.bind(this, @_getClientRects, new WeakMap())
+    @getVisibleClientRect = cachedGet.bind(this, @_getVisibleClientRect, new WeakMap())
+    @getComputedStyle = cachedGet.bind(this, @_getComputedStyle, new WeakMap())
 
   _getComputedStyle: (element) -> window.getComputedStyle element, null
   _getClientRects: (element) -> element.getClientRects()

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -617,16 +617,21 @@ class RenderCache
     @cssStyles = new WeakMap()
 
     # Bind functions for cached getters.
-    @getClientRects = cachedGet.bind(this, @_getClientRects, new WeakMap())
-    @getVisibleClientRect = cachedGet.bind(this, @_getVisibleClientRect, new WeakMap())
     @getComputedStyle = cachedGet.bind(this, @_getComputedStyle, new WeakMap())
+    @getClientRects = cachedGet.bind(this, @_getClientRects, new WeakMap())
+    @getBoundingClientRect = cachedGet.bind(this, @_getBoundingClientRect, new WeakMap())
+    @getVisibleClientRect = cachedGet.bind(this, @_getVisibleClientRect, new WeakMap())
 
   getCssStyle: (element, property) ->
     cssStyles = cachedGet (-> {}), @cssStyles, element
     cssStyles[property] ?= @getComputedStyle(element).getPropertyValue property
 
+  inViewport: (element) ->
+    DomUtils.inViewport @getBoundingClientRect element
+
   _getComputedStyle: (element) -> window.getComputedStyle element, null
   _getClientRects: (element) -> element.getClientRects()
+  _getBoundingClientRect: (element) -> element.getBoundingClientRect()
 
   _getVisibleClientRect: (element) ->
     # Note: this call will be expensive if we modify the DOM in between calls.
@@ -829,7 +834,7 @@ LocalHints =
     # NOTE(mrmr1993): Our previous method (combined XPath and DOM traversal for jsaction) couldn't provide
     # this, so it's necessary to check whether elements are clickable in order, as we do below.
     for element in elements
-      unless requireHref and not element.href
+      unless (requireHref and not element.href) or not renderCache.inViewport element
         visibleElement = @getVisibleClickable element, renderCache
         visibleElements.push visibleElement...
 

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -610,7 +610,12 @@ LocalHints =
   # the viewport.  There may be more than one part of element which is clickable (for example, if it's an
   # image), therefore we always return a array of element/rect pairs (which may also be a singleton or empty).
   #
-  getVisibleClickable: (element) ->
+  getVisibleClickable: (element) -> @isClickable element
+
+  #
+  # Determine whether the element is clickable.
+  #
+  isClickable: (element) ->
     # Get the tag name.  However, `element.tagName` can be an element (not a string, see #2305), so we guard
     # against that.
     tagName = element.tagName.toLowerCase?() ? ""

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -697,9 +697,10 @@ class RenderCache
 
   _hasClickableTabIndex: (element) ->
     tabIndexValue = element.getAttribute "tabindex"
-    tabIndex = if tabIndexValue == "" then 0 else parseInt tabIndexValue
-    unless isNaN(tabIndex) or tabIndex < 0
+    if tabIndexValue == ""
       true
+    else
+      parseInt(tabIndexValue) >= 0
 
 LocalHints =
   #

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -610,7 +610,49 @@ class RenderCache
     @visibleClientRectCache = new WeakMap()
 
   _getVisibleClientRect: (element) ->
-    DomUtils.getVisibleClientRect element, true
+    # Note: this call will be expensive if we modify the DOM in between calls.
+    clientRects = (Rect.copy clientRect for clientRect in element.getClientRects())
+
+    # Inline elements with font-size: 0px; will declare a height of zero, even if a child with non-zero
+    # font-size contains text.
+    isInlineZeroHeight = ->
+      elementComputedStyle = window.getComputedStyle element, null
+      isInlineZeroFontSize = (0 == elementComputedStyle.getPropertyValue("display").indexOf "inline") and
+        (elementComputedStyle.getPropertyValue("font-size") == "0px")
+      # Override the function to return this value for the rest of this context.
+      isInlineZeroHeight = -> isInlineZeroFontSize
+      isInlineZeroFontSize
+
+    for clientRect in clientRects
+      # If the link has zero dimensions, it may be wrapping visible but floated elements. Check for this.
+      if clientRect.width == 0 or clientRect.height == 0
+        for child in element.children
+          computedStyle = window.getComputedStyle(child, null)
+          # Ignore child elements which are not floated and not absolutely positioned for parent elements
+          # with zero width/height, as long as the case described at isInlineZeroHeight does not apply.
+          # NOTE(mrmr1993): This ignores floated/absolutely positioned descendants nested within inline
+          # children.
+          continue if (computedStyle.getPropertyValue("float") == "none" and
+            not (computedStyle.getPropertyValue("position") in ["absolute", "fixed"]) and
+            not (clientRect.height == 0 and isInlineZeroHeight() and
+              0 == computedStyle.getPropertyValue("display").indexOf "inline"))
+          childClientRect = @getVisibleClientRect child
+          continue if childClientRect == null or childClientRect.width < 3 or childClientRect.height < 3
+          return childClientRect
+
+      else
+        clientRect = DomUtils.cropRectToVisible clientRect
+
+        continue if clientRect == null or clientRect.width < 3 or clientRect.height < 3
+
+        # eliminate invisible elements (see test_harnesses/visibility_test.html)
+        computedStyle = window.getComputedStyle(element, null)
+        continue if computedStyle.getPropertyValue('visibility') != 'visible'
+
+        return clientRect
+
+    null
+
   getVisibleClientRect: (element) ->
     unless @visibleClientRectCache.has element
       @visibleClientRectCache.set element, @_getVisibleClientRect element

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -622,6 +622,7 @@ class RenderCache
     @getVisibleClientRect = cachedGet.bind(this, @_getVisibleClientRect, new WeakMap())
     @isInlineZeroHeight = cachedGet.bind(this, @_isInlineZeroHeight, new WeakMap())
     @ariaHiddenOrDisabled = cachedGet.bind(this, @_ariaHiddenOrDisabled, new WeakMap())
+    @hasClickableTabIndex = cachedGet.bind(this, @_hasClickableTabIndex, new WeakMap())
 
   getCssStyle: (element, property) ->
     cssStyles = cachedGet (-> {}), @cssStyles, element
@@ -693,6 +694,12 @@ class RenderCache
     else
       element.getAttribute("aria-hidden")?.toLowerCase() in ["", "true"] or
       element.getAttribute("aria-disabled")?.toLowerCase() in ["", "true"]
+
+  _hasClickableTabIndex: (element) ->
+    tabIndexValue = element.getAttribute "tabindex"
+    tabIndex = if tabIndexValue == "" then 0 else parseInt tabIndexValue
+    unless isNaN(tabIndex) or tabIndex < 0
+      true
 
 LocalHints =
   #
@@ -824,9 +831,7 @@ LocalHints =
 
     # Elements with tabindex are sometimes useful, but usually not. We can treat them as second class
     # citizens when it improves UX, so take special note of them.
-    tabIndexValue = element.getAttribute("tabindex")
-    tabIndex = if tabIndexValue == "" then 0 else parseInt tabIndexValue
-    unless isClickable or isNaN(tabIndex) or tabIndex < 0
+    if not isClickable and renderCache.hasClickableTabIndex element
       isClickable = onlyHasTabIndex = true
 
     if isClickable

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -694,7 +694,7 @@ LocalHints =
   # image), therefore we always return a array of element/rect pairs (which may also be a singleton or empty).
   #
   getVisibleClickable: (element, renderCache) ->
-    visibleElements = @getImageAreaRects element
+    visibleElements = @getImageAreaRects element, renderCache
     clickableProps = @isClickable element, renderCache
     return visibleElements unless clickableProps
 
@@ -708,7 +708,7 @@ LocalHints =
 
     visibleElements
 
-  getImageAreaRects: (element) ->
+  getImageAreaRects: (element, renderCache) ->
     # Insert area elements that provide click functionality to an img.
     if element.tagName.toLowerCase?() == "img"
       mapName = element.getAttribute "usemap"
@@ -716,10 +716,10 @@ LocalHints =
         mapName = mapName.replace(/^#/, "").replace("\"", "\\\"")
         imgMap = document.querySelector "map[name=\"#{mapName}\"]"
 
-        imgClientRects = element.getClientRects()
-        if imgMap and imgClientRects.length > 0
+        imgClientRects = renderCache.getBoundingClientRect element
+        if imgMap and imgClientRects.height > 0
           areas = imgMap.getElementsByTagName "area"
-          return DomUtils.getClientRectsForAreas imgClientRects[0], areas
+          return DomUtils.getClientRectsForAreas imgClientRects, areas
     []
 
   #

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -621,6 +621,7 @@ class RenderCache
     @getBoundingClientRect = cachedGet.bind(this, @_getBoundingClientRect, new WeakMap())
     @getVisibleClientRect = cachedGet.bind(this, @_getVisibleClientRect, new WeakMap())
     @isInlineZeroHeight = cachedGet.bind(this, @_isInlineZeroHeight, new WeakMap())
+    @ariaHiddenOrDisabled = cachedGet.bind(this, @_ariaHiddenOrDisabled, new WeakMap())
 
   getCssStyle: (element, property) ->
     cssStyles = cachedGet (-> {}), @cssStyles, element
@@ -686,6 +687,12 @@ class RenderCache
       return childClientRect
     null
 
+  _ariaHiddenOrDisabled: (element) ->
+    if element.parentElement? and @ariaHiddenOrDisabled element.parentElement
+      true
+    else
+      element.getAttribute("aria-hidden")?.toLowerCase() in ["", "true"] or
+      element.getAttribute("aria-disabled")?.toLowerCase() in ["", "true"]
 
 LocalHints =
   #
@@ -736,8 +743,7 @@ LocalHints =
     reason = null
 
     # Check aria properties to see if the element should be ignored.
-    if (element.getAttribute("aria-hidden")?.toLowerCase() in ["", "true"] or
-        element.getAttribute("aria-disabled")?.toLowerCase() in ["", "true"])
+    if renderCache.ariaHiddenOrDisabled element
       return false # This element should never have a link hint.
 
     # Check for AngularJS listeners on the element.

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -147,6 +147,12 @@ DomUtils =
     else
       boundedRect
 
+  inViewport: (rect) ->
+    rect.bottom > 0 and
+    rect.right > 0 and
+    rect.left < window.innerWidth and
+    rect.top < window.innerHeight
+
   #
   # Get the client rects for the <area> elements in a <map> based on the position of the <img> element using
   # the map. Returns an array of rects.

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -147,12 +147,6 @@ DomUtils =
     else
       boundedRect
 
-  inViewport: (rect) ->
-    rect.bottom > 0 and
-    rect.right > 0 and
-    rect.left < window.innerWidth and
-    rect.top < window.innerHeight
-
   #
   # Get the client rects for the <area> elements in a <map> based on the position of the <img> element using
   # the map. Returns an array of rects.

--- a/lib/rect.coffee
+++ b/lib/rect.coffee
@@ -74,6 +74,11 @@ Rect =
     rect1.bottom > rect2.top and
     rect1.top < rect2.bottom
 
+  # Determine whether two rects overlap, including 0-width intersections at borders.
+  intersectsStrict: (rect1, rect2) ->
+    rect1.right >= rect2.left and rect1.left <= rect2.right and
+    rect1.bottom >= rect2.top and rect1.top <= rect2.bottom
+
   equals: (rect1, rect2) ->
     for property in ["top", "bottom", "left", "right", "width", "height"]
       return false if rect1[property] != rect2[property]
@@ -82,11 +87,6 @@ Rect =
   intersect: (rect1, rect2) ->
     @create (Math.max rect1.left, rect2.left), (Math.max rect1.top, rect2.top),
         (Math.min rect1.right, rect2.right), (Math.min rect1.bottom, rect2.bottom)
-
-  # Determine whether two rects overlap.
-  rectsOverlap: (rect1, rect2) ->
-    rect1.right >= rect2.left and rect1.left <= rect2.right and
-    rect1.bottom >= rect2.top and rect1.top <= rect2.bottom
 
 root = exports ? window
 root.Rect = Rect

--- a/lib/rect.coffee
+++ b/lib/rect.coffee
@@ -67,7 +67,8 @@ Rect =
 
     rects.filter (rect) -> rect.height > 0 and rect.width > 0
 
-  contains: (rect1, rect2) ->
+  # Determine whether two rects overlap.
+  intersects: (rect1, rect2) ->
     rect1.right > rect2.left and
     rect1.left < rect2.right and
     rect1.bottom > rect2.top and

--- a/lib/rect.coffee
+++ b/lib/rect.coffee
@@ -67,6 +67,13 @@ Rect =
 
     rects.filter (rect) -> rect.height > 0 and rect.width > 0
 
+  # Determine whether rect1 contains (ie. completely covers) rect2.
+  contains: (rect1, rect2) ->
+    rect1.left <= rect2.left and
+    rect1.right >= rect2.right and
+    rect1.top <= rect2.top and
+    rect1.bottom >= rect2.bottom
+
   # Determine whether two rects overlap.
   intersects: (rect1, rect2) ->
     rect1.right > rect2.left and

--- a/lib/rect.coffee
+++ b/lib/rect.coffee
@@ -83,13 +83,9 @@ Rect =
         (Math.min rect1.right, rect2.right), (Math.min rect1.bottom, rect2.bottom)
 
   # Determine whether two rects overlap.
-  rectsOverlap: do ->
-    halfOverlapChecker = (rect1, rect2) ->
-      (rect1.left <= rect2.left <= rect1.right or rect1.left <= rect2.right <= rect1.right) and
-        (rect1.top <= rect2.top <= rect1.bottom or rect1.top <= rect2.bottom <= rect1.bottom)
-
-    (rect1, rect2) ->
-      halfOverlapChecker(rect1, rect2) or halfOverlapChecker rect2, rect1
+  rectsOverlap: (rect1, rect2) ->
+    rect1.right >= rect2.left and rect1.left <= rect2.right and
+    rect1.bottom >= rect2.top and rect1.top <= rect2.bottom
 
 root = exports ? window
 root.Rect = Rect

--- a/tests/dom_tests/dom_tests.html
+++ b/tests/dom_tests/dom_tests.html
@@ -29,6 +29,7 @@
     <link rel="stylesheet" type="text/css" href="../../content_scripts/vimium.css" />
     <script type="text/javascript" src="bind.js"></script>
     <script type="text/javascript" src="chrome.js"></script>
+    <script type="text/javascript" src="weakmap.js"></script>
     <script type="text/javascript" src="../../lib/utils.js"></script>
     <script type="text/javascript" src="../../lib/keyboard_utils.js"></script>
     <script type="text/javascript" src="../../lib/dom_utils.js"></script>

--- a/tests/dom_tests/weakmap.js
+++ b/tests/dom_tests/weakmap.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012 The Polymer Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
+if (typeof WeakMap === 'undefined') {
+  (function() {
+    var defineProperty = Object.defineProperty;
+    var counter = Date.now() % 1e9;
+
+    var WeakMap = function() {
+      this.name = '__st' + (Math.random() * 1e9 >>> 0) + (counter++ + '__');
+    };
+
+    WeakMap.prototype = {
+      set: function(key, value) {
+        var entry = key[this.name];
+        if (entry && entry[0] === key)
+          entry[1] = value;
+        else
+          defineProperty(key, this.name, {value: [key, value], writable: true});
+        return this;
+      },
+      get: function(key) {
+        var entry;
+        return (entry = key[this.name]) && entry[0] === key ?
+            entry[1] : undefined;
+      },
+      delete: function(key) {
+        var entry = key[this.name];
+        if (!entry) return false;
+        var hasValue = entry[0] === key;
+        entry[0] = entry[1] = undefined;
+        return hasValue;
+      },
+      has: function(key) {
+        var entry = key[this.name];
+        if (!entry) return false;
+        return entry[0] === key;
+      }
+    };
+
+    window.WeakMap = WeakMap;
+  })();
+}

--- a/tests/unit_tests/rect_test.coffee
+++ b/tests/unit_tests/rect_test.coffee
@@ -234,55 +234,55 @@ context "Rect subtraction",
 context "Rect overlaps",
   should "detect that a rect overlaps itself", ->
     rect = Rect.create 2, 2, 4, 4
-    assert.isTrue Rect.rectsOverlap rect, rect
+    assert.isTrue Rect.intersectsStrict rect, rect
 
   should "detect that non-overlapping rectangles do not overlap on the left", ->
     rect1 = Rect.create 2, 2, 4, 4
     rect2 = Rect.create 0, 2, 1, 4
-    assert.isFalse Rect.rectsOverlap rect1, rect2
+    assert.isFalse Rect.intersectsStrict rect1, rect2
 
   should "detect that non-overlapping rectangles do not overlap on the right", ->
     rect1 = Rect.create 2, 2, 4, 4
     rect2 = Rect.create 5, 2, 6, 4
-    assert.isFalse Rect.rectsOverlap rect1, rect2
+    assert.isFalse Rect.intersectsStrict rect1, rect2
 
   should "detect that non-overlapping rectangles do not overlap on the top", ->
     rect1 = Rect.create 2, 2, 4, 4
     rect2 = Rect.create 2, 0, 2, 1
-    assert.isFalse Rect.rectsOverlap rect1, rect2
+    assert.isFalse Rect.intersectsStrict rect1, rect2
 
   should "detect that non-overlapping rectangles do not overlap on the bottom", ->
     rect1 = Rect.create 2, 2, 4, 4
     rect2 = Rect.create 2, 5, 2, 6
-    assert.isFalse Rect.rectsOverlap rect1, rect2
+    assert.isFalse Rect.intersectsStrict rect1, rect2
 
   should "detect overlapping rectangles on the left", ->
     rect1 = Rect.create 2, 2, 4, 4
     rect2 = Rect.create 0, 2, 2, 4
-    assert.isTrue Rect.rectsOverlap rect1, rect2
+    assert.isTrue Rect.intersectsStrict rect1, rect2
 
   should "detect overlapping rectangles on the right", ->
     rect1 = Rect.create 2, 2, 4, 4
     rect2 = Rect.create 4, 2, 5, 4
-    assert.isTrue Rect.rectsOverlap rect1, rect2
+    assert.isTrue Rect.intersectsStrict rect1, rect2
 
   should "detect overlapping rectangles on the top", ->
     rect1 = Rect.create 2, 2, 4, 4
     rect2 = Rect.create 2, 4, 4, 5
-    assert.isTrue Rect.rectsOverlap rect1, rect2
+    assert.isTrue Rect.intersectsStrict rect1, rect2
 
   should "detect overlapping rectangles on the bottom", ->
     rect1 = Rect.create 2, 2, 4, 4
     rect2 = Rect.create 2, 0, 4, 2
-    assert.isTrue Rect.rectsOverlap rect1, rect2
+    assert.isTrue Rect.intersectsStrict rect1, rect2
 
   should "detect overlapping rectangles when second rectangle is contained in first", ->
     rect1 = Rect.create 1, 1, 4, 4
     rect2 = Rect.create 2, 2, 3, 3
-    assert.isTrue Rect.rectsOverlap rect1, rect2
+    assert.isTrue Rect.intersectsStrict rect1, rect2
 
   should "detect overlapping rectangles when first rectangle is contained in second", ->
     rect1 = Rect.create 1, 1, 4, 4
     rect2 = Rect.create 2, 2, 3, 3
-    assert.isTrue Rect.rectsOverlap rect2, rect1
+    assert.isTrue Rect.intersectsStrict rect2, rect1
 

--- a/tests/unit_tests/rect_test.coffee
+++ b/tests/unit_tests/rect_test.coffee
@@ -201,7 +201,7 @@ context "Rect subtraction",
             subtractRect = Rect.create x, y, (x + width), (y + height)
             resultRects = Rect.subtract rect, subtractRect
             for resultRect in resultRects
-              assert.isFalse Rect.contains subtractRect, resultRect
+              assert.isFalse Rect.intersects subtractRect, resultRect
 
   should "be contained in original rect", ->
     rect = Rect.create 0, 0, 3, 3
@@ -212,7 +212,7 @@ context "Rect subtraction",
             subtractRect = Rect.create x, y, (x + width), (y + height)
             resultRects = Rect.subtract rect, subtractRect
             for resultRect in resultRects
-              assert.isTrue Rect.contains rect, resultRect
+              assert.isTrue Rect.intersects rect, resultRect
 
   should "contain the  subtracted rect in the original minus the results", ->
     rect = Rect.create 0, 0, 3, 3
@@ -229,7 +229,7 @@ context "Rect subtraction",
             assert.isTrue (resultComplement.length == 0 or resultComplement.length == 1)
             if resultComplement.length == 1
               complementRect = resultComplement[0]
-              assert.isTrue Rect.contains subtractRect, complementRect
+              assert.isTrue Rect.intersects subtractRect, complementRect
 
 context "Rect overlaps",
   should "detect that a rect overlaps itself", ->


### PR DESCRIPTION
This PR aims to use caching (and essentially a full-page render) to squeeze some more performance out of link hints. I don't think it's ready for production yet, but my motivation has waned; hopefully this gets some ideas and code out there for addressing #2489.

Things I still want to get done are:
- [ ] restructure the multiple different `WeakMap`s into per-element caches
- [ ] clip elements that are partially or totally outside an `overflow: scroll`/`hidden` ancestor
  * [ ] possibly put this behind an option, so we can disable it for default on Firefox (for better performance)
- [ ] profile `WeakMap` vs `Object` with `undefined` tests, tweak the code to prefer the winner
- [ ] try to detect overlapping elements intelligently as we build the cache, rather than naively at the end
  * [ ] look for overlaps hierarchically, rather than in a flat list of rects at the end
  * [ ] integrate `z-index` comparisons into overlap code
  * [ ] consider overlaps with elements that don't generate hints too
- [ ] improve false positives/duplicate hints (fixing e.g. the non-Chromium-bug part of #2545)
- [ ] make `zeroDimensionHasVisibleChildren` use the calculated `containingElement`s
  * this will probably be easiest to do as part of a rewritten overlap detection loop

So far, none of the commits here have changed user-facing behaviour (except 8b974c4: 1-pixel overlap between two hints no longer qualifies them for reordering with <kbd>space</kbd>), and I've kept them as simple and atomic as I could.

NB: This PR includes the commits from #2558.