### PR TITLE
Exclude Firefox from the scaled DPI fix

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -5,6 +5,7 @@ root = exports ? window
 chrome.runtime.onInstalled.addListener ({ reason }) ->
   # See https://developer.chrome.com/extensions/runtime#event-onInstalled
   return if reason in [ "chrome_update", "shared_module_update" ]
+  return if Utils.isFirefox()
   manifest = chrome.runtime.getManifest()
   # Content scripts loaded on every page should be in the same group. We assume it is the first.
   contentScripts = manifest.content_scripts[0]

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -311,6 +311,7 @@ Frames =
 
   isEnabledForUrl: ({request, tabId, port}) ->
     urlForTab[tabId] = request.url if request.frameIsFocused
+    request.isFirefox = Utils.isFirefox() # Update the value for Utils.isFirefox in the frontend.
     enabledState = Exclusions.isEnabledForUrl request.url
 
     if request.frameIsFocused

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -493,7 +493,8 @@ extend window,
 # the page icon.
 checkIfEnabledForUrl = do ->
   Frame.addEventListener "isEnabledForUrl", (response) ->
-    {isEnabledForUrl, passKeys, frameIsFocused} = response
+    {isEnabledForUrl, passKeys, frameIsFocused, isFirefox} = response
+    Utils.isFirefox = -> isFirefox
     initializeOnEnabledStateKnown isEnabledForUrl
     normalMode.setPassKeys passKeys
     # Hide the HUD if we're not enabled.

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -293,7 +293,8 @@ DomUtils =
     style = getComputedStyle box
     if style.position == "static" and not /content|paint|strict/.test(style.contain or "")
       zoom = +style.zoom || 1
-      ratio = window.devicePixelRatio ? 1
+      ratio = window.devicePixelRatio
+      ratio = 1 if Utils.isFirefox() or not ratio?
       top: Math.ceil(window.scrollY * ratio / zoom), left: Math.ceil(window.scrollX * ratio / zoom)
     else
       rect = box.getBoundingClientRect()

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -7,6 +7,7 @@ window.forTrusted ?= (handler) -> (event) ->
     true
 
 Utils =
+  isFirefox: -> 0 <= navigator.userAgent.indexOf "Firefox"
   getCurrentVersion: ->
     chrome.runtime.getManifest().version
 

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -7,7 +7,13 @@ window.forTrusted ?= (handler) -> (event) ->
     true
 
 Utils =
-  isFirefox: -> 0 <= navigator.userAgent.indexOf "Firefox"
+  isFirefox: do ->
+    # NOTE(mrmr1993): This test only works in the background page, this is overwritten by isEnabledForUrl for
+    # content scripts.
+    isFirefox = false
+    browser?.runtime?.getBrowserInfo?()?.then? (browserInfo) ->
+      isFirefox = browserInfo?.name == "Firefox"
+    -> isFirefox
   getCurrentVersion: ->
     chrome.runtime.getManifest().version
 


### PR DESCRIPTION
The Chrome fix (#2636) breaks Firefox's link hints when the `devicePixelRatio` isn't 1. This adds `Utils.isFirefox` from #2602 and uses it to exclude Firefox.

@smblott-github sorry I missed this with the first PR, took me a while to work out how to scale Firefox (layout.css.devPixelsPerPx in `about:config`).