### PR TITLE
Check whether events are trusted before executing listeners

### DIFF
--- a/content_scripts/mode_find.coffee
+++ b/content_scripts/mode_find.coffee
@@ -199,7 +199,7 @@ class FindMode extends Mode
 
     result
 
-  @restoreDefaultSelectionHighlight: -> document.body.classList.remove("vimiumFindMode")
+  @restoreDefaultSelectionHighlight: forTrusted -> document.body.classList.remove("vimiumFindMode")
 
   checkReturnToViewPort: ->
     window.scrollTo @scrollX, @scrollY if @options.returnToViewport

--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -65,7 +65,7 @@ class InsertMode extends Mode
           eventListeners = {}
           for type in [ "focus", "blur" ]
             eventListeners[type] = do (type) ->
-              (event) -> handlerStack.bubbleEvent type, event
+              forTrusted (event) -> handlerStack.bubbleEvent type, event
             shadowRoot.addEventListener type, eventListeners[type], true
 
           handlerStack.push

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -5,7 +5,7 @@ DomUtils =
   documentReady: do ->
     [isReady, callbacks] = [document.readyState != "loading", []]
     unless isReady
-      window.addEventListener "DOMContentLoaded", onDOMContentLoaded = ->
+      window.addEventListener "DOMContentLoaded", onDOMContentLoaded = forTrusted ->
         window.removeEventListener "DOMContentLoaded", onDOMContentLoaded
         isReady = true
         callback() for callback in callbacks
@@ -16,7 +16,7 @@ DomUtils =
   documentComplete: do ->
     [isComplete, callbacks] = [document.readyState == "complete", []]
     unless isComplete
-      window.addEventListener "load", onLoad = ->
+      window.addEventListener "load", onLoad = forTrusted ->
         window.removeEventListener "load", onLoad
         isComplete = true
         callback() for callback in callbacks

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -1,3 +1,11 @@
+# Only pass events to the handler if they are marked as trusted by the browser.
+# This is kept in the global namespace for brevity and ease of use.
+window.forTrusted ?= (handler) -> (event) ->
+  if event?.isTrusted
+    handler.apply this, arguments
+  else
+    true
+
 Utils =
   getCurrentVersion: ->
     chrome.runtime.getManifest().version

--- a/tests/dom_tests/chrome.coffee
+++ b/tests/dom_tests/chrome.coffee
@@ -7,6 +7,8 @@ root.chromeMessages = []
 
 document.hasFocus = -> true
 
+window.forTrusted = (handler) -> handler
+
 fakeManifest =
   version: "1.51"
 


### PR DESCRIPTION
From @gdh1995's [comment](https://github.com/philc/vimium/pull/2604#issuecomment-323404520) on #2604:

> I've dispatched a fake `unload` event to iframes to force Vimium to exit itself

Clearly this isn't desired behaviour: pages shouldn't be able to disable Vimium on a whim.

This PR creates a `forTrusted` utility function that only executes event listeners when `event.isTrusted` is set, and applies it to every content script DOM event listener. This fixes the issue, and protects us from future similar issues (modulo our adding more unguarded listeners).