### PR TITLE
[WIP] Improved link hints

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -167,6 +167,7 @@ Commands =
       "LinkHints.activateModeToDownloadLink",
       "LinkHints.activateModeToOpenIncognito",
       "LinkHints.activateModeToCopyLinkUrl",
+      "LinkHints.time",
       "goPrevious",
       "goNext",
       "nextFrame",
@@ -220,6 +221,7 @@ Commands =
     "Vomnibar.activateEditUrlInNewTab",
     "LinkHints.activateModeToOpenIncognito",
     "LinkHints.activateModeToCopyLinkUrl",
+    "LinkHints.time",
     "goNext",
     "goPrevious",
     "Marks.activateCreateMode",
@@ -357,6 +359,7 @@ commandDescriptions =
   "LinkHints.activateModeToOpenIncognito": ["Open a link in incognito window"]
   "LinkHints.activateModeToDownloadLink": ["Download link url"]
   "LinkHints.activateModeToCopyLinkUrl": ["Copy a link URL to the clipboard"]
+  "LinkHints.time": ["Compare timings of the old and new algorithms"]
 
   enterFindMode: ["Enter find mode", { noRepeat: true }]
   performFind: ["Cycle forward to the next find match"]

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -382,10 +382,10 @@ HintCoordinator =
     for own frameId, port of @tabState[tabId].ports
       @postMessage tabId, parseInt(frameId), messageType, port, request
 
-  prepareToActivateMode: (tabId, originatingFrameId, {modeIndex, isVimiumHelpDialog}) ->
+  prepareToActivateMode: (tabId, originatingFrameId, {modeIndex, isVimiumHelpDialog, options}) ->
     @tabState[tabId] = {frameIds: frameIdsForTab[tabId][..], hintDescriptors: {}, originatingFrameId, modeIndex}
     @tabState[tabId].ports = extend {}, portsForTab[tabId]
-    @sendMessage "getHintDescriptors", tabId, {modeIndex, isVimiumHelpDialog}
+    @sendMessage "getHintDescriptors", tabId, {modeIndex, isVimiumHelpDialog, options}
 
   # Receive hint descriptors from all frames and activate link-hints mode when we have them all.
   postHintDescriptors: (tabId, frameId, {hintDescriptors}) ->

--- a/content_scripts/mode_normal.coffee
+++ b/content_scripts/mode_normal.coffee
@@ -187,6 +187,22 @@ if LinkHints?
     "LinkHints.activateModeToDownloadLink": LinkHints.activateModeToDownloadLink.bind LinkHints
     "LinkHints.activateModeToCopyLinkUrl": LinkHints.activateModeToCopyLinkUrl.bind LinkHints
 
+    "LinkHints.time": (count) ->
+      oldTimeStart = new Date()
+      for _ in [0 ... count] by 1
+        LocalHints.getLocalHints false, false
+      oldTimeEnd = new Date()
+
+      newTimeStart = new Date()
+      for _ in [0 ... count] by 1
+        LocalHints.getLocalHints false, true
+      newTimeEnd = new Date()
+
+      oldTime = oldTimeEnd - oldTimeStart
+      newTime = newTimeEnd - newTimeStart
+      alert """Old algorithm: #{oldTime}ms/#{count} = #{oldTime/count}ms
+New algorithm: #{newTime}ms/#{count} = #{newTime/count}ms"""
+
 if Vomnibar?
   extend NormalModeCommands,
     "Vomnibar.activate": Vomnibar.activate.bind Vomnibar

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -151,7 +151,7 @@ DomUtils =
   # Get the client rects for the <area> elements in a <map> based on the position of the <img> element using
   # the map. Returns an array of rects.
   #
-  getClientRectsForAreas: (imgClientRect, areas) ->
+  getClientRectsForAreas: (imgClientRect, areas, cropRect) ->
     rects = []
     for area in areas
       coords = area.coords.split(",").map((coord) -> parseInt(coord, 10))
@@ -173,7 +173,10 @@ DomUtils =
         [x1, y1, x2, y2] = coords
 
       rect = Rect.translate (Rect.create x1, y1, x2, y2), imgClientRect.left, imgClientRect.top
-      rect = @cropRectToVisible rect
+      if cropRect
+        rect = Rect.intersect rect, cropRect
+      else
+        rect = @cropRectToVisible rect
 
       rects.push {element: area, rect: rect} if rect and not isNaN rect.top
     rects

--- a/lib/rect.coffee
+++ b/lib/rect.coffee
@@ -88,6 +88,21 @@ Rect =
     @create (Math.max rect1.left, rect2.left), (Math.max rect1.top, rect2.top),
         (Math.min rect1.right, rect2.right), (Math.min rect1.bottom, rect2.bottom)
 
