### PR TITLE
Simplify tab count handling in link hints

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -232,13 +232,9 @@ class LinkHintsMode
   onKeyDownInMode: (event) ->
     return if event.repeat
 
-    previousTabCount = @tabCount
-    @tabCount = 0
-
     # NOTE(smblott) The modifier behaviour here applies only to alphabet hints.
     if event.key in ["Control", "Shift"] and not Settings.get("filterLinkHints") and
       @mode in [ OPEN_IN_CURRENT_TAB, OPEN_WITH_QUEUE, OPEN_IN_NEW_BG_TAB, OPEN_IN_NEW_FG_TAB ]
-        @tabCount = previousTabCount
         # Toggle whether to open the link in a new or current tab.
         previousMode = @mode
         key = event.key
@@ -262,6 +258,7 @@ class LinkHintsMode
 
     else if KeyboardUtils.isBackspace event
       if @markerMatcher.popKeyChar()
+        @tabCount = 0
         @updateVisibleMarkers()
       else
         # Exit via @hintMode.exit(), so that the LinkHints.activate() "onExit" callback sees the key event and
@@ -273,15 +270,14 @@ class LinkHintsMode
       HintCoordinator.sendMessage "activateActiveHintMarker" if @markerMatcher.activeHintMarker
 
     else if event.key == "Tab"
-      @tabCount = previousTabCount + (if event.shiftKey then -1 else 1)
+      if event.shiftKey then @tabCount-- else @tabCount++
       @updateVisibleMarkers @tabCount
 
     else if event.key == " " and @markerMatcher.shouldRotateHints event
-      @tabCount = previousTabCount
       HintCoordinator.sendMessage "rotateHints"
 
     else
-      @tabCount = previousTabCount if event.ctrlKey or event.metaKey or event.altKey
+      @tabCount = 0 unless event.ctrlKey or event.metaKey or event.altKey
       unless event.repeat
         keyChar =
           if Settings.get "filterLinkHints"

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -271,7 +271,7 @@ class LinkHintsMode
 
     else if event.key == "Tab"
       if event.shiftKey then @tabCount-- else @tabCount++
-      @updateVisibleMarkers @tabCount
+      @updateVisibleMarkers()
 
     else if event.key == " " and @markerMatcher.shouldRotateHints event
       HintCoordinator.sendMessage "rotateHints"
@@ -294,9 +294,10 @@ class LinkHintsMode
 
     handlerStack.suppressEvent
 
-  updateVisibleMarkers: (tabCount = 0) ->
+  updateVisibleMarkers: ->
     {hintKeystrokeQueue, linkTextKeystrokeQueue} = @markerMatcher
-    HintCoordinator.sendMessage "updateKeyState", {hintKeystrokeQueue, linkTextKeystrokeQueue, tabCount}
+    HintCoordinator.sendMessage "updateKeyState",
+      {hintKeystrokeQueue, linkTextKeystrokeQueue, tabCount: @tabCount}
 
   updateKeyState: ({hintKeystrokeQueue, linkTextKeystrokeQueue, tabCount}) ->
     extend @markerMatcher, {hintKeystrokeQueue, linkTextKeystrokeQueue}


### PR DESCRIPTION
Currently, tab count handling is.. weird. This PR tries to make it less so.

This changes the behaviour of <kbd>enter</kbd> and <kbd>space</kbd>.
* It should make no difference for <kbd>enter</kbd>, as it exits the mode.
* It makes no sense for rotating the layering of the hints to clear the active hint (when the next key is pressed), so I suspect it was an oversight.
  - This also only applies in the current frame, so all other frames still have the old `tabCount`
  - Inadvertently changing frame straight after rotating hints therefore means that tab may change its behaviour. This is unlikely, but still.. weird.

Also, reduces the number of lines in link hints slightly!