### PR TITLE
Enable Firefox clipboard commands

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -340,8 +340,8 @@ commandDescriptions =
   toggleViewSource: ["View page source", { noRepeat: true }]
 
   copyCurrentUrl: ["Copy the current URL to the clipboard", { noRepeat: true }]
-  openCopiedUrlInCurrentTab: ["Open the clipboard's URL in the current tab", { background: true, noRepeat: true }]
-  openCopiedUrlInNewTab: ["Open the clipboard's URL in a new tab", { background: true, repeatLimit: 20 }]
+  openCopiedUrlInCurrentTab: ["Open the clipboard's URL in the current tab", { noRepeat: true }]
+  openCopiedUrlInNewTab: ["Open the clipboard's URL in a new tab", { repeatLimit: 20 }]
 
   enterInsertMode: ["Enter insert mode", { noRepeat: true }]
   passNextKey: ["Pass the next key to the page"]

--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -90,10 +90,14 @@ HUD =
   # * we don't want to disrupt the focus in the page, in case the page is listening for focus/blur events.
   # * the HUD shouldn't be active for this frame while any of the copy/paste commands are running.
   copyToClipboard: (text) ->
-    @hudUI.postMessage {name: "copyToClipboard", data: text}
+    DomUtils.documentComplete =>
+      @init()
+      @hudUI?.postMessage {name: "copyToClipboard", data: text}
 
   pasteFromClipboard: (@pasteListener) ->
-    @hudUI.postMessage {name: "pasteFromClipboard"}
+    DomUtils.documentComplete =>
+      @init()
+      @hudUI?.postMessage {name: "pasteFromClipboard"}
 
   pasteResponse: ({data}) ->
     @pasteListener data

--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -9,6 +9,8 @@ HUD =
   findMode: null
   abandon: -> @hudUI?.hide false
 
+  pasteListener: null # Set by @pasteFromClipboard to handle the value returned by pasteResponse
+
   # This HUD is styled to precisely mimick the chrome HUD on Mac. Use the "has_popup_and_link_hud.html"
   # test harness to tweak these styles to match Chrome's. One limitation of our HUD display is that
   # it doesn't sit on top of horizontal scrollbars like Chrome's HUD does.
@@ -81,6 +83,20 @@ HUD =
 
     @findMode.exit()
     postExit?()
+
+  # These commands manage copying and pasting from the clipboard in the HUD frame.
+  # NOTE(mrmr1993): We need this to copy and paste on Firefox:
+  # * an element can't be focused in the background page, so copying/pasting doesn't work
+  # * we don't want to disrupt the focus in the page, in case the page is listening for focus/blur events.
+  # * the HUD shouldn't be active for this frame while any of the copy/paste commands are running.
+  copyToClipboard: (text) ->
+    @hudUI.postMessage {name: "copyToClipboard", data: text}
+
+  pasteFromClipboard: (@pasteListener) ->
+    @hudUI.postMessage {name: "pasteFromClipboard"}
+
+  pasteResponse: ({data}) ->
+    @pasteListener data
 
 class Tween
   opacity: 0

--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -97,10 +97,19 @@ HUD =
   pasteFromClipboard: (@pasteListener) ->
     DomUtils.documentComplete =>
       @init()
-      @hudUI?.postMessage {name: "pasteFromClipboard"}
+      # Show the HUD frame, so Firefox will actually perform the paste.
+      @hudUI.toggleIframeElementClasses "vimiumUIComponentHidden", "vimiumUIComponentVisible"
+      @tween.fade 0, 0
+      @hudUI.postMessage {name: "pasteFromClipboard"}
 
   pasteResponse: ({data}) ->
+    # Hide the HUD frame again.
+    @hudUI.toggleIframeElementClasses "vimiumUIComponentVisible", "vimiumUIComponentHidden"
+    @unfocusIfFocused()
     @pasteListener data
+
+  unfocusIfFocused: ->
+    document.activeElement.blur() if document.activeElement == @hudUI?.iframeElement
 
 class Tween
   opacity: 0

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -31,7 +31,7 @@ COPY_LINK_URL =
   indicator: "Copy link URL to Clipboard"
   linkActivator: (link) ->
     if link.href?
-      chrome.runtime.sendMessage handler: "copyToClipboard", data: link.href
+      HUD.copyToClipboard link.href
       url = link.href
       url = url[0..25] + "...." if 28 < url.length
       HUD.showForDuration "Yanked #{url}", 2000

--- a/content_scripts/mode_normal.coffee
+++ b/content_scripts/mode_normal.coffee
@@ -91,7 +91,7 @@ NormalModeCommands =
 
   copyCurrentUrl: ->
     chrome.runtime.sendMessage { handler: "getCurrentTabUrl" }, (url) ->
-      chrome.runtime.sendMessage { handler: "copyToClipboard", data: url }
+      HUD.copyToClipboard url
       url = url[0..25] + "...." if 28 < url.length
       HUD.showForDuration("Yanked #{url}", 2000)
 

--- a/content_scripts/mode_normal.coffee
+++ b/content_scripts/mode_normal.coffee
@@ -95,6 +95,15 @@ NormalModeCommands =
       url = url[0..25] + "...." if 28 < url.length
       HUD.showForDuration("Yanked #{url}", 2000)
 
+  openCopiedUrlInNewTab: (count) ->
+    HUD.pasteFromClipboard (url) ->
+      for i in [0...count] by 1
+        chrome.runtime.sendMessage { handler: "openUrlInNewTab", url }
+
+  openCopiedUrlInCurrentTab: ->
+    HUD.pasteFromClipboard (url) ->
+      chrome.runtime.sendMessage { handler: "openUrlInCurrentTab", url }
+
   # Mode changes.
   enterInsertMode: ->
     # If a focusable element receives the focus, then we exit and leave the permanently-installed insert-mode

