### PR TITLE
Update URLs to use HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/shoulda.js"]
 	path = tests/shoulda.js
-	url = git://github.com/philc/shoulda.js.git
+	url = https://github.com/philc/shoulda.js.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 You'd like to fix a bug or implement a feature? Great! Check out the bugs on our issues tracker, or implement
 one of the suggestions there that have been tagged "help wanted". If you have a suggestion of your own, start
 a discussion on the issues tracker or on the
-[mailing list](http://groups.google.com/group/vimium-dev?hl=en). If it mirrors a similar feature in another
+[mailing list](https://groups.google.com/group/vimium-dev?hl=en). If it mirrors a similar feature in another
 browser or in Vim itself, let us know. Once you've picked something to work on, add a comment to the
 respective issue so others don't duplicate your effort.
 
@@ -37,7 +37,7 @@ Our tests use [shoulda.js](https://github.com/philc/shoulda.js) and [PhantomJS](
 
  1. `git submodule update --init --recursive` -- this pulls in shoulda.js.
  1. Install [PhantomJS](http://phantomjs.org/download.html).
- 1. `npm install path@0.11` to install the [Node.js Path module](http://nodejs.org/api/path.html), used by the test runner.
+ 1. `npm install path@0.11` to install the [Node.js Path module](https://nodejs.org/api/path.html), used by the test runner.
  1. `npm install util` to install the [util module](https://www.npmjs.com/package/util), used by the tests.
  1. `cake build` to compile `*.coffee` to `*.js`
  1. `cake test` to run the tests.
@@ -47,7 +47,7 @@ Our tests use [shoulda.js](https://github.com/philc/shoulda.js) and [PhantomJS](
 You can find out which portions of code need them by looking at our coverage reports. To generate these
 reports:
 
- 1. Download [JSCoverage](http://siliconforks.com/jscoverage/download.html) or `brew install jscoverage`
+ 1. Download [JSCoverage](https://siliconforks.com/jscoverage/download.html) or `brew install jscoverage`
  1. `npm install temp`
  1. `cake coverage` will generate a coverage report in the form of a JSON file (`jscoverage.json`), which can
     then be viewed using [jscoverage-report](https://github.com/int3/jscoverage-report).  See

--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ Changes in git (not yet released)
 -  Arrow keys and function keys can now be mapped using &lt;left&gt;, &lt;right&gt;, &lt;up&gt;, &lt;down&gt;,
    &lt;f1&gt;, &lt;f2&gt;, etc. in the mappings interface.
 -  There is a new command `goUp` (mapped to `gu` by default) that will go up one level in the URL hierarchy.
-   For example: from http://vimium.github.com/foo/bar to http://vimium.github.com/foo. At the moment, `goUp`
+   For example: from https://vimium.github.io/foo/bar to https://vimium.github.io/foo. At the moment, `goUp`
 does not support command repetition.
 -  Bug fixes and optimizations.
 

--- a/background_scripts/completion_engines.coffee
+++ b/background_scripts/completion_engines.coffee
@@ -47,17 +47,17 @@ class GoogleXMLBaseEngine extends BaseEngine
 class Google extends GoogleXMLBaseEngine
   constructor: () ->
     super
-      engineUrl: "http://suggestqueries.google.com/complete/search?ss_protocol=legace&client=toolbar&q=%s"
+      engineUrl: "https://suggestqueries.google.com/complete/search?ss_protocol=legace&client=toolbar&q=%s"
       regexps: "^https?://[a-z]+\\.google\\.(com|ie|co\\.uk|ca|com\\.au)/"
       example:
-        searchUrl: "http://www.google.com/search?q=%s"
+        searchUrl: "https://www.google.com/search?q=%s"
         keyword: "g"
 
 class GoogleMaps extends GoogleXMLBaseEngine
   prefix: "map of "
   constructor: () ->
     super
-      engineUrl: "http://suggestqueries.google.com/complete/search?ss_protocol=legace&client=toolbar&q=#{@prefix.split(' ').join '+'}%s"
+      engineUrl: "https://suggestqueries.google.com/complete/search?ss_protocol=legace&client=toolbar&q=#{@prefix.split(' ').join '+'}%s"
       regexps: "^https?://[a-z]+\\.google\\.(com|ie|co\\.uk|ca|com\\.au)/maps"
       example:
         searchUrl: "https://www.google.com/maps?q=%s"
@@ -77,10 +77,10 @@ class GoogleMaps extends GoogleXMLBaseEngine
 class Youtube extends GoogleXMLBaseEngine
   constructor: ->
     super
-      engineUrl: "http://suggestqueries.google.com/complete/search?client=youtube&ds=yt&xml=t&q=%s"
+      engineUrl: "https://suggestqueries.google.com/complete/search?client=youtube&ds=yt&xml=t&q=%s"
       regexps: "^https?://[a-z]+\\.youtube\\.com/results"
       example:
-        searchUrl: "http://www.youtube.com/results?search_query=%s"
+        searchUrl: "https://www.youtube.com/results?search_query=%s"
         keyword: "y"
 
 class Wikipedia extends BaseEngine
@@ -89,7 +89,7 @@ class Wikipedia extends BaseEngine
       engineUrl: "https://en.wikipedia.org/w/api.php?action=opensearch&format=json&search=%s"
       regexps: "^https?://[a-z]+\\.wikipedia\\.org/"
       example:
-        searchUrl: "http://www.wikipedia.org/w/index.php?title=Special:Search&search=%s"
+        searchUrl: "https://www.wikipedia.org/w/index.php?title=Special:Search&search=%s"
         keyword: "w"
 
   parse: (xhr) -> JSON.parse(xhr.responseText)[1]
@@ -97,7 +97,7 @@ class Wikipedia extends BaseEngine
 class Bing extends BaseEngine
   constructor: ->
     super
-      engineUrl: "http://api.bing.com/osjson.aspx?query=%s"
+      engineUrl: "https://api.bing.com/osjson.aspx?query=%s"
       regexps: "^https?://www\\.bing\\.com/search"
       example:
         searchUrl: "https://www.bing.com/search?q=%s"
@@ -111,7 +111,7 @@ class Amazon extends BaseEngine
       engineUrl: "https://completion.amazon.com/search/complete?method=completion&search-alias=aps&client=amazon-search-ui&mkt=1&q=%s"
       regexps: "^https?://www\\.amazon\\.(com|co\\.uk|ca|de|com\\.au)/s/"
       example:
-        searchUrl: "http://www.amazon.com/s/?field-keywords=%s"
+        searchUrl: "https://www.amazon.com/s/?field-keywords=%s"
         keyword: "a"
 
   parse: (xhr) -> JSON.parse(xhr.responseText)[1]
@@ -131,10 +131,10 @@ class DuckDuckGo extends BaseEngine
 class Webster extends BaseEngine
   constructor: ->
     super
-      engineUrl: "http://www.merriam-webster.com/autocomplete?query=%s"
+      engineUrl: "https://www.merriam-webster.com/autocomplete?query=%s"
       regexps: "^https?://www.merriam-webster.com/dictionary/"
       example:
-        searchUrl: "http://www.merriam-webster.com/dictionary/%s"
+        searchUrl: "https://www.merriam-webster.com/dictionary/%s"
         keyword: "dw"
         description: "Dictionary"
 

--- a/background_scripts/completion_search.coffee
+++ b/background_scripts/completion_search.coffee
@@ -2,7 +2,7 @@
 # This is a wrapper class for completion engines.  It handles the case where a custom search engine includes a
 # prefix query term (or terms).  For example:
 #
-#   http://www.google.com/search?q=javascript+%s
+#   https://www.google.com/search?q=javascript+%s
 #
 # In this case, we get better suggestions if we include the term "javascript" in queries sent to the
 # completion engine.  This wrapper handles adding such prefixes to completion-engine queries and removing them

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -168,20 +168,20 @@ Settings =
     # put in an example search engine
     searchEngines:
       """
-      w: http://www.wikipedia.org/w/index.php?title=Special:Search&search=%s Wikipedia
+      w: https://www.wikipedia.org/w/index.php?title=Special:Search&search=%s Wikipedia
 
       # More examples.
       #
       # (Vimium supports search completion Wikipedia, as
       # above, and for these.)
       #
-      # g: http://www.google.com/search?q=%s Google
-      # l: http://www.google.com/search?q=%s&btnI I'm feeling lucky...
-      # y: http://www.youtube.com/results?search_query=%s Youtube
+      # g: https://www.google.com/search?q=%s Google
+      # l: https://www.google.com/search?q=%s&btnI I'm feeling lucky...
+      # y: https://www.youtube.com/results?search_query=%s Youtube
       # gm: https://www.google.com/maps?q=%s Google maps
       # b: https://www.bing.com/search?q=%s Bing
       # d: https://duckduckgo.com/?q=%s DuckDuckGo
-      # az: http://www.amazon.com/s/?field-keywords=%s Amazon
+      # az: https://www.amazon.com/s/?field-keywords=%s Amazon
       # qw: https://www.qwant.com/?q=%s Qwant
       """
     newTabUrl: "about:newtab"

--- a/pages/help_dialog.html
+++ b/pages/help_dialog.html
@@ -107,7 +107,7 @@
             <a class="vimiumHelDialogLink" target="_blank"
               href="https://chrome.google.com/webstore/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb/reviews">Leave us
                   feedback</a>.<br/>
-            Found a bug? <a class="vimiumHelDialogLink" target="_blank" href="http://github.com/philc/vimium/issues">Report it here</a>.
+            Found a bug? <a class="vimiumHelDialogLink" target="_blank" href="https://github.com/philc/vimium/issues">Report it here</a>.
           </div>
           <div class="vimiumReset vimiumColumn" style="text-align:right">
             <span class="vimiumReset">Version <span id="help-dialog-version"></span></span><br/>

--- a/pages/options.html
+++ b/pages/options.html
@@ -248,7 +248,7 @@ b: http://b.com/?q=%s description
             <td verticalAlign="top">
                 <div class="help">
                   <div class="example">
-                     The search engine to use in the Vomnibar <br> (e.g.: "http://duckduckgo.com/?q=").
+                     The search engine to use in the Vomnibar <br> (e.g.: "https://duckduckgo.com/?q=").
                   </div>
                 </div>
                 <input id="searchUrl" type="text" />


### PR DESCRIPTION
This PR updates various URLs to use HTTPS (where possible and tested/working) within the code, pages, and docs. 

In the case of the submodule URL change, this uses HTTPS over the `git://` protocol, which is insecure and no longer highlighted or mentioned on GitHub's documentation (https://help.github.com/articles/which-remote-url-should-i-use/).  Existing clones of Vimium can update the remote URL by using `git submodule sync`.

Other URL changes are either on the options pages (making for better examples etc), or in the completion engine configuration (where all the given endpoints now support HTTPS).