### PR TITLE
Remove WaitForEnter and TypingProtector modes from link hints code

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -874,26 +874,9 @@ class TypingProtector extends Mode
 
     @onExit ->
       callback true # true -> isSuccess.
-
-class WaitForEnter extends Mode
-  constructor: (callback) ->
-    super
-      name: "hint/wait-for-enter"
-      suppressAllKeyboardEvents: true
-      indicator: "Hit <Enter> to proceed..."
-
-    @push
-      keydown: (event) =>
-        if event.key == "Enter"
-          @exit()
-          callback true # true -> isSuccess.
-        else if KeyboardUtils.isEscape event
-          @exit()
-          callback false # false -> isSuccess.
-
 root = exports ? (window.root ?= {})
 root.LinkHints = LinkHints
 root.HintCoordinator = HintCoordinator
 # For tests:
-extend root, {LinkHintsMode, LocalHints, AlphabetHints, WaitForEnter}
+extend root, {LinkHintsMode, LocalHints, AlphabetHints}
 extend window, root unless exports?

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -301,7 +301,8 @@ class LinkHintsMode
     {linksMatched, userMightOverType} = @markerMatcher.getMatchingHints @hintMarkers, tabCount, this.getNextZIndex.bind this
     if linksMatched.length == 0
       @deactivateMode()
-    else if linksMatched.length == 1
+    else if linksMatched.length == 1 and
+        (not userMightOverType or not Settings.get "waitForEnterForFilteredHints")
       @activateLink linksMatched[0], userMightOverType
     else
       @hideMarker marker for marker in @hintMarkers
@@ -395,11 +396,7 @@ class LinkHintsMode
     if userMightOverType
       HintCoordinator.onExit.push removeFlashElements
       if windowIsFocused()
-        callback = (isSuccess) -> HintCoordinator.sendMessage "exit", {isSuccess}
-        if Settings.get "waitForEnterForFilteredHints"
-          new WaitForEnter callback
-        else
-          new TypingProtector 200, callback
+        new TypingProtector 200, (isSuccess) -> HintCoordinator.sendMessage "exit", {isSuccess}
     else if linkMatched.isLocalMarker
       Utils.setTimeout 400, removeFlashElements
       HintCoordinator.sendMessage "exit", isSuccess: true

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -395,11 +395,8 @@ class LinkHintsMode
 
     if linkMatched.isLocalMarker
       {top: viewportTop, left: viewportLeft} = DomUtils.getViewportTopLeft()
-      flashElements = for rect in clickEl.getClientRects()
+      for rect in clickEl.getClientRects()
         DomUtils.flashRect Rect.translate rect, viewportLeft, viewportTop
-
-    # The frame with the matched link sends the "exit" message.
-    if linkMatched.isLocalMarker
       HintCoordinator.sendMessage "exit", isSuccess: true
 
   #

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -424,6 +424,24 @@ context "Filtered link hints",
       sendKeyboardEvent "Tab", "keydown"
       assert.equal "9", @getActiveHintMarker()
 
+  context "Wait for enter setting",
+    setup ->
+      stubSettings "waitForEnterForFilteredHints", true
+      initializeModeState()
+      testContent = "<a>test</a>"
+      document.getElementById("test-div").innerHTML = testContent
+      @linkHints = activateLinkHintsMode()
+
+    tearDown ->
+      document.getElementById("test-div").innerHTML = ""
+      @linkHints.deactivateMode()
+
+    should "require enter when the setting is enabled", ->
+      sendKeyboardEvents "test"
+      assert.isTrue @linkHints.hintMode.modeIsActive
+      sendKeyboardEvent "Enter"
+      assert.isFalse @linkHints.hintMode.modeIsActive
+
 context "Input focus",
 
   setup ->

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -424,7 +424,7 @@ context "Filtered link hints",
       sendKeyboardEvent "Tab", "keydown"
       assert.equal "9", @getActiveHintMarker()
 
-  context "Wait for enter setting",
+  context "Wait for enter setting enabled",
     setup ->
       stubSettings "waitForEnterForFilteredHints", true
       initializeModeState()
