### PR TITLE
FF: Lazy load the Vomnibar for XML documents

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -160,9 +160,14 @@ installModes = ->
 initializeOnEnabledStateKnown = (isEnabledForUrl) ->
   installModes() unless normalMode
   if isEnabledForUrl
-    # We only initialize (and activate) the Vomnibar in the top frame.  Also, we do not initialize the
-    # Vomnibar until we know that Vimium is enabled.  Thereafter, there's no more initialization to do.
-    DomUtils.documentComplete Vomnibar.init.bind Vomnibar if DomUtils.isTopFrame()
+    unless Utils.isFirefox() and document.documentElement.namespaceURI != "http://www.w3.org/1999/xhtml"
+      # We only initialize (and activate) the Vomnibar in the top frame.  Also, we do not initialize the
+      # Vomnibar until we know that Vimium is enabled.  Thereafter, there's no more initialization to do.
+      #
+      # NOTE(mrmr1993): In XML documents on Firefox, injecting HTML into the DOM breaks the rendering, so we
+      # lazy load the Vomnibar. This comes with the expected issues, but is better than breaking all XML
+      # documents.
+      DomUtils.documentComplete Vomnibar.init.bind Vomnibar if DomUtils.isTopFrame()
     initializeOnEnabledStateKnown = ->
 
 #

--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -53,10 +53,10 @@ Vomnibar =
   #   selectFirst - Optional, boolean. Whether to select the first entry.
   #   newTab      - Optional, boolean. Whether to open the result in a new tab.
   open: (sourceFrameId, options) ->
-    if @vomnibarUI?
-      # The Vomnibar cannot coexist with the help dialog (it causes focus issues).
-      HelpDialog.abort()
-      @vomnibarUI.activate extend options, { name: "activate", sourceFrameId, focus: true }
+    @init()
+    # The Vomnibar cannot coexist with the help dialog (it causes focus issues).
+    HelpDialog.abort()
+    @vomnibarUI.activate extend options, { name: "activate", sourceFrameId, focus: true }
 
 root = exports ? window
 root.Vomnibar = Vomnibar


### PR DESCRIPTION
Injecting HTML into XML documents on Firefox breaks the rendering (collapsing it into plain text). This PR helps us avoid that situation (at least, until a user triggers some of our UI manually).

This fixes #2690.