### PR TITLE
Change description of CSS option

### DIFF
--- a/pages/options.html
+++ b/pages/options.html
@@ -272,11 +272,12 @@ b: http://b.com/?q=%s description
             </td>
           </tr>
           <tr>
-            <td class="caption">CSS for link hints</td>
+            <td class="caption">CSS for Vimium UI</td>
             <td verticalAlign="top">
               <div class="help">
                 <div class="example">
-                  The CSS used to style the characters next to each link hint.<br/><br/>
+                  These styles are applied to link hints, the Vomnibar, the help dialog, the exclusions pop-up and the HUD.<br />
+                  By default, this CSS is used to style the characters next to each link hint.<br/><br/>
                   These styles are used in addition to and take precedence over Vimium's
                   default styles.
                 </div>


### PR DESCRIPTION
This makes it clearer that *any* of the Vimium UI can be styled using the CSS input since #2683.

This fixes #2814, fixes #2342 (although they were technically already fixed by #2683).