### PR TITLE
Add more named keys (version 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,10 @@ The following special keys are available for mapping:
 
 - `<c-*>`, `<a-*>`, `<m-*>` for ctrl, alt, and meta (command on Mac) respectively with any key. Replace `*`
   with the key of choice.
-- `<left>`, `<right>`, `<up>`, `<down>` for the arrow keys
-- `<space>` and `<backspace>` for the space and backspace keys
-- `<f1>` through `<f12>` for the function keys
+- `<left>`, `<right>`, `<up>`, `<down>` for the arrow keys.
+- `<f1>` through `<f12>` for the function keys.
+- `<space>` for the space key.
+- `<tab>`, `<enter>`, `<delete>`, `<backspace>`, `<insert>`, `<home>` and `<end>` for the corresponding non-printable keys (version 1.62 onwards).
 
 Shifts are automatically detected so, for example, `<c-&>` corresponds to ctrl+shift+7 on an English keyboard.
 
@@ -171,6 +172,7 @@ Release Notes
 In `master` (not yet released)
 
 - Backup and restore Vimium options (see the very bottom of the options page, below *Advanced Options*).
+- It is now possible to map `<tab>`, `<enter>`, `<delete>`, `<insert>`, `<home>` and `<end>`.
 
 1.61 (2017-10-27)
 

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -5,7 +5,7 @@ Utils?.monitorChromeStorage "mapKeyRegistry", (value) => mapKeyRegistry = value
 KeyboardUtils =
   # This maps event.key key names to Vimium key names.
   keyNames:
-    "ArrowLeft": "left", "ArrowUp": "up", "ArrowRight": "right", "ArrowDown": "down", " ": "space", "Backspace": "backspace"
+    "ArrowLeft": "left", "ArrowUp": "up", "ArrowRight": "right", "ArrowDown": "down", " ": "space"
 
   init: ->
     if (navigator.userAgent.indexOf("Mac") != -1)
@@ -38,10 +38,8 @@ KeyboardUtils =
       ""
     else if key.length == 1
       key
-    else if key.length == 2 and "F1" <= key <= "F9"
-      key.toLowerCase() # F1 to F9.
-    else if key.length == 3 and "F10" <= key <= "F12"
-      key.toLowerCase() # F10 to F12.
+    else if 1 < key.length
+      key.toLowerCase()
     else
       ""
 


### PR DESCRIPTION
This allows any special key to mapped, simply by using the `event.key`
key name. E.g.

    map <enter> scrollDown

@mrmr1993... What would be the benefit of using `.code` over `.key`?

Replaces #2770.
Fixes #2769.