### PR TITLE
Allow <c-[> to be mapped as a regular command.

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -113,6 +113,9 @@ Commands =
           # We don't need these properties in the content scripts.
           delete currentMapping[key][prop] for prop in ["keySequence", "description"]
     chrome.storage.local.set normalModeKeyStateMapping: keyStateMapping
+    # Inform `KeyboardUtils.isEscape()` whether `<c-[>` should be interpreted as `Escape` (which it is by
+    # default).
+    chrome.storage.local.set useVimLikeEscape: "<c-[>" not of keyStateMapping
 
   # Build the "helpPageData" data structure which the help page needs and place it in Chrome storage.
   prepareHelpPageData: ->

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -60,9 +60,13 @@ KeyboardUtils =
       keyChar = mapKeyRegistry[keyChar] ? keyChar
       keyChar
 
-  isEscape: (event) ->
-    # <c-[> is mapped to Escape in Vim by default.
-    event.key == "Escape" || @getKeyCharString(event) == "<c-[>"
+  isEscape: do ->
+    useVimLikeEscape = true
+    Utils.monitorChromeStorage "useVimLikeEscape", (value) -> useVimLikeEscape = value
+
+    (event) ->
+      # <c-[> is mapped to Escape in Vim by default.
+      event.key == "Escape" or (useVimLikeEscape and @getKeyCharString(event) == "<c-[>")
 
   isBackspace: (event) ->
     event.key in ["Backspace", "Delete"]


### PR DESCRIPTION
If

    map <c-[> someCommand

is configured, then the hardwired `<c-[>` meaning `Escape` behaviour is disabled.

Users who want to map `<c-[>` probably *never* use it as `Escape`.

Fixes #2722.