### PR TITLE
Suppress link hint keys

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -293,11 +293,10 @@ class LinkHintsMode
           if keyChar.length == 1
             @markerMatcher.pushKeyChar keyChar
             @updateVisibleMarkers()
-          handlerStack.suppressEvent
-      return
+          else
+            return
 
-    # We've handled the event, so suppress it and update the mode indicator.
-    DomUtils.suppressEvent event
+    handlerStack.suppressEvent
 
   updateVisibleMarkers: (tabCount = 0) ->
     {hintKeystrokeQueue, linkTextKeystrokeQueue} = @markerMatcher

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -344,7 +344,7 @@ DomUtils =
   consumeKeyup: do ->
     handlerId = null
 
-    (event, callback = null) ->
+    (event, callback = null, suppressPropagation) ->
       unless event.repeat
         handlerStack.remove handlerId if handlerId?
         code = event.code
@@ -353,7 +353,10 @@ DomUtils =
           keyup: (event) ->
             return handlerStack.continueBubbling unless event.code == code
             @remove()
-            DomUtils.suppressEvent event
+            if suppressPropagation
+              DomUtils.suppressPropagation event
+            else
+              DomUtils.suppressEvent event
             handlerStack.continueBubbling
           # We cannot track keyup events if we lose the focus.
           blur: (event) ->

--- a/lib/handler_stack.coffee
+++ b/lib/handler_stack.coffee
@@ -57,7 +57,10 @@ class HandlerStack
         if result == @passEventToPage
           return true
         else if result == @suppressPropagation
-          DomUtils.suppressPropagation event
+          if type == "keydown"
+            DomUtils.consumeKeyup event, null, true
+          else
+            DomUtils.suppressPropagation event
           return false
         else if result == @restartBubbling
           return @bubbleEvent type, event

--- a/tests/unit_tests/handler_stack_test.coffee
+++ b/tests/unit_tests/handler_stack_test.coffee
@@ -4,6 +4,7 @@ extend(global, require "../../lib/handler_stack.js")
 context "handlerStack",
   setup ->
     stub global, "DomUtils", {}
+    stub DomUtils, "consumeKeyup", ->
     stub DomUtils, "suppressEvent", ->
     stub DomUtils, "suppressPropagation", ->
     @handlerStack = new HandlerStack


### PR DESCRIPTION
This fixes #2777.

This bug was introduced in #2753, based on my expectation that `suppressAllKeyboardEvents` wouldn't trigger the default action for events, and of the layout of this code. The behaviour now is to trigger the default action only when we don't handle it (so the user can still <kbd>ctrl</kbd>+<kbd>tab</kbd>, refresh with <kbd>F5</kbd>, etc.).

This also has implications for e.g. `TypingProtector`, where the spacebar will also scroll because of its use of `suppressAllKeyboardEvents`, but I haven't touched that code. (Edit:) This means that typing `map of lake ` fast enough on the example in #2777 will still scroll the page.

Edit: (Forgot to add) this also adds code to avoid passing keyup events to the page when we have done so for keydowns. This should have been in #2753, but I missed it.