+  # Determine whether innerRect is contained by outerRect.
+  contains: (innerRect, outerRect) ->
+    innerRect.left >= outerRect.left and
+    innerRect.right <= outerRect.right and
+    innerRect.top >= outerRect.top and
+    innerRect.bottom <= outerRect.bottom
+
+  containsX: (innerRect, outerRect) ->
+    innerRect.left >= outerRect.left and
+    innerRect.right <= outerRect.right
+
+  containsY: (innerRect, outerRect) ->
+    innerRect.top >= outerRect.top and
+    innerRect.bottom <= outerRect.bottom
+
 root = exports ? (window.root ?= {})
 root.Rect = Rect
 extend window, root unless exports?

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -102,8 +102,7 @@ class Renderer
   rendered: (elementInfo) ->
     elementInfo.rendered ?=
       elementInfo.clippedRect.left < elementInfo.clippedRect.right and
-      elementInfo.clippedRect.top < elementInfo.clippedRect.bottom and
-      @isVisible elementInfo
+      elementInfo.clippedRect.top < elementInfo.clippedRect.bottom
 
   # processRendered is called on each rendered element as it is found, passed Renderer's internal elementInfo
   # struct as the only argument.
@@ -118,16 +117,18 @@ class Renderer
       if @inViewport elementInfo
         elementInfo.clippedRect = Rect.intersect elementInfo.boundingRect, @viewport
 
-        if parentInfo?
-          if parentInfo.clippedRect? and Rect.contains elementInfo.clippedRect, parentInfo.clippedRect and
-              @isVisible elementInfo
-            processRendered elementInfo
-            renderedElements.push elementInfo
-          else
-            @clipBy elementInfo, parentInfo
-            if @rendered elementInfo
+        if @isVisible elementInfo
+          if parentInfo?
+            if parentInfo.clippedRect? and Rect.contains elementInfo.clippedRect, parentInfo.clippedRect
               processRendered elementInfo
               renderedElements.push elementInfo
+            else
+              @clipBy elementInfo, parentInfo
+              if @rendered elementInfo
+                processRendered elementInfo
+                renderedElements.push elementInfo
+        else
+          elementInfo.rendered = false
       else
         elementInfo.rendered = false
 

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -96,14 +96,19 @@ class Renderer
       elementInfo.clippedRect = Rect.intersect elementInfo.clippedRect, absClippingRect
     return
 
+  visibility: (elementInfo) ->
+    elementInfo.visibility ?= window.getComputedStyle(elementInfo.element).visibility
+
   rendered: (elementInfo) ->
     elementInfo.rendered ?=
       elementInfo.clippedRect.left < elementInfo.clippedRect.right and
-      elementInfo.clippedRect.top < elementInfo.clippedRect.bottom
+      elementInfo.clippedRect.top < elementInfo.clippedRect.bottom and
+      "visible" == @visibility elementInfo
 
   setOverflowingElement: (elementInfo, ancestorInfo, checkBounds) ->
-    if not checkBounds or Rect.contains elementInfo.clippedRect, ancestorInfo.clippedRect
-      (ancestorInfo.overflowingElements ?= []).push elementsInfo
+    if not checkBounds or not ancestorInfo.clippedRect or
+        Rect.contains elementInfo.clippedRect, ancestorInfo.clippedRect
+      (ancestorInfo.overflowingElements ?= []).push elementInfo
       @setOverflowingElement elementInfo, ancestorInfo.parentInfo, true if ancestorInfo.parentInfo?
 
   # - processRendered is called on each rendered element as it is found
@@ -122,7 +127,8 @@ class Renderer
         elementInfo.clippedRect = Rect.intersect elementInfo.boundingRect, @viewport
 
         if parentInfo?
-          if parentInfo.clippedRect? and Rect.contains elementInfo.clippedRect, parentInfo.clippedRect
+          if parentInfo.clippedRect? and Rect.contains elementInfo.clippedRect, parentInfo.clippedRect and
+              "visible" == @visibility elementInfo
             processRendered elementInfo
             renderedElements.push elementInfo
           else

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -9,6 +9,8 @@ class Renderer
     else if clientRects.length == 1
       elementInfo.boundingRect = clientRects[0]
     else
+      # This element is inline, so it can't clip overflow.
+      elementInfo.clips = elementInfo.clipsX = elementInfo.clipsY = false
       elementInfo.boundingRect = elementInfo.element.getBoundingClientRect()
     # Don't need to use intersectsStrict here, since we don't care about 0-width intersections.
     Rect.intersects elementInfo.boundingRect, @viewport

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -147,6 +147,131 @@ class Renderer
 
     renderedElements
 
