### PR TITLE
Add backup/restore for Vimium options.

### DIFF
--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -202,7 +202,7 @@ Settings.init()
 
 # Perform migration from old settings versions, if this is the background page.
 if Utils.isBackgroundPage()
-  Settings.onLoaded ->
+  Settings.applyMigrations = ->
     unless Settings.get "settingsVersion"
       # This is a new install.  For some settings, we retain a legacy default behaviour for existing users but
       # use a non-default behaviour for new users.
@@ -217,6 +217,8 @@ if Utils.isBackgroundPage()
     # Remove legacy key which was used to control storage migration.  This was after 1.57 (2016-10-01), and can
     # be removed after 1.58 has been out for sufficiently long.
     Settings.nuke "copyNonDefaultsToChromeStorage-20150717"
+
+  Settings.onLoaded Settings.applyMigrations.bind Settings
 
 root = exports ? (window.root ?= {})
 root.Settings = Settings

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -335,7 +335,7 @@ DomUtils?.documentReady ->
       backup[option.field] = option.readValueFromElement()
     # Create the blob in the background page so it isn't garbage collected when the page closes in FF.
     bgWin = chrome.extension.getBackgroundPage()
-    blob = new bgWin.Blob [ JSON.stringify backup ]
+    blob = new bgWin.Blob [ JSON.stringify backup, null, 2 ]
     url =  bgWin.URL.createObjectURL blob
     a = $ "backupLink"
     a.href = url

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -333,15 +333,14 @@ DomUtils?.documentReady ->
     backup = {}
     for option in Option.all
       backup[option.field] = option.readValueFromElement()
-    blob = new Blob [ JSON.stringify backup ]
-    url =  window.URL.createObjectURL blob
-    a = document.createElement "a"
-    document.body.appendChild a
-    a.style = "display: none"
+    # Create the blob in the background page so it isn't garbage collected when the page closes in FF.
+    bgWin = chrome.extension.getBackgroundPage()
+    blob = new bgWin.Blob [ JSON.stringify backup ]
+    url =  bgWin.URL.createObjectURL blob
+    a = $ "backupLink"
     a.href = url
-    a.download = "vimium-options-#{new Date().toISOString().split("T")[0]}.json"
-    a.click()
-    document.body.removeChild a
+    a.style.display = ""
+    a.click() unless Utils.isFirefox()
 
   $("chooseFile").addEventListener "change", (event) ->
     document.activeElement?.blur()

--- a/pages/options.html
+++ b/pages/options.html
@@ -327,6 +327,7 @@ b: http://b.com/?q=%s description
                   </div>
                 </div>
               <input id="backupButton" type="button" value="Create Backup" />
+              <a id="backupLink" style="display: none" download="vimium-options.json">Download Backup</span>
             </td>
           </tr>
           <tr>

--- a/pages/options.html
+++ b/pages/options.html
@@ -315,6 +315,32 @@ b: http://b.com/?q=%s description
           </tr>
           -->
         </tbody>
+        <tbody id='backupAndRestor'>
+          <tr>
+            <td colspan="2"><header>Backup and Restore</header></td>
+          </tr>
+          <tr>
+            <td class="caption">Backup</td>
+            <td>
+                <div class="help">
+                  <div class="example">
+                  </div>
+                </div>
+              <input id="backupButton" type="button" value="Create Backup" />
+            </td>
+          </tr>
+          <tr>
+            <td class="caption">Restore</td>
+            <td>
+                <div class="help">
+                  <div class="example">
+                    Choose file, then click <i>Save Changes</i>, below, to confirm restore.
+                  </div>
+                </div>
+              <input id="chooseFile" type="file" accept=".json" style="width: 200px;"/>
+            </td>
+          </tr>
+        </tbody>
       </table>
     </div>
 


### PR DESCRIPTION
See the *very* bottom of the options page (below advanced settings).

Clicking "Backup" creates a JSON file.

Selecting a backup populates the options inputs, the user then clicks *Save Changes* to confirm.

Looks like this:

![snapshot](https://user-images.githubusercontent.com/2641335/32135382-3f2d85fe-bbf6-11e7-8923-4b9f76bbfa97.png)

@mrmr1993 I've always been reticent about doing this in the past, mainly concerned that some combination of backup restore and a change to `Settings` could goof things up.

What do you think?  Also, should we add `settingsVersion` (or anything else) to the backup?

Fixes #1440.