### PR TITLE
Special-case modifiers now they are resolved as keys

### DIFF
--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -59,7 +59,7 @@ class KeyHandlerMode extends Mode
       @reset if @keyState.length == 1 then @countPrefix * 10 + digit else digit
       @suppressEvent
     else
-      @reset() if keyChar
+      @reset() unless event.key in ["Control", "Shift", "Alt", "OS", "AltGraph"]
       @continueBubbling
 
   # This tests whether there is a mapping of keyChar in the current key state (and accounts for pass keys).

--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -52,7 +52,7 @@ class KeyHandlerMode extends Mode
     else if isEscape
       @continueBubbling
     else if @isMappedKey keyChar
-      @handleKeyChar keyChar
+      @handleKeyChar keyChar, KeyboardUtils.isModifier event
       @suppressEvent
     else if @isCountKey keyChar
       digit = parseInt keyChar
@@ -78,12 +78,15 @@ class KeyHandlerMode extends Mode
   isInResetState: ->
     @countPrefix == 0 and @keyState.length == 1
 
-  handleKeyChar: (keyChar) ->
+  handleKeyChar: (keyChar, maySkipKey) ->
     bgLog "handle key #{keyChar} (#{@name})"
     # A count prefix applies only so long a keyChar is mapped in @keyState[0]; e.g. 7gj should be 1j.
     @countPrefix = 0 unless keyChar of @keyState[0]
     # Advance the key state.  The new key state is the current mappings of keyChar, plus @keyMapping.
-    @keyState = [(mapping[keyChar] for mapping in @keyState when keyChar of mapping)..., @keyMapping]
+    oldKeyState = @keyState
+    @keyState = (mapping[keyChar] for mapping in @keyState when keyChar of mapping)
+    @keyState = @keyState.concat oldKeyState if maySkipKey
+    @keyState.push @keyMapping
     if @keyState[0].command?
       command = @keyState[0]
       count = if 0 < @countPrefix then @countPrefix else 1

--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -59,7 +59,7 @@ class KeyHandlerMode extends Mode
       @reset if @keyState.length == 1 then @countPrefix * 10 + digit else digit
       @suppressEvent
     else
-      @reset() unless event.key in ["Control", "Shift", "Alt", "OS", "AltGraph"]
+      @reset() unless KeyboardUtils.isModifier event
       @continueBubbling
 
   # This tests whether there is a mapping of keyChar in the current key state (and accounts for pass keys).

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -70,6 +70,9 @@ KeyboardUtils =
   isPrintable: (event) ->
     @getKeyCharString(event)?.length == 1
 
+  isModifier: (event) ->
+    event.key in ["Control", "Shift", "Alt", "OS", "AltGraph", "Meta"]
+
   enUsTranslations:
     "Backquote":     ["`", "~"]
     "Minus":         ["-", "_"]


### PR DESCRIPTION
This fixes number prefixes for normal and visual modes, which were broken by #2772.