### PR TITLE
Make link hints all equal length

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -17,6 +17,7 @@ Contributors:
   ConradIrwin
   Daniel MacDougall <dmacdougall@gmail.com> (github: dmacdougall)
   drizzd
+  Eugene Y. Q. Shen <eugene@eyqs.ca> (github: eyqs)
   gpurkins
   hogelog
   int3

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -484,12 +484,14 @@ class FilterHints
     # link-hint numbers.
     @splitRegexp = new RegExp "[\\W#{Utils.escapeRegexSpecialCharacters @linkHintNumbers}]+"
 
-  generateHintString: (linkHintNumber) ->
+  generateHintString: (linkHintNumber, hintLength) ->
     base = @linkHintNumbers.length
     hint = []
     while 0 < linkHintNumber
       hint.push @linkHintNumbers[Math.floor linkHintNumber % base]
       linkHintNumber = Math.floor linkHintNumber / base
+    while hint.length < hintLength
+      hint.push @linkHintNumbers[0]
     hint.reverse().join ""
 
   renderMarker: (marker) ->
@@ -555,9 +557,10 @@ class FilterHints
       @linkTextKeystrokeQueue.pop()
       @filterLinkHints hintMarkers
     else
+      hintLength = Math.ceil((Math.log 1 + matchingHintMarkers.length) / (Math.log @linkHintNumbers.length))
       linkHintNumber = 1
       for linkMarker in matchingHintMarkers
-        linkMarker.hintString = @generateHintString linkHintNumber++
+        linkMarker.hintString = @generateHintString linkHintNumber++, hintLength
         @renderMarker linkMarker
         linkMarker
 


### PR DESCRIPTION
In link-hint mode, I'm used to links opening immediately after I enter the last number. When there are more than ten links on the page, and I type "1", it always takes me a few seconds to realize that I then need to press enter.

This pull request fixes this by making all link hints the same length with leading 0s. The only downside I can see is that on a page with more than a hundred (!) links, typing "002" takes one extra keystroke compared to typing "2<Enter>". I think the frustration of remembering to press enter far outweighs this.