### PR TITLE
Add more named keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,10 @@ The following special keys are available for mapping:
 
 - `<c-*>`, `<a-*>`, `<m-*>` for ctrl, alt, and meta (command on Mac) respectively with any key. Replace `*`
   with the key of choice.
-- `<left>`, `<right>`, `<up>`, `<down>` for the arrow keys
-- `<space>` and `<backspace>` for the space and backspace keys
-- `<f1>` through `<f12>` for the function keys
+- `<left>`, `<right>`, `<up>`, `<down>` for the arrow keys.
+- `<f1>` through `<f12>` for the function keys.
+- `<space>` for the space key.
+- `<tab>`, `<enter>`, `<delete>`, `<backspace>`, `<insert>`, `<home>` and `<end>` for the corresponding non-printable keys.
 
 Shifts are automatically detected so, for example, `<c-&>` corresponds to ctrl+shift+7 on an English keyboard.
 

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -5,7 +5,18 @@ Utils?.monitorChromeStorage "mapKeyRegistry", (value) => mapKeyRegistry = value
 KeyboardUtils =
   # This maps event.key key names to Vimium key names.
   keyNames:
-    "ArrowLeft": "left", "ArrowUp": "up", "ArrowRight": "right", "ArrowDown": "down", " ": "space", "Backspace": "backspace"
+    "ArrowLeft": "left"
+    "ArrowUp": "up"
+    "ArrowRight": "right"
+    "ArrowDown": "down"
+    "Backspace": "backspace"
+    "Tab": "tab"
+    "Enter": "enter"
+    "Delete": "delete"
+    "Insert": "insert"
+    "Home": "home"
+    "End": "end"
+    " ": "space"
 
   init: ->
     if (navigator.userAgent.indexOf("Mac") != -1)


### PR DESCRIPTION
This adds several additional named keys:

    tab
    enter
    delete
    insert
    home
    end

This is partially in response to #2769.

The rationale is: why not?  Just let the user decide what they want.