### PR TITLE
Add global objects to window.root, re-add to window on DOMLoad

### DIFF
--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -127,5 +127,6 @@ class Tween
       }
     """
 
-root = exports ? window
+root = exports ? (window.root ?= {})
 root.HUD = HUD
+extend window, root unless exports?

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -897,8 +897,9 @@ class WaitForEnter extends Mode
           @exit()
           callback false # false -> isSuccess.
 
-root = exports ? window
+root = exports ? (window.root ?= {})
 root.LinkHints = LinkHints
 root.HintCoordinator = HintCoordinator
 # For tests:
 extend root, {LinkHintsMode, LocalHints, AlphabetHints, WaitForEnter}
+extend window, root unless exports?

--- a/content_scripts/marks.coffee
+++ b/content_scripts/marks.coffee
@@ -84,5 +84,6 @@ Marks =
                 @showMessage "Local mark not set", keyChar
           DomUtils.consumeKeyup event
 
-root = exports ? window
+root = exports ? (window.root ?= {})
 root.Marks =  Marks
+extend window, root unless exports?

--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -209,5 +209,6 @@ class SuppressAllKeyboardEvents extends Mode
       suppressAllKeyboardEvents: true
     super extend defaults, options
 
-root = exports ? window
+root = exports ? (window.root ?= {})
 extend root, {Mode, SuppressAllKeyboardEvents}
+extend window, root unless exports?

--- a/content_scripts/mode_find.coffee
+++ b/content_scripts/mode_find.coffee
@@ -215,6 +215,7 @@ getCurrentRange = ->
     selection.collapseToStart() if selection.type == "Range"
     selection.getRangeAt 0
 
-root = exports ? window
+root = exports ? (window.root ?= {})
 root.PostFindMode = PostFindMode
 root.FindMode = FindMode
+extend window, root unless exports?

--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -129,6 +129,7 @@ class PassNextKeyMode extends Mode
               @exit()
         @passEventToPage
 
-root = exports ? window
+root = exports ? (window.root ?= {})
 root.InsertMode = InsertMode
 root.PassNextKeyMode = PassNextKeyMode
+extend window, root unless exports?

--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -93,5 +93,6 @@ class KeyHandlerMode extends Mode
       @exit() if @options.count? and --@options.count <= 0
     @suppressEvent
 
-root = exports ? window
+root = exports ? (window.root ?= {})
 root.KeyHandlerMode = KeyHandlerMode
+extend window, root unless exports?

--- a/content_scripts/mode_visual.coffee
+++ b/content_scripts/mode_visual.coffee
@@ -380,6 +380,7 @@ class CaretMode extends VisualMode
           return true
     false
 
-root = exports ? window
+root = exports ? (window.root ?= {})
 root.VisualMode = VisualMode
 root.VisualLineMode = VisualLineMode
+extend window, root unless exports?

--- a/content_scripts/scroller.coffee
+++ b/content_scripts/scroller.coffee
@@ -301,5 +301,6 @@ Scroller =
         element = findScrollableElement element, "x", amount, 1
         CoreScroller.scroll element, "x", amount, false
 
-root = exports ? window
+root = exports ? (window.root ?= {})
 root.Scroller = Scroller
+extend window, root unless exports?

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -96,5 +96,6 @@ class UIComponent
         @options = null
         @postMessage "hidden" # Inform the UI component that it is hidden.
 
-root = exports ? window
+root = exports ? (window.root ?= {})
 root.UIComponent = UIComponent
+extend window, root unless exports?

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -6,7 +6,7 @@ root = exports ? (window.root ?= {})
 # On Firefox, sometimes the variables assigned to window are lost (bug 1408996), so we reinstall them.
 # NOTE(mrmr1993): This bug leads to catastrophic failure (ie. nothing works and errors abound).
 DomUtils.documentReady ->
-  (extend ? root.extend) window, root
+  root.extend window, root unless extend?
 
 isEnabledForUrl = true
 isIncognitoMode = chrome.extension.inIncognitoContext

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -2,6 +2,12 @@
 # This content script must be run prior to domReady so that we perform some operations very early.
 #
 
+root = exports ? (window.root ?= {})
+# On Firefox, sometimes the variables assigned to window are lost (bug 1408996), so we reinstall them.
+# NOTE(mrmr1993): This bug leads to catastrophic failure (ie. nothing works and errors abound).
+DomUtils.documentReady ->
+  (extend ? root.extend) window, root
+
 isEnabledForUrl = true
 isIncognitoMode = chrome.extension.inIncognitoContext
 normalMode = null
@@ -245,7 +251,7 @@ Frame =
   postMessage: (handler, request = {}) -> @port.postMessage extend request, {handler}
   linkHintsMessage: (request) -> HintCoordinator[request.messageType] request
   registerFrameId: ({chromeFrameId}) ->
-    frameId = window.frameId = chromeFrameId
+    frameId = root.frameId = window.frameId = chromeFrameId
     # We register a frame immediately only if it is focused or its window isn't tiny.  We register tiny
     # frames later, when necessary.  This affects focusFrame() and link hints.
     if windowIsFocused() or not DomUtils.windowIsTooSmall()
@@ -327,7 +333,7 @@ focusThisFrame = (request) ->
   document.activeElement.blur() if document.activeElement.tagName.toLowerCase() == "iframe"
   flashFrame() if request.highlight
 
-extend window,
+extend root,
   scrollToBottom: ->
     Marks.setPreviousPosition()
     Scroller.scrollTo "y", "max"
@@ -345,7 +351,7 @@ extend window,
   scrollLeft: (count) -> Scroller.scrollBy "x", -1 * Settings.get("scrollStepSize") * count
   scrollRight: (count) -> Scroller.scrollBy "x", Settings.get("scrollStepSize") * count
 
-extend window,
+extend root,
   reload: (count, options) ->
     hard = options?.hard
     window.location.reload(hard)
@@ -654,12 +660,12 @@ findAndFollowRel = (value) ->
         followLink(element)
         return true
 
-window.goPrevious = ->
+root.goPrevious = ->
   previousPatterns = Settings.get("previousPatterns") || ""
   previousStrings = previousPatterns.split(",").filter( (s) -> s.trim().length )
   findAndFollowRel("prev") || findAndFollowLink(previousStrings)
 
-window.goNext = ->
+root.goNext = ->
   nextPatterns = Settings.get("nextPatterns") || ""
   nextStrings = nextPatterns.split(",").filter( (s) -> s.trim().length )
   findAndFollowRel("next") || findAndFollowLink(nextStrings)
@@ -669,11 +675,11 @@ enterFindMode = ->
   Marks.setPreviousPosition()
   new FindMode()
 
-window.showHelp = (sourceFrameId) ->
+root.showHelp = (sourceFrameId) ->
   HelpDialog.toggle {sourceFrameId, showAllCommandDetails: false}
 
 # If we are in the help dialog iframe, then HelpDialog is already defined with the necessary functions.
-window.HelpDialog ?=
+root.HelpDialog ?=
   helpUI: null
   isShowing: -> @helpUI?.showing
   abort: -> @helpUI.hide false if @isShowing()
@@ -690,7 +696,6 @@ window.HelpDialog ?=
 initializePreDomReady()
 DomUtils.documentReady initializeOnDomReady
 
-root = exports ? window
 root.handlerStack = handlerStack
 root.frameId = frameId
 root.Frame = Frame
@@ -701,3 +706,4 @@ extend root, {handleEscapeForFindMode, handleEnterForFindMode, performFind, perf
   enterFindMode, focusThisFrame}
 # These are exported only for the tests.
 extend root, {installModes}
+extend window, root unless exports?

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -419,7 +419,10 @@ extend root,
     # Track the most recently focused input element.
     recentlyFocusedElement = null
     window.addEventListener "focus",
-      forTrusted (event) -> recentlyFocusedElement = event.target if DomUtils.isEditable event.target
+      forTrusted (event) ->
+        DomUtils = window.DomUtils ? root.DomUtils # Workaround FF bug 1408996.
+        if DomUtils.isEditable event.target
+          recentlyFocusedElement = event.target
     , true
 
     (count) ->

--- a/content_scripts/vomnibar.coffee
+++ b/content_scripts/vomnibar.coffee
@@ -58,5 +58,6 @@ Vomnibar =
     HelpDialog.abort()
     @vomnibarUI.activate extend options, { name: "activate", sourceFrameId, focus: true }
 
-root = exports ? window
+root = exports ? (window.root ?= {})
 root.Vomnibar = Vomnibar
+extend window, root unless exports?

--- a/lib/clipboard.coffee
+++ b/lib/clipboard.coffee
@@ -25,5 +25,6 @@ Clipboard =
     value
 
 
-root = exports ? window
+root = exports ? (window.root ?= {})
 root.Clipboard = Clipboard
+extend window, root unless exports?

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -416,5 +416,6 @@ DomUtils =
       style.textContent = Settings.get "userDefinedLinkHintCss"
       document.head.appendChild style
 
-root = exports ? window
+root = exports ? (window.root ?= {})
 root.DomUtils = DomUtils
+extend window, root unless exports?

--- a/lib/find_mode_history.coffee
+++ b/lib/find_mode_history.coffee
@@ -46,5 +46,6 @@ FindModeHistory =
   refreshRawQueryList: (query, rawQueryList) ->
     ([ query ].concat rawQueryList.filter (q) => q != query)[0..@max]
 
-root = exports ? window
+root = exports ? (window.root ?= {})
 root.FindModeHistory = FindModeHistory
+extend window, root unless exports?

--- a/lib/handler_stack.coffee
+++ b/lib/handler_stack.coffee
@@ -1,4 +1,4 @@
-root = exports ? window
+root = exports ? (window.root ?= {})
 
 class HandlerStack
   constructor: ->
@@ -120,3 +120,4 @@ class HandlerStack
 
 root.HandlerStack = HandlerStack
 root.handlerStack = new HandlerStack()
+extend window, root unless exports?

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -101,5 +101,6 @@ KeyboardUtils =
 
 KeyboardUtils.init()
 
-root = exports ? window
+root = exports ? (window.root ?= {})
 root.KeyboardUtils = KeyboardUtils
+extend window, root unless exports?

--- a/lib/rect.coffee
+++ b/lib/rect.coffee
@@ -91,5 +91,6 @@ Rect =
     (rect1, rect2) ->
       halfOverlapChecker(rect1, rect2) or halfOverlapChecker rect2, rect1
 
-root = exports ? window
+root = exports ? (window.root ?= {})
 root.Rect = Rect
+extend window, root unless exports?

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -218,5 +218,6 @@ if Utils.isBackgroundPage()
     # be removed after 1.58 has been out for sufficiently long.
     Settings.nuke "copyNonDefaultsToChromeStorage-20150717"
 
-root = exports ? window
+root = exports ? (window.root ?= {})
 root.Settings = Settings
+extend window, root unless exports?

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -335,8 +335,11 @@ class JobRunner
   onReady: (callback) ->
     @fetcher.use callback
 
-root = exports ? window
+root = exports ? (window.root ?= {})
 root.Utils = Utils
 root.SimpleCache = SimpleCache
 root.AsyncDataFetcher = AsyncDataFetcher
 root.JobRunner = JobRunner
+unless exports?
+  root.extend = extend
+  extend window, root


### PR DESCRIPTION
This PR rewrites assignments to `window` to use `window.root` as an intermediate. We then re-add `window.root`'s properties to `window` ([in `vimium_frontend.coffee`](https://github.com/philc/vimium/commit/aca953e06a7cf5aa6906df677a8fb6ed3e688a03#diff-d0bdd7e52a95f0b05be2cd0f116c20edR8)) so they are still accessible if they disappear as a result of [Firefox bug 1408996](https://bugzilla.mozilla.org/show_bug.cgi?id=1408996).

This fixes Vimium on Facebook.com, CNN.com, support.microsoft.com, etc. Fixes #2675 (and #2739).