### PR TITLE
FF: Restore window expando on every event listener

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -157,6 +157,7 @@ initializePreDomReady = ->
 # Wrapper to install event listeners.  Syntactic sugar.
 installListener = (element, event, callback) ->
   element.addEventListener(event, forTrusted(->
+    root.extend window, root unless extend?
     if isEnabledForUrl then callback.apply(this, arguments) else true
   ), true)
 


### PR DESCRIPTION
This should fix *most* problems from Firefox issue [1408996](https://bugzilla.mozilla.org/show_bug.cgi?id=1408996), by implementing a more aggressive version of #2742.

The root cause of the bug is that document.domain is set, and Firefox discards the 'expando' for the window that contains all properties we set. Technically, this can happen at any time, and so some failures are still possible. This fixes #2799.