### PR TITLE
Inject user css into all frames

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -263,10 +263,9 @@ selectTab = (direction, {count, tab}) ->
             Math.max 0, tabs.length - count
       chrome.tabs.update tabs[toSelect].id, active: true
 
-chrome.tabs.onUpdated.addListener (tabId, changeInfo, tab) ->
-  return unless changeInfo.status == "loading" # Only do this once per URL change.
+chrome.webNavigation.onCommitted.addListener ({tabId, frameId}) ->
   cssConf =
-    allFrames: true
+    frameId: frameId
     code: Settings.get("userDefinedLinkHintCss")
     runAt: "document_start"
   chrome.tabs.insertCSS tabId, cssConf, -> chrome.runtime.lastError

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -407,5 +407,13 @@ DomUtils =
   windowIsTooSmall: ->
     return window.innerWidth < 3 or window.innerHeight < 3
 
+  # Inject user styles manually. This is only necessary for our chrome-extension:// pages and frames.
+  injectUserCss: ->
+    Settings.onLoaded ->
+      style = document.createElement "style"
+      style.type = "text/css"
+      style.textContent = Settings.get "userDefinedLinkHintCss"
+      document.head.appendChild style
+
 root = exports ? window
 root.DomUtils = DomUtils

--- a/pages/help_dialog.coffee
+++ b/pages/help_dialog.coffee
@@ -131,6 +131,9 @@ UIComponentServer.registerHandler (event) ->
       # Abandon any HUD which might be showing within the help dialog.
       HUD.abandon()
 
+document.addEventListener "DOMContentLoaded", ->
+  DomUtils.injectUserCss() # Manually inject custom user styles.
+
 root = exports ? window
 root.HelpDialog = HelpDialog
 root.isVimiumHelpDialog = true

--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -12,6 +12,9 @@ setTextInInputElement = (inputElement, text) ->
   selection.removeAllRanges()
   selection.addRange range
 
+document.addEventListener "DOMContentLoaded", ->
+  DomUtils.injectUserCss() # Manually inject custom user styles.
+
 document.addEventListener "keydown", (event) ->
   inputElement = document.getElementById "hud-find-input"
   return unless inputElement? # Don't do anything if we're not in find mode.

--- a/pages/logging.coffee
+++ b/pages/logging.coffee
@@ -1,6 +1,7 @@
 $ = (id) -> document.getElementById id
 
 document.addEventListener "DOMContentLoaded", ->
+  DomUtils.injectUserCss() # Manually inject custom user styles.
   $("vimiumVersion").innerText = Utils.getCurrentVersion()
 
   chrome.storage.local.get "installDate", (items) ->

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -311,6 +311,7 @@ initPopupPage = ->
 #
 # Initialization.
 document.addEventListener "DOMContentLoaded", ->
+  DomUtils.injectUserCss() # Manually inject custom user styles.
   xhr = new XMLHttpRequest()
   xhr.open 'GET', chrome.extension.getURL('pages/exclusions.html'), true
   xhr.onreadystatechange = ->

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -335,5 +335,8 @@ UIComponentServer.registerHandler (event) ->
     when "hidden" then Vomnibar.onHidden()
     when "activate" then Vomnibar.activate event.data
 
+document.addEventListener "DOMContentLoaded", ->
+  DomUtils.injectUserCss() # Manually inject custom user styles.
+
 root = exports ? window
 root.Vomnibar = Vomnibar

--- a/tests/unit_tests/test_chrome_stubs.coffee
+++ b/tests/unit_tests/test_chrome_stubs.coffee
@@ -60,6 +60,8 @@ exports.chrome =
       addListener: () ->
     onReferenceFragmentUpdated:
       addListener: () ->
+    onCommitted:
+      addListener: () ->
 
   windows:
     onRemoved:


### PR DESCRIPTION
This fixes #2594 by using the idea from [my comment](https://github.com/philc/vimium/issues/2594#issuecomment-322198798) there.

I've also added code to manually inject the css into all of our pages/frames. This means that
* custom link hint styles will be applied in the options page, help dialog, etc.
* this also technically fixes #2676 and similar in the process, since the user css can be used to theme our `UIComponent` iframe contents.