### PR TITLE
Always use getBoundingClientRect for getViewportTopLeft

### DIFF
--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -292,13 +292,18 @@ DomUtils =
     box = document.documentElement
     style = getComputedStyle box
     rect = box.getBoundingClientRect()
-    {clientTop, clientLeft} = box
     if style.position == "static" and not /content|paint|strict/.test(style.contain or "")
       # The margin is included in the client rect, so we need to subtract it back out.
       marginTop = parseInt style.marginTop
       marginLeft = parseInt style.marginLeft
       top: -rect.top + marginTop, left: -rect.left + marginLeft
     else
+      if Utils.isFirefox()
+        # These are always 0 for documentElement on Firefox, so we derive them from CSS border.
+        clientTop = parseInt style.borderTopWidth
+        clientLeft = parseInt style.borderLeftWidth
+      else
+        {clientTop, clientLeft} = box
       top: -rect.top - clientTop, left: -rect.left - clientLeft
 
 

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -291,12 +291,16 @@ DomUtils =
   getViewportTopLeft: ->
     box = document.documentElement
     style = getComputedStyle box
+    rect = box.getBoundingClientRect()
+    {clientTop, clientLeft} = box
     if style.position == "static" and not /content|paint|strict/.test(style.contain or "")
-      zoom = +style.zoom || 1
-      top: Math.ceil(window.scrollY / zoom), left: Math.ceil(window.scrollX / zoom)
+      # The margin is included in the client rect, so we need to subtract it back out.
+      marginTop = parseInt style.marginTop
+      marginLeft = parseInt style.marginLeft
+      top: -rect.top + marginTop, left: -rect.left + marginLeft
     else
-      rect = box.getBoundingClientRect()
-      top: -rect.top - box.clientTop, left: -rect.left - box.clientLeft
+      top: -rect.top - clientTop, left: -rect.left - clientLeft
+
 
   suppressPropagation: (event) ->
     event.stopImmediatePropagation()


### PR DESCRIPTION
With this PR, we end up working with absolute positions and pixel offsets for everything in link hints, so nothing needs to be scaled.

This should fix all of the link hint zoom/scaling issues. It passes all the testcases I could think of.

Ping @gdh1995 @smblott-github.