### PR TITLE
Ignore keyboard layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Release Notes
 
 Changes in git (not yet released)
 
+- Added a new option to ignore keyboard layout; this might be useful for users of non-Latin keyboards.
 - Firefox support.  This is a work in progress; please report any issues [here](https://github.com/philc/vimium/issues?q=is%3Aopen+sort%3Aupdated-desc).
 - Reworked key handling; please report any new key-handling bugs [here](https://github.com/philc/vimium/issues?q=is%3Aopen+sort%3Aupdated-desc).
 - Fixed search completion for Firefox (released as 1.59.1, Firefox only).

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -23,7 +23,6 @@ KeyboardUtils =
       key = event.code
       # Strip some standard prefixes.
       key = key[3..] if key[...3] == "Key"
-      key = key[5..] if key[...5] == "Digit"
       key = key[6..] if key[...6] == "Numpad"
       # Translate some special keys to event.key-like strings.
       if @enUsTranslations[key]
@@ -83,6 +82,16 @@ KeyboardUtils =
     "Period":        [".", ">"]
     "Slash":         ["/", "?"]
     "Space":         [" ", " "]
+    "Digit1":        ["1", "!"]
+    "Digit2":        ["2", "@"]
+    "Digit3":        ["3", "#"]
+    "Digit4":        ["4", "$"]
+    "Digit5":        ["5", "%"]
+    "Digit6":        ["6", "^"]
+    "Digit7":        ["7", "&"]
+    "Digit8":        ["8", "*"]
+    "Digit9":        ["9", "("]
+    "Digit0":        ["0", ")"]
 
 KeyboardUtils.init()
 

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -19,8 +19,15 @@ KeyboardUtils =
     unless Settings.get "ignoreKeyboardLayout"
       key = event.key
     else
+      # The logic here is from the vim-like-key-notation project (https://github.com/lydell/vim-like-key-notation).
       key = event.code
+      # Strip some standard prefixes.
       key = key[3..] if key[...3] == "Key"
+      key = key[5..] if key[...5] == "Digit"
+      key = key[6..] if key[...6] == "Numpad"
+      # Translate some special keys to event.key-like strings.
+      if @enUsTranslations[key]
+        key = if event.shift then @enUsTranslations[key][1] else @enUsTranslations[key][0]
       key = key.toLowerCase() unless event.shiftKey
 
     if key of @keyNames
@@ -61,6 +68,21 @@ KeyboardUtils =
 
   isPrintable: (event) ->
     @getKeyCharString(event)?.length == 1
+
+  enUsTranslations:
+    "Backquote":     ["`", "~"]
+    "Minus":         ["-", "_"]
+    "Equal":         ["=", "+"]
+    "Backslash":     ["\\","|"]
+    "IntlBackslash": ["\\","|"]
+    "BracketLeft":   ["[", "{"]
+    "BracketRight":  ["]", "}"]
+    "Semicolon":     [";", ":"]
+    "Quote":         ["'", '"']
+    "Comma":         [",", "<"]
+    "Period":        [".", ">"]
+    "Slash":         ["/", "?"]
+    "Space":         [" ", " "]
 
 KeyboardUtils.init()
 

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -18,12 +18,13 @@ KeyboardUtils =
   getKeyChar: (event) ->
     unless Settings.get "ignoreKeyboardLayout"
       key = event.key
+    else if event.code[...6] == "Numpad"
+      # We cannot correctly emulate the numpad, so fall back to event.key; see #2626.
+      key = event.key
     else
       # The logic here is from the vim-like-key-notation project (https://github.com/lydell/vim-like-key-notation).
       key = event.code
-      # Strip some standard prefixes.
       key = key[3..] if key[...3] == "Key"
-      key = key[6..] if key[...6] == "Numpad"
       # Translate some special keys to event.key-like strings.
       if @enUsTranslations[key]
         key = if event.shift then @enUsTranslations[key][1] else @enUsTranslations[key][0]

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -16,17 +16,24 @@ KeyboardUtils =
       @platform = "Windows"
 
   getKeyChar: (event) ->
-    if event.key of @keyNames
-      @keyNames[event.key]
-    # It appears that event.key is not always defined (see #2453).
-    else if not event.key?
+    unless Settings.get "ignoreKeyboardLayout"
+      key = event.key
+    else
+      key = event.code
+      key = key[3..] if key[...3] == "Key"
+      key = key.toLowerCase() unless event.shiftKey
+
+    if key of @keyNames
+      @keyNames[key]
+    # It appears that key is not always defined (see #2453).
+    else if not key?
       ""
-    else if event.key.length == 1
-      event.key
-    else if event.key.length == 2 and "F1" <= event.key <= "F9"
-      event.key.toLowerCase() # F1 to F9.
-    else if event.key.length == 3 and "F10" <= event.key <= "F12"
-      event.key.toLowerCase() # F10 to F12.
+    else if key.length == 1
+      key
+    else if key.length == 2 and "F1" <= key <= "F9"
+      key.toLowerCase() # F1 to F9.
+    else if key.length == 3 and "F10" <= key <= "F12"
+      key.toLowerCase() # F10 to F12.
     else
       ""
 

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -25,10 +25,11 @@ KeyboardUtils =
       # The logic here is from the vim-like-key-notation project (https://github.com/lydell/vim-like-key-notation).
       key = event.code
       key = key[3..] if key[...3] == "Key"
-      # Translate some special keys to event.key-like strings.
+      # Translate some special keys to event.key-like strings and handle <Shift>.
       if @enUsTranslations[key]
-        key = if event.shift then @enUsTranslations[key][1] else @enUsTranslations[key][0]
-      key = key.toLowerCase() unless event.shiftKey
+        key = if event.shiftKey then @enUsTranslations[key][1] else @enUsTranslations[key][0]
+      else if key.length == 1 and not event.shiftKey
+        key = key.toLowerCase()
 
     if key of @keyNames
       @keyNames[key]

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -10,24 +10,8 @@
 #
 # In all cases except Settings.defaults, values are stored as jsonified strings.
 
-# This is a minimal stub of chrome services for the tests.  This needs to be here (and not in
-# ../tests/dom_tests/chrome.coffee) because the regular test stubs are not loaded in the Vomnibar or HUD
-# iframes.
-# NOTE(smblott): Possibly these should go in a separate file.
-window.chrome ?=
-  runtime:
-    lastError: false
-  storage:
-    local:
-      get: ->
-      set: ->
-    sync:
-      get: (_, callback) -> callback? {}
-      set: ->
-    onChanged:
-      addListener: ->
-  extension:
-    inIncognitoContext: false
+# If the current frame is the Vomnibar or the HUD, then we'll need our Chrome stubs for the tests.
+window.chrome ?= window.top?.chrome
 
 storageArea = if chrome.storage.sync? then "sync" else "local"
 

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -10,6 +10,25 @@
 #
 # In all cases except Settings.defaults, values are stored as jsonified strings.
 
+# This is a minimal stub of chrome services for the tests.  This needs to be here (and not in
+# ../tests/dom_tests/chrome.coffee) because the regular test stubs are not loaded in the Vomnibar or HUD
+# iframes.
+# NOTE(smblott): Possibly these should go in a separate file.
+window.chrome ?=
+  runtime:
+    lastError: false
+  storage:
+    local:
+      get: ->
+      set: ->
+    sync:
+      get: (_, callback) -> callback? {}
+      set: ->
+    onChanged:
+      addListener: ->
+  extension:
+    inIncognitoContext: false
+
 storageArea = if chrome.storage.sync? then "sync" else "local"
 
 Settings =

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -193,6 +193,7 @@ Settings =
     helpDialog_showAdvancedCommands: false
     optionsPage_showAdvancedOptions: false
     passNextKeyKeys: []
+    ignoreKeyboardLayout: false
 
 Settings.init()
 

--- a/pages/hud.html
+++ b/pages/hud.html
@@ -4,6 +4,7 @@
     <link rel="stylesheet" type="text/css" href="../content_scripts/vimium.css" />
     <script type="text/javascript" src="../lib/utils.js"></script>
     <script type="text/javascript" src="../lib/dom_utils.js"></script>
+    <script type="text/javascript" src="../lib/settings.js"></script>
     <script type="text/javascript" src="../lib/keyboard_utils.js"></script>
     <script type="text/javascript" src="../lib/find_mode_history.js"></script>
     <script type="text/javascript" src="ui_component_server.js"></script>

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -193,6 +193,7 @@ Options =
   nextPatterns: NonEmptyTextOption
   previousPatterns: NonEmptyTextOption
   regexFindMode: CheckBoxOption
+  ignoreKeyboardLayout: CheckBoxOption
   scrollStepSize: NumberOption
   smoothScroll: CheckBoxOption
   grabBackFocus: CheckBoxOption

--- a/pages/options.html
+++ b/pages/options.html
@@ -207,6 +207,20 @@ b: http://b.com/?q=%s description
             </td>
           </tr>
           <tr>
+            <td class="caption"></td>
+            <td verticalAlign="top" class="booleanOption">
+              <div class="help">
+                <div class="example">
+                  This is useful for non-Latin keyboards.
+                </div>
+              </div>
+              <label>
+                <input id="ignoreKeyboardLayout" type="checkbox"/>
+                Ignore keyboard layout
+              </label>
+            </td>
+          </tr>
+          <tr>
             <td class="caption">Previous patterns</td>
             <td verticalAlign="top">
                 <div class="help">

--- a/pages/options.html
+++ b/pages/options.html
@@ -211,7 +211,8 @@ b: http://b.com/?q=%s description
             <td verticalAlign="top" class="booleanOption">
               <div class="help">
                 <div class="example">
-                  This is useful for non-Latin keyboards.
+                  This forces the use of <code>en-US</code> QWERTY layout and
+                  can be helpful for non-Latin keyboards.
                 </div>
               </div>
               <label>

--- a/pages/vomnibar.html
+++ b/pages/vomnibar.html
@@ -2,6 +2,7 @@
   <head>
     <title>Vomnibar</title>
     <script type="text/javascript" src="../lib/utils.js"></script>
+    <script type="text/javascript" src="../lib/settings.js"></script>
     <script type="text/javascript" src="../lib/keyboard_utils.js"></script>
     <script type="text/javascript" src="../lib/dom_utils.js"></script>
     <script type="text/javascript" src="../lib/handler_stack.js"></script>


### PR DESCRIPTION
This adds a new (advanced) option `ignoreKeyboardLayout` (as per @lydell's suggestion in #2618) to allow users of non-Latin keyboard layout's to avoid switching layout.