### PR TITLE
Typos

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -355,7 +355,7 @@ handleFrameFocused = ({tabId, frameId}) ->
 
 # Rotate through frames to the frame count places after frameId.
 cycleToFrame = (frames, frameId, count = 0) ->
-  # We can't always track which frame chrome has focussed, but here we learn that it's frameId; so add an
+  # We can't always track which frame chrome has focused, but here we learn that it's frameId; so add an
   # additional offset such that we do indeed start from frameId.
   count = (count + Math.max 0, frames.indexOf frameId) % frames.length
   [frames[count..]..., frames[0...count]...]

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -236,7 +236,7 @@ Frame =
     handlerStack.reset()
     isEnabledForUrl = false
     window.removeEventListener "focus", onFocus
-    window.removeEventListener "hashchange", onFocus
+    window.removeEventListener "hashchange", checkEnabledAfterURLChange
 
 setScrollPosition = ({ scrollX, scrollY }) ->
   DomUtils.documentReady ->

--- a/pages/options.html
+++ b/pages/options.html
@@ -316,7 +316,7 @@ b: http://b.com/?q=%s description
           </tr>
           -->
         </tbody>
-        <tbody id='backupAndRestor'>
+        <tbody id='backupAndRestore'>
           <tr>
             <td colspan="2"><header>Backup and Restore</header></td>
           </tr>


### PR DESCRIPTION
This PR removes the right listener for `hashchange` when we're clearing our listeners, and fixes another couple of typos.