### PR TITLE
Only handle trusted events.

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -208,7 +208,8 @@ installListeners = Utils.makeIdempotent ->
   # Key event handlers fire on window before they do on document. Prefer window for key events so the page
   # can't set handlers to grab the keys before us.
   for type in ["keydown", "keypress", "keyup", "click", "focus", "blur", "mousedown", "scroll"]
-    do (type) -> installListener window, type, (event) -> handlerStack.bubbleEvent type, event
+    do (type) -> installListener window, type, (event) ->
+      handlerStack.bubbleEvent type, event if event.isTrusted
   installListener document, "DOMActivate", (event) -> handlerStack.bubbleEvent 'DOMActivate', event
 
 #


### PR DESCRIPTION
... otherwise, the page can generate events which trigger Vimium commands.

We should possibly/probably do this on all event handlers.  However, most of the others seem safe.

Fixes #2453.
Specifically, see https://github.com/philc/vimium/issues/2453#issuecomment-327289851 from @derrotebaron.