### PR TITLE
FF: Simulate default click action for <a target="_blank">s

### DIFF
--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -276,8 +276,7 @@ DomUtils =
       # but Webkit will. Dispatching a click on an input box does not seem to focus it; we do that separately
       element.dispatchEvent(mouseEvent)
 
-  simulateClickDefaultAction: (element, modifiers) ->
-    return unless modifiers?
+  simulateClickDefaultAction: (element, modifiers = {}) ->
     return unless element.tagName?.toLowerCase() == "a" and element.href?
 
     {ctrlKey, shiftKey, metaKey, altKey} = modifiers
@@ -295,6 +294,8 @@ DomUtils =
     else if shiftKey == true and metaKey == false and ctrlKey == false and altKey == false
       # Open in new window.
       chrome.runtime.sendMessage {handler: "openUrlInNewWindow", url: element.href}
+    else if element.target == "_blank"
+      chrome.runtime.sendMessage {handler: "openUrlInNewTab", url: element.href, active: true}
 
     return
 


### PR DESCRIPTION
This is an expansion of #2602 to a case I missed, which fixes #2672.