### PR TITLE
Recognise (FF) internal URLs.

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -56,7 +56,7 @@ Utils =
     url.startsWith "javascript:"
 
   hasFullUrlPrefix: do ->
-    urlPrefix = new RegExp "^[a-z]{3,}://."
+    urlPrefix = new RegExp "^[a-z][-+.a-z0-9]{2,}://."
     (url) -> urlPrefix.test url
 
   # Decode valid escape sequences in a URI.  This is intended to mimic the best-effort decoding

--- a/tests/unit_tests/utils_test.coffee
+++ b/tests/unit_tests/utils_test.coffee
@@ -22,6 +22,9 @@ context "isUrl",
     assert.isTrue Utils.isUrl "illinois.state.museum"
     assert.isTrue Utils.isUrl "eqt5g4fuenphqinx.onion"
 
+    # Internal URLs.
+    assert.isTrue Utils.isUrl "moz-extension://c66906b4-3785-4a60-97bc-094a6366017e/pages/options.html"
+
   should "reject invalid URLs", ->
     assert.isFalse Utils.isUrl "a.x"
     assert.isFalse Utils.isUrl "www-domain-tld"


### PR DESCRIPTION
Recognise URLs like:
   - `moz-extension://c66906b4-3785-4a60-97bc-094a6366017e/pages/options.html`

Fixes #2657.