### PR TITLE
Don't suppress default action for non-printing keys in link hints

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -294,7 +294,7 @@ class LinkHintsMode
             @markerMatcher.pushKeyChar keyChar
             @updateVisibleMarkers()
           else
-            return
+            return handlerStack.suppressPropagation
 
     handlerStack.suppressEvent
 

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -363,8 +363,12 @@ DomUtils =
             @remove() if event.target == window
             handlerStack.continueBubbling
       callback?()
-      @suppressEvent event
-      handlerStack.suppressEvent
+      if suppressPropagation
+        DomUtils.suppressPropagation event
+        handlerStack.suppressPropagation
+      else
+        DomUtils.suppressEvent event
+        handlerStack.suppressEvent
 
   # Polyfill for selection.type (which is not available in Firefox).
   getSelectionType: (selection = document.getSelection()) ->


### PR DESCRIPTION
This restores the old behaviour prior to #2772.