--- a/content_scripts/mode_visual.coffee
+++ b/content_scripts/mode_visual.coffee
@@ -312,7 +312,7 @@ class VisualMode extends KeyHandlerMode
   yank: (args = {}) ->
     @yankedText = @selection.toString()
     @exit()
-    chrome.runtime.sendMessage handler: "copyToClipboard", data: @yankedText
+    HUD.copyToClipboard @yankedText
 
     message = @yankedText.replace /\s+/g, " "
     message = message[...12] + "..." if 15 < @yankedText.length

--- a/lib/clipboard.coffee
+++ b/lib/clipboard.coffee
@@ -3,6 +3,7 @@ Clipboard =
     textArea = document.createElement "textarea"
     textArea.style.position = "absolute"
     textArea.style.left = "-100%"
+    textArea.contentEditable = "true"
     textArea
 
   # http://groups.google.com/group/chromium-extensions/browse_thread/thread/49027e7f3b04f68/f6ab2457dee5bf55

--- a/lib/clipboard.coffee
+++ b/lib/clipboard.coffee
@@ -1,6 +1,6 @@
 Clipboard =
-  _createTextArea: ->
-    textArea = document.createElement "textarea"
+  _createTextArea: (tagName = "textarea") ->
+    textArea = document.createElement tagName
     textArea.style.position = "absolute"
     textArea.style.left = "-100%"
     textArea.contentEditable = "true"
@@ -17,11 +17,11 @@ Clipboard =
     document.body.removeChild(textArea)
 
   paste: ->
-    textArea = @_createTextArea()
+    textArea = @_createTextArea "div" # Use a <div> so Firefox pastes rich text.
     document.body.appendChild(textArea)
     textArea.focus()
     document.execCommand("Paste")
-    value = textArea.value
+    value = textArea.innerText
     document.body.removeChild(textArea)
     value
 

--- a/manifest.json
+++ b/manifest.json
@@ -32,6 +32,7 @@
     "bookmarks",
     "history",
     "clipboardRead",
+    "clipboardWrite",
     "storage",
     "sessions",
     "notifications",

--- a/pages/help_dialog.coffee
+++ b/pages/help_dialog.coffee
@@ -83,7 +83,7 @@ HelpDialog =
               commandNameElement.textContent = command.command
               commandNameElement.title = "Click to copy \"#{command.command}\" to clipboard."
               commandNameElement.addEventListener "click", ->
-                chrome.runtime.sendMessage handler: "copyToClipboard", data: commandNameElement.textContent
+                HUD.copyToClipboard commandNameElement.textContent
                 HUD.showForDuration("Yanked #{commandNameElement.textContent}.", 2000)
 
       @showAdvancedCommands(@getShowAdvancedCommands())

--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -100,6 +100,7 @@ handlers =
     Clipboard.copy data
     focusedElement?.focus()
     window.parent.focus()
+    UIComponentServer.postMessage {name: "unfocusIfFocused", data}
 
   pasteFromClipboard: ->
     focusedElement = document.activeElement

--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -95,5 +95,16 @@ handlers =
       " (No matches)"
     countElement.textContent = if showMatchText then countText else ""
 
+  copyToClipboard: (data) ->
+    focusedElement = document.activeElement
+    Clipboard.copy data
+    focusedElement?.focus()
+
+  pasteFromClipboard: ->
+    focusedElement = document.activeElement
+    data = Clipboard.paste()
+    focusedElement?.focus()
+    UIComponentServer.postMessage {name: "pasteResponse", data}
+
 UIComponentServer.registerHandler ({data}) -> handlers[data.name ? data]? data
 FindModeHistory.init()

--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -99,11 +99,13 @@ handlers =
     focusedElement = document.activeElement
     Clipboard.copy data
     focusedElement?.focus()
+    window.parent.focus()
 
   pasteFromClipboard: ->
     focusedElement = document.activeElement
     data = Clipboard.paste()
     focusedElement?.focus()
+    window.parent.focus()
     UIComponentServer.postMessage {name: "pasteResponse", data}
 
 UIComponentServer.registerHandler ({data}) -> handlers[data.name ? data]? data

--- a/pages/hud.html
+++ b/pages/hud.html
@@ -7,6 +7,7 @@
     <script type="text/javascript" src="../lib/settings.js"></script>
     <script type="text/javascript" src="../lib/keyboard_utils.js"></script>
     <script type="text/javascript" src="../lib/find_mode_history.js"></script>
+    <script type="text/javascript" src="../lib/clipboard.js"></script>
     <script type="text/javascript" src="ui_component_server.js"></script>
     <script type="text/javascript" src="hud.js"></script>
   </head>


### PR DESCRIPTION
This replaces #2524.

* Copying from the clipboard works in both Chrome and Firefox.
* Pasting from the clipboard only works in Chrome.
  - I can't work out why it's not working in Firefox.
  - the method [here](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Interact_with_the_clipboard) for pasting is almost exactly what we're using, so I'm pretty low on ideas.
* ~~I haven't converted the `LinkHints.activateModeToCopyLinkUrl` command to use the new handler, since I'm focusing on getting Firefox to paste.~~ Done

NB: this directs the copy/paste commands via the HUD. This feels (and is) weird, but it's the best we've got if the background page doesn't do this for us on FF.

/cc @smblott-github