### PR TITLE
Add minimum Chrome version of 51

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,7 @@
   "icons": {  "16": "icons/icon16.png",
               "48": "icons/icon48.png",
              "128": "icons/icon128.png" },
+  "minimum_chrome_version": "51.0",
   "background": {
     "scripts": [
       "lib/utils.js",


### PR DESCRIPTION
Since key handling has been migrated to use `KeyboardEvent.key`, we need the user's Chrome version to support it. This support began at version 51 in May 2016.

Proposing based on @philc's [comment](https://github.com/philc/vimium/issues/2646#issuecomment-330098362) on #2646.

This fixes #2790 and #2646.