### PR TITLE
Show tabs in the results when using the 'o' vomnibar

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -364,19 +364,22 @@ class TabCompleter
     chrome.tabs.query {}, (tabs) =>
       results = tabs.filter (tab) -> RankingUtils.matches(queryTerms, tab.url, tab.title)
       suggestions = results.map (tab) =>
-        new Suggestion
+        suggestion = new Suggestion
           queryTerms: queryTerms
           type: "tab"
           url: tab.url
           title: tab.title
-          relevancyFunction: @computeRelevancy
           tabId: tab.id
           deDuplicate: false
+        suggestion.relevancy = @computeRelevancy suggestion
+        suggestion
+      .sort (a,b) -> b.relevancy - a.relevancy
+      suggestions.forEach( (sugg,i) -> sugg.relevancy /= ( i / 4 + 1 ) )
       onComplete suggestions
 
   computeRelevancy: (suggestion) ->
     if suggestion.queryTerms.length
-      RankingUtils.wordRelevancy(suggestion.queryTerms, suggestion.url, suggestion.title)
+      RankingUtils.wordRelevancy(suggestion.queryTerms, suggestion.url, suggestion.title) * 8.0
     else
       BgUtils.tabRecency.recencyScore(suggestion.tabId)
 

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -43,6 +43,7 @@ completers =
     completionSources.bookmarks
     completionSources.history
     completionSources.domains
+    completionSources.tabs
     completionSources.searchEngines
     ]
   bookmarks: new MultiCompleter [completionSources.bookmarks]


### PR DESCRIPTION

Related to issue #2459.

Addresses a workflow like the following:
- Lots of tabs with e.g. issue tracker tickets, or admin web apps for lots of sites.
- I want to work on ticket x or site y, but I don't want x or y open in multiple tabs
- press 't', search for tab, not found
- close vomnibar
- press 'O', search for ticket or site

Getting access to the tab (if any) or otherwise the history item, bookmark, or search result from one vomnibar interaction is smoother here.

Changed the tab completer to have a quick weight falloff for subsequent tab entries to avoid crowding out other completion sources. This should have no influence on the workings of 't'.