@@ -436,11 +436,27 @@ context "Filtered link hints",
       document.getElementById("test-div").innerHTML = ""
       @linkHints.deactivateMode()
 
-    should "require enter when the setting is enabled", ->
+    should "require enter before exiting the mode", ->
       sendKeyboardEvents "test"
       assert.isTrue @linkHints.hintMode.modeIsActive
       sendKeyboardEvent "Enter"
       assert.isFalse @linkHints.hintMode.modeIsActive
+
+  context "Wait for enter setting disabled",
+    setup ->
+      stubSettings "waitForEnterForFilteredHints", false
+      initializeModeState()
+      testContent = "<a>test</a>"
+      document.getElementById("test-div").innerHTML = testContent
+      handlerStack.push keydown: (event) -> assert.isFalse event.key
+      @linkHints = activateLinkHintsMode()
+
+    tearDown ->
+      document.getElementById("test-div").innerHTML = ""
+      @linkHints.deactivateMode()
+
+    should "not leak filtering keys", ->
+      sendKeyboardEvents "test"
 
 context "Input focus",
 

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -996,33 +996,6 @@ context "PostFindMode",
     sendKeyboardEvent "Escape", "keydown"
     assert.isTrue @postFindMode.modeIsActive
 
-context "WaitForEnter",
-  setup ->
-    initializeModeState()
-    @isSuccess = null
-    @waitForEnter = new WaitForEnter (isSuccess) => @isSuccess = isSuccess
-
-  should "exit with success on Enter", ->
-    assert.isTrue @waitForEnter.modeIsActive
-    assert.isFalse @isSuccess?
-    sendKeyboardEvent "Enter", "keydown"
-    assert.isFalse @waitForEnter.modeIsActive
-    assert.isTrue @isSuccess? and @isSuccess == true
-
-  should "exit without success on Escape", ->
-    assert.isTrue @waitForEnter.modeIsActive
-    assert.isFalse @isSuccess?
-    sendKeyboardEvent "Escape", "keydown"
-    assert.isFalse @waitForEnter.modeIsActive
-    assert.isTrue @isSuccess? and @isSuccess == false
-
-  should "not exit on other keyboard events", ->
-    assert.isTrue @waitForEnter.modeIsActive
-    assert.isFalse @isSuccess?
-    sendKeyboardEvents "abc"
-    assert.isTrue @waitForEnter.modeIsActive
-    assert.isFalse @isSuccess?
-
 context "GrabBackFocus",
   setup ->
     testContent = "<input type='text' value='some value' id='input'/>"


### PR DESCRIPTION
Update: Part of this PR has been merged as #2823.

The remaining changes here are:
* `WaitForEnter` mode logic is moved into `LinkHintsMode` main logic: the mode doesn't try to exit until enter is pressed
  - the leaves the HUD showing the link hints contents rather than `Hit <enter> to proceed`
  - the user can 'back out' of the current selection by typing <kbd>backspace</kbd> and select a different link, since they're still in the full link hints mode
* `TypingProtector` mode logic is also moved into `LinkHintsMode` main logic: the mode waits until it seems like the user has stopped typing before trying to exit
  - this means that the link is no longer highlighted as soon as there is only 1 match left, but instead when it is clicked. This is an easy one-line change if we want to keep the old behaviour.
  - again, the user can 'back out' of the current selection (if they are fast enough)


Old description:

------------------------

This PR does some tidying up of link hints. The commit messages give a good summary of everything that this changes.

Most notably, this kills `WaitForEnter` mode. Instead, this PR makes link hints mode stay active until enter is pressed. The only user-visible UI changes are:
* in filter hints with `waitForEnterForFilteredHints` enabled:
  - the HUD still shows the link hints contents rather than `Hit <enter> to proceed`
  - the user can 'back out' of the current selection by typing <kbd>backspace</kbd> and select a different link, since they're still in the full link hints mode
  - the border highlight isn't shown before pressing <kbd>enter</kbd> (which was a bit strange anyway)
* in alphabet hints, the border highlight for the selected link now covers all parts of the link, as it already did for filter hints.