### PR TITLE
Firefox: Simulate default action for clicking links with link hints

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -117,6 +117,16 @@ TabOperations =
       catch
         callback.apply this, arguments
 
+  # Opens request.url in new window and switches to it.
+  openUrlInNewWindow: (request, callback = (->)) ->
+    winConfig =
+      url: Utils.convertToUrl request.url
+      active: true
+    winConfig.active = request.active if request.active?
+    # Firefox does not support "about:newtab" in chrome.tabs.create.
+    delete tabConfig["url"] if tabConfig["url"] == Settings.defaults.newTabUrl
+    chrome.windows.create winConfig, callback
+
 toggleMuteTab = do ->
   muteTab = (tab) -> chrome.tabs.update tab.id, {muted: !tab.mutedInfo.muted}
 
@@ -416,6 +426,7 @@ sendRequestHandlers =
   # with Chrome-specific URLs like "view-source:http:..".
   getCurrentTabUrl: ({tab}) -> tab.url
   openUrlInNewTab: (request) -> TabOperations.openUrlInNewTab request
+  openUrlInNewWindow: (request) -> TabOperations.openUrlInNewWindow request
   openUrlInIncognito: (request) -> chrome.windows.create incognito: true, url: Utils.convertToUrl request.url
   openUrlInCurrentTab: TabOperations.openUrlInCurrentTab
   openOptionsPageInNewTab: (request) ->

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -106,6 +106,7 @@ TabOperations =
       index: request.tab.index + 1
       active: true
       windowId: request.tab.windowId
+    tabConfig.active = request.active if request.active?
     # Firefox does not support "about:newtab" in chrome.tabs.create.
     delete tabConfig["url"] if tabConfig["url"] == Settings.defaults.newTabUrl
     chrome.tabs.create tabConfig, (tab) ->

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -11,7 +11,6 @@
 # The "name" property below is a short-form name to appear in the link-hints mode's name.  It's for debug only.
 #
 isMac = KeyboardUtils.platform == "Mac"
-simulateClickDefaultAction = true
 OPEN_IN_CURRENT_TAB =
   name: "curr-tab"
   indicator: "Open link in current tab"
@@ -387,6 +386,7 @@ class LinkHintsMode
           else
             clickActivator = (modifiers) -> (link) ->
               defaultActionsTriggered = DomUtils.simulateClick link, modifiers
+              simulateClickDefaultAction = Utils.isFirefox()
               if simulateClickDefaultAction and
                   defaultActionsTriggered[3] and link.tagName?.toLowerCase() == "a" and
                   modifiers? and modifiers.metaKey == isMac and modifiers.ctrlKey == not isMac

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -384,17 +384,7 @@ class LinkHintsMode
             window.focus()
             DomUtils.simulateSelect clickEl
           else
-            clickActivator = (modifiers) -> (link) ->
-              defaultActionsTriggered = DomUtils.simulateClick link, modifiers
-              simulateClickDefaultAction = Utils.isFirefox()
-              if simulateClickDefaultAction and
-                  defaultActionsTriggered[3] and link.tagName?.toLowerCase() == "a" and
-                  modifiers? and modifiers.metaKey == isMac and modifiers.ctrlKey == not isMac
-              # We've clicked a link that *should* open in a new tab. If simulateClickDefaultAction is true,
-              # we assume the popup-blocker is active, and simulate opening the new tab ourselves.
-                chrome.runtime.sendMessage {handler: "openUrlInNewTab", url: link.href, active:
-                  modifiers.shiftKey == true}
-
+            clickActivator = (modifiers) -> (link) -> DomUtils.simulateClick link, modifiers
             linkActivator = @mode.linkActivator ? clickActivator @mode.clickModifiers
             # TODO: Are there any other input elements which should not receive focus?
             if clickEl.nodeName.toLowerCase() in ["input", "select"] and clickEl.type not in ["button", "submit"]


### PR DESCRIPTION
This makes the `LinkHints.activateModeToOpenInNew{,Foreground}Tab` commands work as expected on Firefox.

Currently the flag (`simulateClickDefaultAction`) is hardcoded on, which opens tabs twice in Chrome for the affected cases. It could be an option, use UA sniffing, or both (default set by UA sniffing), so I've left it for now.

@smblott-github this is a big usability win (currently FF can only open links in the current page).