### PR TITLE
Work better with Google Docs

### DIFF
--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -25,7 +25,7 @@ class InsertMode extends Mode
         if window.frameElement?
           # We can't get a |frameId| from a |window| in a content script, so the only way of communicating
           # with a specific window is a custom event.
-          vimiumBlurEvent = new CustomEvent "vimiumBlurEvent"
+          vimiumBlurEvent = new CustomEvent "vimiumBlurEvent", {detail: JSON.stringify event}
           window.frameElement.dispatchEvent vimiumBlurEvent
           return DomUtils.consumeKeyup event
         return @passEventToPage # We can't use the <esc>: assume the user intended it for the page.

--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -25,7 +25,7 @@ class InsertMode extends Mode
         if window.frameElement?
           # We can't get a |frameId| from a |window| in a content script, so the only way of communicating
           # with a specific window is a custom event.
-          vimiumBlurEvent = new CustomEvent "vimiumBlurEvent", {detail: JSON.stringify event}
+          vimiumBlurEvent = new CustomEvent "vimiumBlurEvent", {detail: {code: event.code}}
           window.frameElement.dispatchEvent vimiumBlurEvent
           return DomUtils.consumeKeyup event
         return @passEventToPage # We can't use the <esc>: assume the user intended it for the page.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -218,12 +218,14 @@ handleSubframeBlur = (event) ->
   if document.activeElement != event.target
     return # The frame isn't focused anyway.
   if isEnabledForUrl
-    window.focus()
     document.activeElement.blur()
+    window.focus()
+    keyEvent = JSON.parse event.detail
+    DomUtils.consumeKeyup keyEvent
   else if window.frameElement?
     # If we blur to this frame, the user will get stuck, since we're not enabled. Instead, we pass the event
     # up to the parent frame, if one exists.
-    vimiumBlurEvent = new CustomEvent "vimiumBlurEvent"
+    vimiumBlurEvent = new CustomEvent "vimiumBlurEvent", {detail: event.detail}
     window.frameElement.dispatchEvent vimiumBlurEvent
 
 #

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -220,8 +220,23 @@ handleSubframeBlur = (event) ->
   if isEnabledForUrl
     document.activeElement.blur()
     window.focus()
-    keyEvent = JSON.parse event.detail
-    DomUtils.consumeKeyup keyEvent
+    keyEvent = event.detail
+
+    captureKey = (event) ->
+      if event.code == keyEvent.code
+        @suppressEvent
+      else
+        @continueBubbling
+    handlerStack.push
+      _name: "subframeBlur-keyEventSuppressor"
+      keydown: captureKey
+      keypress: captureKey
+      keyup: (event) ->
+        if event.code == keyEvent.code
+          @remove()
+          @suppressEvent
+        else
+          @continueBubbling
   else if window.frameElement?
     # If we blur to this frame, the user will get stuck, since we're not enabled. Instead, we pass the event
     # up to the parent frame, if one exists.

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -299,10 +299,10 @@ DomUtils =
       top: -rect.top - box.clientTop, left: -rect.left - box.clientLeft
 
   suppressPropagation: (event) ->
-    event.stopImmediatePropagation()
+    event.stopImmediatePropagation?()
 
   suppressEvent: (event) ->
-    event.preventDefault()
+    event.preventDefault?()
     @suppressPropagation(event)
 
   consumeKeyup: do ->

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -299,10 +299,10 @@ DomUtils =
       top: -rect.top - box.clientTop, left: -rect.left - box.clientLeft
 
   suppressPropagation: (event) ->
-    event.stopImmediatePropagation?()
+    event.stopImmediatePropagation()
 
   suppressEvent: (event) ->
-    event.preventDefault?()
+    event.preventDefault()
     @suppressPropagation(event)
 
   consumeKeyup: do ->


### PR DESCRIPTION
This makes `<esc>` blur out of frames whose body is an editable element.

Fixes #2075.

Notes:
* The focused frame for Google Docs is __not__ what it appears to be: a hidden iframe collects the typing events, but the content is rendered in the main frame.
* I can't find an obvious element that clicking should be enabled for to return focus to the editor, so you have to use the mouse to continue editing.
* **Any bindings that use modifier keys will drop focus back into the editor:** Docs captures the events for them and uses them to refocus it.