### PR TITLE
Recognise role=tab elements as clickable

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -660,7 +660,7 @@ LocalHints =
 
     # Check for attributes that make an element clickable regardless of its tagName.
     if (element.hasAttribute("onclick") or
-        element.getAttribute("role")?.toLowerCase() in ["button", "link"] or
+        element.getAttribute("role")?.toLowerCase() in ["button" , "tab" , "link"] or
         element.getAttribute("contentEditable")?.toLowerCase() in ["", "contentEditable", "true"])
       isClickable = true
 


### PR DESCRIPTION
In particular, these are used in the current (2017-10-19) version of YouTube. This fixes #2730.