### PR TITLE
Updated "Treat find queries as regular expressions"

### DIFF
--- a/pages/options.html
+++ b/pages/options.html
@@ -202,7 +202,7 @@ b: http://b.com/?q=%s description
               </div>
               <label>
                 <input id="regexFindMode" type="checkbox"/>
-                Treat find queries as regular expressions
+                Treat find queries as JavaScript regular expressions
               </label>
             </td>
           </tr>


### PR DESCRIPTION
Changed "Treat find queries as regular expressions" to "Treat find queries as Javascript regular expressions", to reduce confusion. There are tonnes of different types of regular expressions, so specifying what type of regular expressions is used, will reduce confusion.