### PR TITLE
Use openerTabId in chrome.tabs.create when possible

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -6,14 +6,22 @@ window.forTrusted ?= (handler) -> (event) ->
   else
     true
 
+browserInfo = browser?.runtime?.getBrowserInfo?()
+
 Utils =
   isFirefox: do ->
     # NOTE(mrmr1993): This test only works in the background page, this is overwritten by isEnabledForUrl for
     # content scripts.
     isFirefox = false
-    browser?.runtime?.getBrowserInfo?()?.then? (browserInfo) ->
+    browserInfo?.then? (browserInfo) ->
       isFirefox = browserInfo?.name == "Firefox"
     -> isFirefox
+  firefoxVersion: do ->
+    # NOTE(mrmr1993): This only works in the background page.
+    ffVersion = undefined
+    browserInfo?.then? (browserInfo) ->
+      ffVersion = browserInfo?.version
+    -> ffVersion
   getCurrentVersion: ->
     chrome.runtime.getManifest().version
 


### PR DESCRIPTION
Now Firefox supports `openerTabId` in version 57+, we should try to use it whenever we can.

This also means that we can support e.g. Tree Style Tab in these newer versions. This fixes #2680 for FF57+.