### PR TITLE
Revert #2636.

### DIFF
--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -293,9 +293,7 @@ DomUtils =
     style = getComputedStyle box
     if style.position == "static" and not /content|paint|strict/.test(style.contain or "")
       zoom = +style.zoom || 1
-      ratio = window.devicePixelRatio
-      ratio = 1 if Utils.isFirefox() or not ratio?
-      top: Math.ceil(window.scrollY * ratio / zoom), left: Math.ceil(window.scrollX * ratio / zoom)
+      top: Math.ceil(window.scrollY / zoom), left: Math.ceil(window.scrollX / zoom)
     else
       rect = box.getBoundingClientRect()
       top: -rect.top - box.clientTop, left: -rect.left - box.clientLeft


### PR DESCRIPTION
Mention @mrmr1993.
Mention @gdh1995.

We have zoom issues resulting from:
   - style
   - zoom
   - `--force-device-scale-factor=1.5`
   - HiDPI

This intended to fix HiDPI, but seems to have created problems in the some of the other cases.

I don't have time to figure out the problem right now, so I'm going to revert this and push it as 1.60.2.

That leaves us pretty much where we were before, I think, in terms of zoom.

We can come back to it later.