### PR TITLE
Use .textContent instead of .innerHTML, where appropriate.

### DIFF
--- a/pages/help_dialog.coffee
+++ b/pages/help_dialog.coffee
@@ -73,7 +73,7 @@ HelpDialog =
           for key in command.keys.sort compareKeys
             @instantiateHtmlTemplate keysElement, "#keysTemplate", (element) ->
               lastElement = element
-              $$(element, ".vimiumHelpDialogKey").innerHTML = Utils.escapeHtml key
+              $$(element, ".vimiumHelpDialogKey").textContent = key
           # And strip off the trailing ", ", if necessary.
           lastElement.removeChild $$ lastElement, ".commaSeparator" if lastElement
 
@@ -109,7 +109,7 @@ HelpDialog =
     vimiumHelpDialogContainer.scrollTop += scrollHeightDelta if 0 < scrollHeightDelta
 
   showAdvancedCommands: (visible) ->
-    document.getElementById("toggleAdvancedCommands").innerHTML =
+    document.getElementById("toggleAdvancedCommands").textContent =
       if visible then "Hide advanced commands" else "Show advanced commands"
 
     # Add/remove the showAdvanced class to show/hide advanced commands.

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -204,7 +204,7 @@ Options =
 initOptionsPage = ->
   onUpdated = ->
     $("saveOptions").removeAttribute "disabled"
-    $("saveOptions").innerHTML = "Save Changes"
+    $("saveOptions").textContent = "Save Changes"
 
   # Display either "linkHintNumbers" or "linkHintCharacters", depending upon "filterLinkHints".
   maintainLinkHintsView = ->
@@ -222,10 +222,10 @@ initOptionsPage = ->
   maintainAdvancedOptions = ->
     if bgSettings.get "optionsPage_showAdvancedOptions"
       $("advancedOptions").style.display = "table-row-group"
-      $("advancedOptionsButton").innerHTML = "Hide Advanced Options"
+      $("advancedOptionsButton").textContent = "Hide Advanced Options"
     else
       $("advancedOptions").style.display = "none"
-      $("advancedOptionsButton").innerHTML = "Show Advanced Options"
+      $("advancedOptionsButton").textContent = "Show Advanced Options"
   maintainAdvancedOptions()
 
   toggleAdvancedOptions = (event) ->
@@ -241,7 +241,7 @@ initOptionsPage = ->
     $("linkHintCharacters").value = $("linkHintCharacters").value.toLowerCase()
     Option.saveOptions()
     $("saveOptions").disabled = true
-    $("saveOptions").innerHTML = "No Changes"
+    $("saveOptions").textContent = "Saved"
 
   $("saveOptions").addEventListener "click", saveOptions
   $("advancedOptionsButton").addEventListener "click", toggleAdvancedOptions
@@ -250,7 +250,7 @@ initOptionsPage = ->
 
   for element in document.getElementsByClassName "nonEmptyTextOption"
     element.className = element.className + " example info"
-    element.innerHTML = "Leave empty to reset this option."
+    element.textContent = "Leave empty to reset this option."
 
   window.onbeforeunload = -> "You have unsaved changes to options." unless $("saveOptions").disabled
 
@@ -287,12 +287,12 @@ initPopupPage = ->
     onUpdated = ->
       $("helpText").innerHTML = "Type <strong>Ctrl-Enter</strong> to save and close."
       $("saveOptions").removeAttribute "disabled"
-      $("saveOptions").innerHTML = "Save Changes"
+      $("saveOptions").textContent = "Save Changes"
       updateState() if exclusions
 
     saveOptions = ->
       Option.saveOptions()
-      $("saveOptions").innerHTML = "Saved"
+      $("saveOptions").textContent = "Saved"
       $("saveOptions").disabled = true
 
     $("saveOptions").addEventListener "click", saveOptions


### PR DESCRIPTION
From a FF extension reviewer (gatekeeper) on Mozilla add-ons:

  Comments:
  Thank you for your contribution.

  Please note the following for the next update:
  1) For inserting text, textContent (or JQuery text) or createTextNode() should be used instead of innerHTML.
  eg: $(&quot;saveOptions&quot;).innerHTML = &quot;Save Changes&quot;;

So, here, `.innerHTML` is replaced with `.textContent` for elements which only ever have text content.