### PR TITLE
Add some roles used by GMail to link hints

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -658,9 +658,12 @@ LocalHints =
     isClickable ||= @checkForAngularJs element
 
     # Check for attributes that make an element clickable regardless of its tagName.
-    if (element.hasAttribute("onclick") or
-        element.getAttribute("role")?.toLowerCase() in ["button" , "tab" , "link"] or
-        element.getAttribute("contentEditable")?.toLowerCase() in ["", "contentEditable", "true"])
+    if element.hasAttribute("onclick") or
+        (role = element.getAttribute "role") and role.toLowerCase() in [
+          "button" , "tab" , "link", "checkbox", "menuitem", "menuitemcheckbox", "menuitemradio"
+        ] or
+        (contentEditable = element.getAttribute "contentEditable") and
+          contentEditable.toLowerCase() in ["", "contentEditable", "true"]
       isClickable = true
 
     # Check for jsaction event listeners on the element.


### PR DESCRIPTION
This PR also reduces the number of comparisons needed for (the vast majority of) elements which have no `role` or `contentEditable` attribute.