### PR TITLE
Add hard option to reload command

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -346,7 +346,9 @@ extend window,
   scrollRight: (count) -> Scroller.scrollBy "x", Settings.get("scrollStepSize") * count
 
 extend window,
-  reload: -> window.location.reload()
+  reload: (count, options) ->
+    hard = options?.hard
+    window.location.reload(hard)
   goBack: (count) -> history.go(-count)
   goForward: (count) -> history.go(count)
 


### PR DESCRIPTION
With this PR, you can `map <key> reload hard` to reload the page without using the browser cache. This fixes #2486 and closes #2487.

\cc @MrJadaml @krlooss.