### PR TITLE
Minimal Firefox Android support

### DIFF
--- a/background_scripts/bg_utils.coffee
+++ b/background_scripts/bg_utils.coffee
@@ -18,7 +18,7 @@ class TabRecency
       @deregister removedTabId
       @register addedTabId
 
-    chrome.windows.onFocusChanged.addListener (wnd) =>
+    chrome.windows?.onFocusChanged.addListener (wnd) =>
       if wnd != chrome.windows.WINDOW_ID_NONE
         chrome.tabs.query {windowId: wnd, active: true}, (tabs) =>
           @register tabs[0].id if tabs[0]

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -324,7 +324,7 @@ Frames =
     enabledState = Exclusions.isEnabledForUrl request.url
 
     if request.frameIsFocused
-      chrome.browserAction.setIcon tabId: tabId, imageData: do ->
+      chrome.browserAction.setIcon? tabId: tabId, imageData: do ->
         enabledStateIcon =
           if not enabledState.isEnabledForUrl
             DISABLED_ICON

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -148,7 +148,7 @@ toggleMuteTab = do ->
 #
 selectSpecificTab = (request) ->
   chrome.tabs.get(request.id, (tab) ->
-    chrome.windows.update(tab.windowId, { focused: true })
+    chrome.windows?.update(tab.windowId, { focused: true })
     chrome.tabs.update(request.id, { active: true }))
 
 moveTab = ({count, tab, registryEntry}) ->
@@ -449,7 +449,7 @@ chrome.tabs.onRemoved.addListener (tabId) ->
   delete cache[tabId] for cache in [frameIdsForTab, urlForTab, portsForTab, HintCoordinator.tabState]
   chrome.storage.local.get "findModeRawQueryListIncognito", (items) ->
     if items.findModeRawQueryListIncognito
-      chrome.windows.getAll null, (windows) ->
+      chrome.windows?.getAll null, (windows) ->
         for window in windows
           return if window.incognito
         # There are no remaining incognito-mode tabs, and findModeRawQueryListIncognito is set.

--- a/background_scripts/marks.coffee
+++ b/background_scripts/marks.coffee
@@ -82,7 +82,7 @@ Marks =
   # Given a list of tabs candidate tabs, pick one.  Prefer tabs in the current window and tabs with shorter
   # (matching) URLs.
   pickTab: (tabs, callback) ->
-    chrome.windows.getCurrent ({ id }) ->
+    tabPicker = ({ id }) ->
       # Prefer tabs in the current window, if there are any.
       tabsInWindow = tabs.filter (tab) -> tab.windowId == id
       tabs = tabsInWindow if 0 < tabsInWindow.length
@@ -92,6 +92,10 @@ Marks =
       # Prefer shorter URLs.
       tabs.sort (a,b) -> a.url.length - b.url.length
       callback tabs[0]
+    if chrome.windows?
+      chrome.windows.getCurrent tabPicker
+    else
+      tabPicker({id: undefined})
 
 root = exports ? window
 root.Marks = Marks


### PR DESCRIPTION
`chrome.windows` and `chrome.browserAction.setIcon` [aren't supported by Firefox on android](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Differences_between_desktop_and_Android). By adding guards to these in the code, Vimium then works (or, at least, doesn't crash) on Firefox for Android.

I've only added guards where the code runs as expected on android without the APIs. Where code *needs* to access `chrome.windows` I've left it unguarded, so that we get errors that might be useful for debugging later on. E.g. opening an incognito window will still throw an error, since we're unable to call `chrome.windows.create`. None of these are in places where throwing will crash the extension.

This fixes #2662, in the loosest sense of the word.