### PR TITLE
Coffeescript v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js: 0.12
 before_install:
-  - "npm install -g coffee-script"
+  - "npm install -g coffeescript@1"
   - "npm install path@0.11"
   - "npm install util"
   - "npm install -g phantomjs@1.9.20"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,6 @@ Vimium is written in Coffeescript, which compiles to Javascript. To
 install Vimium from source:
 
  1. Install [Coffeescript](http://coffeescript.org/#installation).
-   - Vimium doesn't currently support Coffeescript v2.
-   - You can install the latest Coffeescript v1 release using `npm install --global coffeescript@1`.
  1. Run `cake build` from within your vimium directory. Any coffeescript files you change will now be automatically compiled to Javascript.
  1. Navigate to `chrome://extensions`
  1. Toggle into Developer Mode
@@ -37,6 +35,7 @@ install Vimium from source:
 
 Our tests use [shoulda.js](https://github.com/philc/shoulda.js) and [PhantomJS](http://phantomjs.org/). To run the tests:
 
+ 1. `npm install coffeescript@1` to install Coffeescript v1. We do not yet support coffeescript v2.
  1. `git submodule update --init --recursive` -- this pulls in shoulda.js.
  1. Install [PhantomJS](http://phantomjs.org/download.html).
  1. `npm install path@0.11` to install the [Node.js Path module](https://nodejs.org/api/path.html), used by the test runner.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,8 @@ Vimium is written in Coffeescript, which compiles to Javascript. To
 install Vimium from source:
 
  1. Install [Coffeescript](http://coffeescript.org/#installation).
+   - Vimium doesn't currently support Coffeescript v2.
+   - You can install the latest Coffeescript v1 release using `npm install --global coffeescript@1`.
  1. Run `cake build` from within your vimium directory. Any coffeescript files you change will now be automatically compiled to Javascript.
  1. Navigate to `chrome://extensions`
  1. Toggle into Developer Mode

--- a/Cakefile
+++ b/Cakefile
@@ -118,7 +118,7 @@ runUnitTests = (projectDir=".", testNameFilter) ->
   Tests.run(testNameFilter)
   return Tests.testsFailed
 
-option '', '--filter-tests [string]', 'filter tests by matching string'
+option undefined, '--filter-tests [string]', 'filter tests by matching string'
 task "test", "run all tests", (options) ->
   unitTestsFailed = runUnitTests('.', options['filter-tests'])
 

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -862,15 +862,17 @@ LocalHints =
 # Suppress all keyboard events until the user stops typing for sufficiently long.
 class TypingProtector extends Mode
   constructor: (delay, callback) ->
+    super
+      name: "hint/typing-protector"
+      suppressAllKeyboardEvents: true
+
     @timer = Utils.setTimeout delay, => @exit()
 
     resetExitTimer = (event) =>
       clearTimeout @timer
       @timer = Utils.setTimeout delay, => @exit()
 
-    super
-      name: "hint/typing-protector"
-      suppressAllKeyboardEvents: true
+    @push
       keydown: resetExitTimer
       keypress: resetExitTimer
 

--- a/content_scripts/mode_find.coffee
+++ b/content_scripts/mode_find.coffee
@@ -60,12 +60,6 @@ class FindMode extends Mode
     hasResults: false
 
   constructor: (options = {}) ->
-    # Save the selection, so findInPlace can restore it.
-    @initialRange = getCurrentRange()
-    FindMode.query = rawQuery: ""
-    if options.returnToViewport
-      @scrollX = window.scrollX
-      @scrollY = window.scrollY
     super extend options,
       name: "find"
       indicator: false
@@ -74,6 +68,13 @@ class FindMode extends Mode
       # This prevents further Vimium commands launching before the find-mode HUD receives the focus.
       # E.g. "/" followed quickly by "i" should not leave us in insert mode.
       suppressAllKeyboardEvents: true
+
+    # Save the selection, so findInPlace can restore it.
+    @initialRange = getCurrentRange()
+    FindMode.query = rawQuery: ""
+    if options.returnToViewport
+      @scrollX = window.scrollX
+      @scrollY = window.scrollY
 
     HUD.showFindMode this
 

--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -1,6 +1,11 @@
 
 class InsertMode extends Mode
   constructor: (options = {}) ->
+    defaults =
+      name: "insert"
+      indicator: if not options.permanent and not Settings.get "hideHud"  then "Insert mode"
+    super extend defaults, options
+
     # There is one permanently-installed instance of InsertMode.  It tracks focus changes and
     # activates/deactivates itself (by setting @insertModeLock) accordingly.
     @permanent = options.permanent
@@ -28,14 +33,10 @@ class InsertMode extends Mode
       @exit event, event.target
       DomUtils.consumeKeyup event
 
-    defaults =
-      name: "insert"
-      indicator: if not @permanent and not Settings.get "hideHud"  then "Insert mode"
+    @push
       keypress: handleKeyEvent
       keyup: handleKeyEvent
       keydown: handleKeyEvent
-
-    super extend defaults, options
 
     @insertModeLock =
       if options.targetElement and DomUtils.isEditable options.targetElement

--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -27,7 +27,8 @@ class KeyHandlerMode extends Mode
 
     super extend options,
       keydown: @onKeydown.bind this
-      # We cannot track keyup events if we lose the focus.
+
+    @push # We cannot track keyup events if we lose the focus.
       blur: (event) => @alwaysContinueBubbling => @keydownEvents = {} if event.target == window
 
     if options.exitOnEscape

--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -14,7 +14,6 @@
 class KeyHandlerMode extends Mode
   setKeyMapping: (@keyMapping) -> @reset()
   setPassKeys: (@passKeys) -> @reset()
-  # Only for tests.
   setCommandHandler: (@commandHandler) ->
 
   # Reset the key state, optionally retaining the count provided.
@@ -22,7 +21,6 @@ class KeyHandlerMode extends Mode
     @keyState = [@keyMapping]
 
   constructor: (options) ->
-    @commandHandler = options.commandHandler ? (->)
     @setKeyMapping options.keyMapping ? {}
 
     super extend options,

--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -21,12 +21,12 @@ class KeyHandlerMode extends Mode
     @keyState = [@keyMapping]
 
   constructor: (options) ->
+    super options
     @setKeyMapping options.keyMapping ? {}
 
-    super extend options,
+    @push
       keydown: @onKeydown.bind this
-
-    @push # We cannot track keyup events if we lose the focus.
+      # We cannot track keyup events if we lose the focus.
       blur: (event) => @alwaysContinueBubbling => @keydownEvents = {} if event.target == window
 
     if options.exitOnEscape

--- a/content_scripts/mode_visual.coffee
+++ b/content_scripts/mode_visual.coffee
@@ -237,7 +237,7 @@ class VisualMode extends KeyHandlerMode
       exitOnEscape: true
       suppressAllKeyboardEvents: true
       keyMapping: keyMapping
-      commandHandler: @commandHandler.bind this
+    @setCommandHandler @commandHandler.bind this
 
     # If there was a range selection when the user lanuched visual mode, then we retain the selection on exit.
     @shouldRetainSelectionOnExit = @options.userLaunchedMode and DomUtils.getSelectionType(@selection) == "Range"

--- a/content_scripts/mode_visual.coffee
+++ b/content_scripts/mode_visual.coffee
@@ -209,6 +209,13 @@ class VisualMode extends KeyHandlerMode
     "o": -> @movement.reverseSelection()
 
   constructor: (options = {}) ->
+    super extend options,
+      name: options.name ? "visual"
+      indicator: options.indicator ? "Visual mode"
+      singleton: "visual-mode-group" # Visual mode, visual-line mode and caret mode each displace each other.
+      exitOnEscape: true
+      suppressAllKeyboardEvents: true
+
     @movement = new Movement options.alterMethod ? "extend"
     @selection = @movement.selection
 
@@ -230,13 +237,7 @@ class VisualMode extends KeyHandlerMode
       "<c-e>": command: (count) -> Scroller.scrollBy "y", count * Settings.get("scrollStepSize"), 1, false
       "<c-y>": command: (count) -> Scroller.scrollBy "y", -count * Settings.get("scrollStepSize"), 1, false
 
-    super extend options,
-      name: options.name ? "visual"
-      indicator: options.indicator ? "Visual mode"
-      singleton: "visual-mode-group" # Visual mode, visual-line mode and caret mode each displace each other.
-      exitOnEscape: true
-      suppressAllKeyboardEvents: true
-      keyMapping: keyMapping
+    @setKeyMapping keyMapping
     @setCommandHandler @commandHandler.bind this
 
     # If there was a range selection when the user lanuched visual mode, then we retain the selection on exit.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -116,9 +116,9 @@ class NormalMode extends KeyHandlerMode
     defaults =
       name: "normal"
       indicator: false # There is normally no mode indicator in normal mode.
-      commandHandler: @commandHandler.bind this
 
     super extend defaults, options
+    @setCommandHandler @commandHandler.bind this
 
     chrome.storage.local.get "normalModeKeyStateMapping", (items) =>
       @setKeyMapping items.normalModeKeyStateMapping

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -45,17 +45,17 @@ bgLog = (args...) ->
 class GrabBackFocus extends Mode
 
   constructor: ->
+    super
+      name: "grab-back-focus"
+
     exitEventHandler = =>
       @alwaysContinueBubbling =>
         @exit()
         chrome.runtime.sendMessage handler: "sendMessageToFrames", message: name: "userIsInteractingWithThePage"
 
-    super
-      name: "grab-back-focus"
-      keydown: exitEventHandler
-
     @push
-      _name: "grab-back-focus-mousedown"
+      _name: "grab-back-focus-keydown-mousedown"
+      keydown: exitEventHandler
       mousedown: exitEventHandler
 
     Settings.use "grabBackFocus", (grabBackFocus) =>

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -133,6 +133,7 @@ class ExclusionRulesOption extends Option
 class ExclusionRulesOnPopupOption extends ExclusionRulesOption
   constructor: (@url, args...) ->
     super(args...)
+    @fetch()
 
   addRule: ->
     element = super @generateDefaultPattern()
@@ -151,7 +152,7 @@ class ExclusionRulesOnPopupOption extends ExclusionRulesOption
     haveMatch = false
     for element in elements
       pattern = @getPattern(element).value.trim()
-      if 0 <= @url.search bgExclusions.RegexpCache.get pattern
+      if 0 <= @url?.search bgExclusions.RegexpCache.get pattern
         haveMatch = true
         @getPassKeys(element).focus()
       else


### PR DESCRIPTION
This PR makes the changes necessary to get Vimium running on Coffeescript 2.

Points of interest are the commit that fixes #2671 (7fa2358) and the commit that applies a `blur` handler that previously only *looked* like it was being applied (af74f65). Everything else is shuffling code around to satisfy ES6 classes' "no this before super" requirement or updating documentation.

Note: The tests don't currently run under CS2; for that we still need CS1. I have updated the documentation to reflect this.

Everything seems to function as normal in Chrome and Firefox in a CS2 build.

Edit: there's also a coffeescript bug, so you'll want the [patch for that](https://github.com/jashkenas/coffeescript/pull/4730#issuecomment-333614795) to test it. For the current version, you can just drop [this file](https://github.com/mrmr1993/coffeescript/blob/b93c4475991fd4a5ce31fcc50e07acde30022252/lib/coffeescript/lexer.js) over `node_modules/coffeescript/lib/coffeescript/lexer.js`.

Edit 2: all tests run properly and pass as expected on [PhantomJS 2.5.0-beta](https://bitbucket.org/ariya/phantomjs/downloads/) with a few minor tweaks (346d5395f8e15e31e45fdb49347d7731a8d83978 and f2e8813111eda01d5b4a18d3dff1b96e37772174).