### PR TITLE
Firefox: Use options_ui to declare the options page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,11 @@
       "background_scripts/main.js"
     ]
   },
-  "options_page": "pages/options.html",
+  "options_ui": {
+    "page": "pages/options.html",
+    "chrome_style": false,
+    "open_in_tab": true
+  },
   "permissions": [
     "tabs",
     "bookmarks",


### PR DESCRIPTION
Firefox doesn't recognise the ["options_page"](https://developer.chrome.com/extensions/options) manifest key, and so isn't showing a preferences button for Vimium-ff.

This PR switches to using ["options_ui"](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/options_ui)[[1]](https://developer.chrome.com/extensions/optionsV2), which works properly on Chrome and Firefox.

(See also [this Vimium-ff review](https://addons.mozilla.org/en-US/firefox/addon/vimium-ff/reviews/904018/).)