### PR TITLE
Allowed binding of < and > with modifier keys.

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -64,7 +64,8 @@ Commands =
   parseKeySequence: do ->
     modifier = "(?:[acm]-)"                             # E.g. "a-", "c-", "m-".
     namedKey = "(?:[a-z][a-z0-9]+)"                     # E.g. "left" or "f12" (always two characters or more).
-    modifiedKey = "(?:#{modifier}+(?:.|#{namedKey}))"   # E.g. "c-*" or "c-left".
+    escapedKey = "(?:\\\\[<>])"                           # Escaped < or >
+    modifiedKey = "(?:#{modifier}+(?:#{namedKey}|#{escapedKey}|.))"   # E.g. "c-*" or "c-left".
     specialKeyRegexp = new RegExp "^<(#{namedKey}|#{modifiedKey})>(.*)", "i"
     (key) ->
       if key.length == 0
@@ -73,6 +74,7 @@ Commands =
       else if 0 == key.search specialKeyRegexp
         [modifiers..., keyChar] = RegExp.$1.split "-"
         keyChar = keyChar.toLowerCase() unless keyChar.length == 1
+        keyChar = keyChar.replace("\\", "")
         modifiers = (modifier.toLowerCase() for modifier in modifiers)
         modifiers.sort()
         ["<#{[modifiers..., keyChar].join '-'}>", @parseKeySequence(RegExp.$2)...]

--- a/tests/unit_tests/commands_test.coffee
+++ b/tests/unit_tests/commands_test.coffee
@@ -30,6 +30,12 @@ context "Key mappings",
     @testKeySequence "##", "#/#", 2
     @testKeySequence "..", "./.", 2
 
+  should "recognize extra angle brackets", ->
+    @testKeySequence "<", "<", 1
+    @testKeySequence ">", ">", 1
+    @testKeySequence "<c-\\>>", "<c->>", 1
+    @testKeySequence "<c-\\<>", "<c-<>", 1
+
   should "parse keys with modifiers", ->
     @testKeySequence "<c-a>", "<c-a>", 1
     @testKeySequence "<c-A>", "<c-A>", 1


### PR DESCRIPTION
By escaping the > and <, both can be bound in the modifier keys
format. This enables binding shortcuts like <c-\>> and <c-\<>.