+  getImageMapRects: (elementInfo) ->
+    element = elementInfo.element
+    if element.tagName.toLowerCase?() == "img"
+      mapName = element.getAttribute "usemap"
+      if mapName
+        mapName = mapName.replace(/^#/, "").replace("\"", "\\\"")
+        map = document.querySelector "map[name=\"#{mapName}\"]"
+        if map and imgClientRects.length > 0
+          areas = map.getElementsByTagName "area"
+          DomUtils.getClientRectsForAreas elementInfo.clippedRect, areas, elementInfo.clippedRect
+
+  #
+  # Determine whether the element is visible and clickable. If it is, find the rect bounding the element in
+  # the viewport.  There may be more than one part of element which is clickable (for example, if it's an
+  # image), therefore we always return a array of element/rect pairs (which may also be a singleton or empty).
+  #
+  isVisibleClickable: (elementInfo) ->
+    # Get the tag name.  However, `element.tagName` can be an element (not a string, see #2305), so we guard
+    # against that.
+    element = elementInfo.element
+    tagName = element.tagName.toLowerCase?() ? ""
+    isClickable = false
+    onlyHasTabIndex = false
+    possibleFalsePositive = false
+    visibleElements = []
+    reason = null
+
+    # Check aria properties to see if the element should be ignored.
+    if (element.getAttribute("aria-hidden")?.toLowerCase() in ["", "true"] or
+        element.getAttribute("aria-disabled")?.toLowerCase() in ["", "true"])
+      return false # This element should never have a link hint.
+
+    # Check for AngularJS listeners on the element.
+    @checkForAngularJs ?= do ->
+      angularElements = document.getElementsByClassName "ng-scope"
+      if angularElements.length == 0
+        -> false
+      else
+        ngAttributes = []
+        for prefix in [ '', 'data-', 'x-' ]
+          for separator in [ '-', ':', '_' ]
+            ngAttributes.push "#{prefix}ng#{separator}click"
+        (element) ->
+          for attribute in ngAttributes
+            return true if element.hasAttribute attribute
+          false
+
+    isClickable ||= @checkForAngularJs element
+
+    # Check for attributes that make an element clickable regardless of its tagName.
+    if element.hasAttribute("onclick") or
+        (role = element.getAttribute "role") and role.toLowerCase() in [
+          "button" , "tab" , "link", "checkbox", "menuitem", "menuitemcheckbox", "menuitemradio"
+        ] or
+        (contentEditable = element.getAttribute "contentEditable") and
+          contentEditable.toLowerCase() in ["", "contenteditable", "true"]
+      isClickable = true
+
+    # Check for jsaction event listeners on the element.
+    if not isClickable and element.hasAttribute "jsaction"
+      jsactionRules = element.getAttribute("jsaction").split(";")
+      for jsactionRule in jsactionRules
+        ruleSplit = jsactionRule.trim().split ":"
+        if 1 <= ruleSplit.length <= 2
+          [eventType, namespace, actionName ] =
+            if ruleSplit.length == 1
+              ["click", ruleSplit[0].trim().split(".")..., "_"]
+            else
+              [ruleSplit[0], ruleSplit[1].trim().split(".")..., "_"]
+          isClickable ||= eventType == "click" and namespace != "none" and actionName != "_"
+
+    # Check for tagNames which are natively clickable.
+    switch tagName
+      when "a"
+        isClickable = true
+      when "textarea"
+        isClickable ||= not element.disabled and not element.readOnly
+      when "input"
+        isClickable ||= not (element.getAttribute("type")?.toLowerCase() == "hidden" or
+                             element.disabled or
+                             (element.readOnly and DomUtils.isSelectable element))
+      when "button", "select"
+        isClickable ||= not element.disabled
+      when "label"
+        isClickable ||= element.control? and not element.control.disabled and
+                        not @getVisibleClickable element.control
+      when "body"
+        isClickable ||=
+          if element == document.body and not windowIsFocused() and
+              window.innerWidth > 3 and window.innerHeight > 3 and
+              document.body?.tagName.toLowerCase() != "frameset"
+            reason = "Frame."
+        isClickable ||=
+          if element == document.body and windowIsFocused() and Scroller.isScrollableElement element
+            reason = "Scroll."
+      when "img"
+        isClickable ||= element.style.cursor in ["zoom-in", "zoom-out"]
+      when "div", "ol", "ul"
+        isClickable ||=
+          if element.clientHeight < element.scrollHeight and Scroller.isScrollableElement element
+            reason = "Scroll."
+      when "details"
+        isClickable = true
+        reason = "Open."
+
+    # An element with a class name containing the text "button" might be clickable.  However, real clickables
+    # are often wrapped in elements with such class names.  So, when we find clickables based only on their
+    # class name, we mark them as unreliable.
+    if not isClickable and 0 <= element.getAttribute("class")?.toLowerCase().indexOf "button"
+      possibleFalsePositive = isClickable = true
+
+    # Elements with tabindex are sometimes useful, but usually not. We can treat them as second class
+    # citizens when it improves UX, so take special note of them.
+    tabIndexValue = element.getAttribute("tabindex")
+    tabIndex = if tabIndexValue == "" then 0 else parseInt tabIndexValue
+    unless isClickable or isNaN(tabIndex) or tabIndex < 0
+      isClickable = onlyHasTabIndex = true
+
+    if isClickable
+      {element, secondClassCitizen: onlyHasTabIndex, possibleFalsePositive, reason}
+    else
+      false
+
+  getLinkHint
+
 root = exports ? (window.root ?= {})
 root.Renderer = Renderer
 extend window, root unless exports?

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -20,10 +20,10 @@ class Renderer
       elementInfo.overflowY = computedStyle.overflowY
 
     if elementInfo.overflow == "visible"
-      element.clips = elementInfo.clipsX = elementInfo.clipsY = false
+      elementInfo.clips = elementInfo.clipsX = elementInfo.clipsY = false
     else if elementInfo.overflowX == "visible"
       elementInfo.clipsX = false
-      element.clips = elementInfo.clipsY = true
+      elementInfo.clips = elementInfo.clipsY = true
     else if elementInfo.overflowY == "visible"
       elementInfo.clipsY = false
       elementInfo.clips = elementInfo.clipsX = true
@@ -76,6 +76,8 @@ class Renderer
         else
          elementInfo.clippingRect = @viewport
 
+    elementInfo.clippingRect
+
   getAbsClippingRect: (elementInfo) ->
     # This is called after getClippingRect, which computes elementInfo.absClippingRect for us if relevant.
     return elementInfo.absClippingRect if elementInfo.absClippingRect?
@@ -90,7 +92,7 @@ class Renderer
     if "absolute" != @position elementInfo
       elementInfo.clippedRect = Rect.intersect elementInfo.clippedRect, clippingRect
     else
-      absClippingRect = @getAbsClippingRect parentInfo
+      absClippingRect = @getAbsClippingRect clippingElementInfo
       elementInfo.clippedRect = Rect.intersect elementInfo.clippedRect, absClippingRect
     return
 
@@ -114,7 +116,7 @@ class Renderer
     renderedElements = []
     elementIndex = 0
     while element
-      parentInfo = parentStack[parentStack - 1]
+      parentInfo = parentStack[parentStack.length - 1]
       elementInfo = {element, parentInfo, elementIndex: elementIndex++}
       if @inViewport elementInfo
         elementInfo.clippedRect = Rect.intersect elementInfo.boundingRect, @viewport
@@ -132,17 +134,18 @@ class Renderer
       else
         elementInfo.rendered = false
 
-      currentElement = element
-      element = currentElement.firstElementChild
+      currentElement = elementInfo
+      element = currentElement.element.firstElementChild
       if element
         parentStack.push currentElement
       else
-        element = currentElement.nextElementSibling
+        element = currentElement.element.nextElementSibling
 
         while currentElement and not element
           currentElement = parentStack.pop()
+          break unless currentElement
           if not currentElement.rendered and currentElement.overflowingElements
-            processRenderedDecendents condition elementInfo
+            processRenderedDecendents elementInfo
           element = currentElement.element.nextElementSibling
 
     renderedElements

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -104,9 +104,7 @@ class Renderer
       elementInfo.clippedRect.left < elementInfo.clippedRect.right and
       elementInfo.clippedRect.top < elementInfo.clippedRect.bottom
 
-  # processRendered is called on each rendered element as it is found, passed Renderer's internal elementInfo
-  # struct as the only argument.
-  getRenderedElements: (root, processRendered = (->)) ->
+  getRenderedElements: (root) ->
     element = root
     parentStack = []
     renderedElements = []
@@ -120,12 +118,10 @@ class Renderer
         if @isVisible elementInfo
           if parentInfo?
             if parentInfo.clippedRect? and Rect.contains elementInfo.clippedRect, parentInfo.clippedRect
-              processRendered elementInfo
               renderedElements.push elementInfo
             else
               @clipBy elementInfo, parentInfo
               if @rendered elementInfo
-                processRendered elementInfo
                 renderedElements.push elementInfo
         else
           elementInfo.rendered = false
@@ -312,8 +308,7 @@ class Renderer
 
   getLinksForHints: ->
     renderedElements = @getRenderedElements document.documentElement
-    , (elementInfo) =>
-      @isClickableOrDeferring elementInfo
+    renderedElements.map @isClickableOrDeferring.bind this
 
     renderedClickableElements = @renderElements renderedElements
     , (elementInfo) ->

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -160,8 +160,9 @@ class Renderer
           for negativeRect in @getClientRects negativeElement
             # Subtract negativeRect from every rect in rects, and concatenate the resulting arrays.
             rects = [].concat (rects.map (rect) -> Rect.subtract rect, negativeRect)...
-      if rects and rects.length > 0
-        elementInfo.renderedRects = rects ? @getClientRects elementInfo
+      rects ?= @getClientRects elementInfo
+      if rects.length > 0
+        elementInfo.renderedRects = rects
         process elementInfo
         renderedElements.push elementInfo
       else if exceptionFilter elementInfo

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -1,0 +1,152 @@
+class Renderer
+  constructor: ->
+    @viewport = {left: 0, top: 0, right: window.innerWidth, bottom: window.innerHeight}
+
+  inViewport: (elementInfo) ->
+    elementInfo.boundingRect = elementInfo.element.getBoundingClientRect()
+    # Don't need to use intersectsStrict here, since we don't care about 0-width intersections.
+    # NOTE(mrmr1993): This also excluded display: none; elements, which have {left: 0, right: 0, ...}
+    Rect.intersects elementInfo.boundingRect, @viewport
+
+  isClipping: (elementInfo) ->
+    return elementInfo.clips if elementInfo.clips?
+    # Most elements have no overflow CSS set, so it is usually cheaper to check this.
+    computedStyle = window.getComputedStyle elementInfo.element
+    elementInfo.overflow = computedStyle.overflow
+    if elementInfo.overflow
+      elementInfo.overflowX = elementInfo.overflowY = elementInfo.overflow
+    else
+      elementInfo.overflowX = computedStyle.overflowX
+      elementInfo.overflowY = computedStyle.overflowY
+
+    if elementInfo.overflow == "visible"
+      element.clips = elementInfo.clipsX = elementInfo.clipsY = false
+    else if elementInfo.overflowX == "visible"
+      elementInfo.clipsX = false
+      element.clips = elementInfo.clipsY = true
+    else if elementInfo.overflowY == "visible"
+      elementInfo.clipsY = false
+      elementInfo.clips = elementInfo.clipsX = true
+    else
+      elementInfo.clips = elementInfo.clipsX = elementInfo.clipsY = true
+
+  position: (elementInfo) -> elementInfo.position ?= window.getComputedStyle(elementInfo.element).position
+
+  getClippingRect: (elementInfo) ->
+    return elementInfo.clippingRect if elementInfo.clippingRect?
+    if @isClipping elementInfo
+      isAbsolute = "absolute" == @position elementInfo
+      if elementInfo.parentInfo?
+        if isAbsolute
+          clippingRect = @getAbsClippingRect elementInfo.parentInfo
+        else
+          clippingRect = @getClippingRect elementInfo.parentInfo
+      else
+        clippingRect = @viewport
+
+      if elementInfo.clippedRect?
+        if elementInfo.clipsX
+          if elementInfo.clipsY
+            elementInfo.clippingRect = Rect.intersect elementInfo.clippedRect, clippingRect
+          else
+            elementInfo.clippingRect =
+              left: Math.max elementInfo.clippedRect.left, clippingRect.left
+              right: Max.min elementInfo.clippedRect.right, clippingRect.right
+              top: clippingRect.top
+              bottom: clippingRect.bottom
+        else # elementInfo.clipsY
+          elementInfo.clippingRect =
+            left: clippingRect.left
+            right: clippingRect.right,
+            top: Math.max elementInfo.clippedRect.top, clippingRect.top
+            bottom: Max.min elementInfo.clippedRect.bottom, clippingRect.bottom
+        elementInfo.absClippingRect = elementInfo.clippingRect if isAbsolute
+      else
+        elementInfo.clippingRect = {left: 0, right: 0, top: 0, bottom: 0}
+        elementInfo.absClippingRect = elementInfo.clippingRect if isAbsolute
+    else
+      if "absolute" == @position.elementInfo
+        if elementInfo.parentInfo?
+          elementInfo.clippingRect = elementInfo.absClippingRect = @getAbsClippingRect elementInfo.parentInfo
+        else
+          elementInfo.clippingRect = elementInfo.absClippingRect = @viewport
+      else
+        if elementInfo.parentInfo?
+          elementInfo.clippingRect = @getClippingRect elementInfo.parentInfo
+        else
+         elementInfo.clippingRect = @viewport
+
+  getAbsClippingRect: (elementInfo) ->
+    # This is called after getClippingRect, which computes elementInfo.absClippingRect for us if relevant.
+    return elementInfo.absClippingRect if elementInfo.absClippingRect?
+    if elementInfo.parentInfo?
+      elementInfo.absClippingRect = @getAbsClippingRect elementInfo.parentInfo
+    else
+      elementInfo.absClippingRect = @viewport
+
+  clipBy: (elementInfo, clippingElementInfo) ->
+    clippingRect = @getClippingRect clippingElementInfo
+    return if Rect.contains elementInfo.clippedRect, clippingRect
+    if "absolute" != @position elementInfo
+      elementInfo.clippedRect = Rect.intersect elementInfo.clippedRect, clippingRect
+    else
+      absClippingRect = @getAbsClippingRect parentInfo
+      elementInfo.clippedRect = Rect.intersect elementInfo.clippedRect, absClippingRect
+    return
+
+  rendered: (elementInfo) ->
+    elementInfo.rendered ?=
+      elementInfo.clippedRect.left < elementInfo.clippedRect.right and
+      elementInfo.clippedRect.top < elementInfo.clippedRect.bottom
+
+  setOverflowingElement: (elementInfo, ancestorInfo, checkBounds) ->
+    if not checkBounds or Rect.contains elementInfo.clippedRect, ancestorInfo.clippedRect
+      (ancestorInfo.overflowingElements ?= []).push elementsInfo
+      @setOverflowingElement elementInfo, ancestorInfo.parentInfo, true if ancestorInfo.parentInfo?
+
+  # - processRendered is called on each rendered element as it is found
+  # - processRenderedDescendents is called on each unrendered element with rendered children *after*
+  #   every child has been processed, but before any outer ancestors are processed
+  # Both of these are passed the elementInfo struct used internally by renderer as their only argument.
+  getRenderedElements: (root, processRendered = (->), processRenderedDecendents = (->)) ->
+    element = root
+    parentStack = []
+    renderedElements = []
+    elementIndex = 0
+    while element
+      parentInfo = parentStack[parentStack - 1]
+      elementInfo = {element, parentInfo, elementIndex: elementIndex++}
+      if @inViewport elementInfo
+        elementInfo.clippedRect = Rect.intersect elementInfo.boundingRect, @viewport
+
+        if parentInfo?
+          if parentInfo.clippedRect? and Rect.contains elementInfo.clippedRect, parentInfo.clippedRect
+            processRendered elementInfo
+            renderedElements.push elementInfo
+          else
+            @clipBy elementInfo, parentInfo
+            if @rendered elementInfo
+              processRendered elementInfo
+              renderedElements.push elementInfo
+              @setOverflowingElement elementInfo, parentInfo
+      else
+        elementInfo.rendered = false
+
+      currentElement = element
+      element = currentElement.firstElementChild
+      if element
+        parentStack.push currentElement
+      else
+        element = currentElement.nextElementSibling
+
+        while currentElement and not element
+          currentElement = parentStack.pop()
+          if not currentElement.rendered and currentElement.overflowingElements
+            processRenderedDecendents condition elementInfo
+          element = currentElement.element.nextElementSibling
+
+    renderedElements
+
+root = exports ? (window.root ?= {})
+root.Renderer = Renderer
+extend window, root unless exports?

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -3,9 +3,14 @@ class Renderer
     @viewport = {left: 0, top: 0, right: window.innerWidth, bottom: window.innerHeight}
 
   inViewport: (elementInfo) ->
-    elementInfo.boundingRect = elementInfo.element.getBoundingClientRect()
+    elementInfo.rawClientRects = clientRects = elementInfo.element.getClientRects()
+    if clientRects.length == 0
+      return false # This element is display: none.
+    else if clientRects.length == 1
+      elementInfo.boundingRect = clientRects[0]
+    else
+      elementInfo.boundingRect = elementInfo.element.getBoundingClientRect()
     # Don't need to use intersectsStrict here, since we don't care about 0-width intersections.
-    # NOTE(mrmr1993): This also excluded display: none; elements, which have {left: 0, right: 0, ...}
     Rect.intersects elementInfo.boundingRect, @viewport
 
   isClipping: (elementInfo) ->
@@ -143,7 +148,7 @@ class Renderer
     renderedElements
 
   getClientRects: (elementInfo) ->
-    elementInfo.clientRects ?= Array::map.call elementInfo.element.getClientRects(), (rect) ->
+    elementInfo.clientRects ?= Array::map.call elementInfo.rawClientRects, (rect) ->
       Rect.intersect rect, elementInfo.boundingRect
 
   renderElements: (elements, preFilter = (-> true), postFilter = (-> true), process = (->)) ->

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -294,11 +294,14 @@ class Renderer
 
   isClickableOrDeferring: (elementInfo) ->
     isClickable = @isClickable elementInfo
-    return isClickable if isClickable and not isClickable.secondClassCitizen
+    isDeferring = @isClickableOrDeferring elementInfo.parentInfo if elementInfo.parentInfo?
+    if isClickable and not isClickable.possibleFalsePositive
+      if isDeferring and isDeferring.possibleFalsePositive
+        isDeferring.resolvedBy = elementInfo.element
+      return isClickable
 
-    isDeferring = @isClickableOrDeferring elementInfo.parentElement if elementInfo.parentElement?
     if isDeferring
-      if isClickable and isDeferring.secondClassCitizen
+      if isClickable and isDeferring.possibleFalsePositive
         isClickable
       else
         elementInfo.defersTo = isDeferring
@@ -325,7 +328,8 @@ class Renderer
 
     [renderedClickableElements, unrenderedClickableElements] = @renderElements renderedElements
     , (elementInfo) ->
-      elementInfo.clickable or elementInfo.defersTo and not elementInfo.defersTo.resolvedBy
+      clickableRef = elementInfo.clickable or elementInfo.defersTo
+      clickableRef and not clickableRef.resolvedBy
     , isLinkVisible
     , (elementInfo) ->
       (elementInfo.clickable or elementInfo.defersTo).resolvedBy = elementInfo

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -160,9 +160,8 @@ class Renderer
           for negativeRect in @getClientRects negativeElement
             # Subtract negativeRect from every rect in rects, and concatenate the resulting arrays.
             rects = [].concat (rects.map (rect) -> Rect.subtract rect, negativeRect)...
-      rects ?= @getClientRects elementInfo
+      elementInfo.renderedRects = rects ?= @getClientRects elementInfo
       if rects.length > 0
-        elementInfo.renderedRects = rects
         if postFilter elementInfo
           process elementInfo
           renderedElements.push elementInfo

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -96,14 +96,14 @@ class Renderer
       elementInfo.clippedRect = Rect.intersect elementInfo.clippedRect, absClippingRect
     return
 
-  visibility: (elementInfo) ->
-    elementInfo.visibility ?= window.getComputedStyle(elementInfo.element).visibility
+  isVisible: (elementInfo) ->
+    elementInfo.visibile ?= (window.getComputedStyle(elementInfo.element).visibility == "visible")
 
   rendered: (elementInfo) ->
     elementInfo.rendered ?=
       elementInfo.clippedRect.left < elementInfo.clippedRect.right and
       elementInfo.clippedRect.top < elementInfo.clippedRect.bottom and
-      "visible" == @visibility elementInfo
+      @isVisible elementInfo
 
   # processRendered is called on each rendered element as it is found, passed Renderer's internal elementInfo
   # struct as the only argument.
@@ -120,7 +120,7 @@ class Renderer
 
         if parentInfo?
           if parentInfo.clippedRect? and Rect.contains elementInfo.clippedRect, parentInfo.clippedRect and
-              "visible" == @visibility elementInfo
+              @isVisible elementInfo
             processRendered elementInfo
             renderedElements.push elementInfo
           else

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -152,13 +152,13 @@ class Renderer
 
   # `exceptionFilter elem = true` should always imply `outputFilter elem = true`
   renderElements: (elements, outputFilter = (-> true), exceptionFilter = (-> false)) ->
-    elements = elements.reverse()
     renderedElements = []
-    while elementInfo = elements.pop()
+    for elementInfo, index in elements
       continue unless outputFilter elementInfo
       {clippedRect} = elementInfo
       rects = undefined
-      for negativeElement in elements
+      for i in [index+1 ... elements.length] by 1
+        negativeElement = elements[i]
         if Rect.intersects clippedRect, negativeElement.clippedRect
           rects ?= @getClientRects elementInfo
           for negativeRect in @getClientRects negativeElement

--- a/lib/renderer.coffee
+++ b/lib/renderer.coffee
@@ -147,7 +147,7 @@ class Renderer
       Rect.intersect rect, elementInfo.boundingRect
 
   # `exceptionFilter elem = true` should always imply `outputFilter elem = true`
-  renderElements: (elements, outputFilter = (-> true), exceptionFilter = (-> false)) ->
+  renderElements: (elements, outputFilter = (-> true), exceptionFilter = (-> false), process = (->)) ->
     renderedElements = []
     for elementInfo, index in elements
       continue unless outputFilter elementInfo
@@ -162,9 +162,11 @@ class Renderer
             rects = [].concat (rects.map (rect) -> Rect.subtract rect, negativeRect)...
       if rects and rects.length > 0
         elementInfo.renderedRects = rects ? @getClientRects elementInfo
+        process elementInfo
         renderedElements.push elementInfo
       else if exceptionFilter elementInfo
         elementInfo.renderedRects = @getClientRects elementInfo
+        process elementInfo
         renderedElements.push elementInfo
 
     renderedElements
@@ -312,9 +314,11 @@ class Renderer
 
     renderedClickableElements = @renderElements renderedElements
     , (elementInfo) ->
-      elementInfo.clickable or elementInfo.defersTo
+      elementInfo.clickable or elementInfo.defersTo and not elementInfo.defersTo.resolvedBy
     , (elementInfo) ->
       not (elementInfo.clickable or elementInfo.defersTo).secondClassCitizen
+    , (elementInfo) ->
+      (elementInfo.clickable or elementInfo.defersTo).resolvedBy = elementInfo
 
     # Position the rects within the window.
     {top, left} = DomUtils.getViewportTopLeft()

--- a/manifest.json
+++ b/manifest.json
@@ -49,6 +49,7 @@
              "lib/handler_stack.js",
              "lib/settings.js",
              "lib/find_mode_history.js",
+             "lib/renderer.js",
              "content_scripts/mode.js",
              "content_scripts/ui_component.js",
              "content_scripts/link_hints.js",

--- a/pages/blank.html
+++ b/pages/blank.html
@@ -8,6 +8,7 @@
     <script src="../lib/handler_stack.js"></script>
     <script src="../lib/settings.js"></script>
     <script src="../lib/find_mode_history.js"></script>
+    <script src="../lib/renderer.js"></script>
     <script src="../content_scripts/mode.js"></script>
     <script src="../content_scripts/ui_component.js"></script>
     <script src="../content_scripts/link_hints.js"></script>

--- a/pages/completion_engines.html
+++ b/pages/completion_engines.html
@@ -11,6 +11,7 @@
     <script src="../lib/handler_stack.js"></script>
     <script src="../lib/settings.js"></script>
     <script src="../lib/find_mode_history.js"></script>
+    <script src="../lib/renderer.js"></script>
     <script src="../content_scripts/mode.js"></script>
     <script src="../content_scripts/ui_component.js"></script>
     <script src="../content_scripts/link_hints.js"></script>

--- a/pages/help_dialog.html
+++ b/pages/help_dialog.html
@@ -8,6 +8,7 @@
     <script src="../lib/handler_stack.js"></script>
     <script src="../lib/settings.js"></script>
     <script src="../lib/find_mode_history.js"></script>
+    <script src="../lib/renderer.js"></script>
     <script src="../content_scripts/mode.js"></script>
     <script src="../content_scripts/ui_component.js"></script>
     <script src="../content_scripts/link_hints.js"></script>

--- a/pages/logging.html
+++ b/pages/logging.html
@@ -8,6 +8,7 @@
     <script src="../lib/handler_stack.js"></script>
     <script src="../lib/settings.js"></script>
     <script src="../lib/find_mode_history.js"></script>
+    <script src="../lib/renderer.js"></script>
     <script src="../content_scripts/mode.js"></script>
     <script src="../content_scripts/ui_component.js"></script>
     <script src="../content_scripts/link_hints.js"></script>

--- a/pages/options.html
+++ b/pages/options.html
@@ -9,6 +9,7 @@
     <script src="../lib/handler_stack.js"></script>
     <script src="../lib/settings.js"></script>
     <script src="../lib/find_mode_history.js"></script>
+    <script src="../lib/renderer.js"></script>
     <script src="../content_scripts/mode.js"></script>
     <script src="../content_scripts/ui_component.js"></script>
     <script src="../content_scripts/link_hints.js"></script>

--- a/tests/dom_tests/dom_tests.html
+++ b/tests/dom_tests/dom_tests.html
@@ -39,6 +39,7 @@
     <script type="text/javascript" src="../../lib/clipboard.js"></script>
     <script type="text/javascript" src="../../lib/settings.js"></script>
     <script type="text/javascript" src="../../lib/find_mode_history.js"></script>
+    <script type="text/javascript" src="../../lib/renderer.js"></script>
     <script type="text/javascript" src="../../content_scripts/mode.js"></script>
     <script type="text/javascript" src="../../content_scripts/ui_component.js"></script>
     <script type="text/javascript" src="../../content_scripts/link_hints.js"></script>

--- a/tests/unit_tests/commands_test.coffee
+++ b/tests/unit_tests/commands_test.coffee
@@ -7,6 +7,7 @@ global.Settings = {postUpdateHooks: {}, get: (-> ""), set: ->}
 # Include mode_normal to check that all commands have been implemented.
 global.KeyHandlerMode = global.Mode = {}
 global.KeyboardUtils = {platform: ""}
+extend global, require "../../lib/renderer.js"
 extend global, require "../../content_scripts/link_hints.js"
 extend global, require "../../content_scripts/marks.js"
 extend global, require "../../content_scripts/vomnibar.js"


### PR DESCRIPTION
This PR is a work in progress, but already brings some concrete improvements to link hints.

Overview:
* The new code is in a new class, `Renderer`. The general functions in it generate a 'rendering' of the page.
* A big speed-up (especially on Firefox) is using `Element.getBoundingClientRect` initially, before we fall back to `Element.getClientRects` to get the actual location of the elements.
  - This is how e.g. VimFx was able to be faster than us.
  - Using the combined approach gives us the extra speed of `getBoundingClientRect` while still putting the hints where the elements **actually are**, which VimFX would not have been able to do for e.g. line-wrapping inline elements.
* Another speed-up is reworking the code that finds alternatives for clickable but invisible elements.
  - In the old code, we checked children directly, with the associated performance penalties.
  - In this new code, via `isClickableOrDeferring`, we associate each element with its closest clickable ancestor.
* This clips elements that overflow their containers (via `clipBy` and `getClippingRect`/`getAbsClippingRect`), which the old implementation didn't try to do.
  - This has a small performance penalty, but is more than covered by the other gains in nearly all cases.
  - A nice place to test this is in the options page, if you create more exclusion rule slots than the containing area can fit.
* The `getVisibleClickable` function from `LinkHints` has been imported whole to `Renderer` and then modified.
  - This is mainly so that the old implementation can be tested side-by-side with the new one.
* (Testing, 986f7c6) The `LinkHints` commands have been modified to accept and pass user options.
  - Notably, the commands now accept a `useNew` option, which makes link hints run with the new algorithm instead of the old one.
* (Testing, 9934347) Added `LinkHints.time` to time the old and new algorithms for `count` repetitions and `alert` the total and average time for each.

Problems and TODOs:
* The `Renderer` class doesn't yet limit us to 1 returned element per clickable element, so we get (sometimes a lot of) duplicates.
  - In doing this, we'll also eliminate some more `getClientRects` calls, which will further help with speed.
* Move overflow checks from `getRenderedElements` to `renderElements`.
  - This should bring a large improvement on Facebook.
* I haven't done any profiling yet in Firefox, since there's no way to profile extensions' content scripts.
* The `LinkHints`-specific code (`isClickable`, `getLinksForHints`) will eventually need to go back into `LocalHints`.
* Image maps are currently not used.
* Labels are currently not used.

Some test-runs:

Page | FF 56 Old | FF 56 New | Chrome 62 Old | Chrome 62 New | FF 58 Old | FF 58 New
--- | --- | --- | --- | --- | --- | ---
Options page | 92ms/80 = 1.15ms | 353ms/80 = 4.4125ms | 756ms/250 = 3.024ms | 946ms/250 = 3.784ms |  276ms/250 = 1.104ms | 1345ms/250 = 5.38ms
https://www.x.org/releases/X11R7.7/doc/libX11/libX11/libX11.html (Bottom of page) | 5432ms/8 = 679ms | 3275ms/8 = 409.375ms | 3591ms/25 = 143.64ms | 3661ms/25 = 146.44ms | 19011ms/25 = 760.44ms | 11443ms/25 = 457.72ms
twitter.com (Pressed <kbd>end</kbd> 8 times) | 3302ms/8 = 412.75ms | 1815ms/8 = 226.875ms | 2114ms/25 = 84.56ms | 2093ms/25 = 83.72ms | 12051ms/25 = 482.04ms | 7531ms/25 = 301.24ms
facebook.com | 512ms/8 = 64ms | 1321ms/8 = 165.125ms | 404ms/25 = 16.16ms | 780ms/25 = 31.2ms | 1652ms/25 = 66.08ms | 5105ms/25 = 204.2ms

