### PR TITLE
Fix backup link for FF and Chrome.

### DIFF
--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -333,8 +333,7 @@ document.addEventListener "DOMContentLoaded", ->
 #
 # Backup and restore. "?" is for the tests."
 DomUtils?.documentReady ->
-  $("backupButton").addEventListener "click", ->
-    document.activeElement?.blur()
+  populateBackupLinkUrl = ->
     backup = settingsVersion: bgSettings.get "settingsVersion"
     for option in Option.all
       backup[option.field] = option.readValueFromElement()
@@ -344,12 +343,8 @@ DomUtils?.documentReady ->
     url =  bgWin.URL.createObjectURL blob
     a = $ "backupLink"
     a.href = url
-    if Utils.isFirefox()
-      # On Firefox, the user has to click the link manually.
-      a.style.display = ""
-      a.textContent = "Click to download backup"
-    else
-      a.click()
+
+  $("backupLink").addEventListener "mousedown", populateBackupLinkUrl, true
 
   $("chooseFile").addEventListener "change", (event) ->
     document.activeElement?.blur()

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -340,9 +340,7 @@ DomUtils?.documentReady ->
     # Create the blob in the background page so it isn't garbage collected when the page closes in FF.
     bgWin = chrome.extension.getBackgroundPage()
     blob = new bgWin.Blob [ JSON.stringify backup, null, 2 ]
-    url =  bgWin.URL.createObjectURL blob
-    a = $ "backupLink"
-    a.href = url
+    $("backupLink").href = bgWin.URL.createObjectURL blob
 
   $("backupLink").addEventListener "mousedown", populateBackupLinkUrl, true
 

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -100,8 +100,10 @@ class ExclusionRulesOption extends Option
       element
 
   populateElement: (rules) ->
-    for rule in rules
-      @appendRule rule
+    # For the case of restoring a backup, we first have to remove existing rules.
+    exclusionRules = $ "exclusionRules"
+    exclusionRules.deleteRow 1 while exclusionRules.rows[1]
+    @appendRule rule for rule in rules
 
   # Append a row for a new rule.  Return the newly-added element.
   appendRule: (rule) ->

--- a/pages/options.css
+++ b/pages/options.css
@@ -231,3 +231,6 @@ input.pattern, input.passKeys, .exclusionHeaderText {
   white-space: nowrap;
   width: 110px;
 }
+#backupLink {
+  cursor: pointer;
+}

--- a/pages/options.html
+++ b/pages/options.html
@@ -326,8 +326,7 @@ b: http://b.com/?q=%s description
                   <div class="example">
                   </div>
                 </div>
-              <input id="backupButton" type="button" value="Create Backup" />
-              <a id="backupLink" style="display: none" download="vimium-options.json"></a>
+              <a id="backupLink" download="vimium-options.json">Click to download backup</a>
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
This makes the UI for generating an options backup the same for FF and Chrome.

We populate the *Backup* link on `mousedown`.

@mrmr1993 This seems to make the UI as similar as possible between Chrome and Firefox.