### PR TITLE
Use the same link flashing algorithm for filter hints and alphabet hints

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -359,7 +359,7 @@ class LinkHintsMode
   # When only one hint remains, activate it in the appropriate way.  The current frame may or may not contain
   # the matched link, and may or may not have the focus.  The resulting four cases are accounted for here by
   # selectively pushing the appropriate HintCoordinator.onExit handlers.
-  activateLink: (linkMatched, userMightOverType) ->
+  activateLink: (linkMatched, userMightOverType = false) ->
     @removeHintMarkers()
 
     if linkMatched.isLocalMarker

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -387,13 +387,14 @@ class LinkHintsMode
 
     if linkMatched.isLocalMarker
       {top: viewportTop, left: viewportLeft} = DomUtils.getViewportTopLeft()
-      for rect in clickEl.getClientRects()
-        flashEl = DomUtils.addFlashRect Rect.translate rect, viewportLeft, viewportTop
-        do (flashEl) -> HintCoordinator.onExit.push -> DomUtils.removeElement flashEl
+      flashElements = for rect in clickEl.getClientRects()
+        DomUtils.addFlashRect Rect.translate rect, viewportLeft, viewportTop
 
     # If we're using a keyboard blocker, then the frame with the focus sends the "exit" message, otherwise the
     # frame containing the matched link does.
     if userMightOverType
+      if flashElements?
+        HintCoordinator.onExit.push -> DomUtils.removeElement flashEl for flashEl in flashElements
       if windowIsFocused()
         callback = (isSuccess) -> HintCoordinator.sendMessage "exit", {isSuccess}
         if Settings.get "waitForEnterForFilteredHints"
@@ -401,6 +402,7 @@ class LinkHintsMode
         else
           new TypingProtector 200, callback
     else if linkMatched.isLocalMarker
+      Utils.setTimeout 400, -> DomUtils.removeElement flashEl for flashEl in flashElements
       HintCoordinator.sendMessage "exit", isSuccess: true
 
   #

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -305,7 +305,7 @@ class LinkHintsMode
     if linksMatched.length == 0
       @deactivateMode()
     else if linksMatched.length == 1
-      @activateLink linksMatched[0], userMightOverType ? false
+      @activateLink linksMatched[0], userMightOverType
     else
       @hideMarker marker for marker in @hintMarkers
       @showMarker matched, @markerMatcher.hintKeystrokeQueue.length for matched in linksMatched
@@ -359,7 +359,7 @@ class LinkHintsMode
   # When only one hint remains, activate it in the appropriate way.  The current frame may or may not contain
   # the matched link, and may or may not have the focus.  The resulting four cases are accounted for here by
   # selectively pushing the appropriate HintCoordinator.onExit handlers.
-  activateLink: (linkMatched, userMightOverType=false) ->
+  activateLink: (linkMatched, userMightOverType) ->
     @removeHintMarkers()
 
     if linkMatched.isLocalMarker
@@ -397,10 +397,11 @@ class LinkHintsMode
 
     # If we're using a keyboard blocker, then the frame with the focus sends the "exit" message, otherwise the
     # frame containing the matched link does.
-    if userMightOverType and Settings.get "waitForEnterForFilteredHints"
-      installKeyboardBlocker (callback) -> new WaitForEnter callback
-    else if userMightOverType
-      installKeyboardBlocker (callback) -> new TypingProtector 200, callback
+    if userMightOverType
+      if Settings.get "waitForEnterForFilteredHints"
+        installKeyboardBlocker (callback) -> new WaitForEnter callback
+      else
+        installKeyboardBlocker (callback) -> new TypingProtector 200, callback
     else if linkMatched.isLocalMarker
       DomUtils.flashRect linkMatched.rect
       HintCoordinator.sendMessage "exit", isSuccess: true

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -385,15 +385,15 @@ class LinkHintsMode
               clickEl.focus()
             linkActivator clickEl
 
+    if linkMatched.isLocalMarker
+      {top: viewportTop, left: viewportLeft} = DomUtils.getViewportTopLeft()
+      for rect in clickEl.getClientRects()
+        flashEl = DomUtils.addFlashRect Rect.translate rect, viewportLeft, viewportTop
+        do (flashEl) -> HintCoordinator.onExit.push -> DomUtils.removeElement flashEl
+
     # If we're using a keyboard blocker, then the frame with the focus sends the "exit" message, otherwise the
     # frame containing the matched link does.
     if userMightOverType
-      if linkMatched.isLocalMarker
-        {top: viewportTop, left: viewportLeft} = DomUtils.getViewportTopLeft()
-        for rect in clickEl.getClientRects()
-          flashEl = DomUtils.addFlashRect Rect.translate rect, viewportLeft, viewportTop
-          do (flashEl) -> HintCoordinator.onExit.push -> DomUtils.removeElement flashEl
-
       if windowIsFocused()
         callback = (isSuccess) -> HintCoordinator.sendMessage "exit", {isSuccess}
         if Settings.get "waitForEnterForFilteredHints"
@@ -401,7 +401,6 @@ class LinkHintsMode
         else
           new TypingProtector 200, callback
     else if linkMatched.isLocalMarker
-      DomUtils.flashRect linkMatched.rect
       HintCoordinator.sendMessage "exit", isSuccess: true
 
   #

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -388,9 +388,8 @@ class LinkHintsMode
     installKeyboardBlocker = (startKeyboardBlocker) ->
       if linkMatched.isLocalMarker
         {top: viewportTop, left: viewportLeft} = DomUtils.getViewportTopLeft()
-        for rect in (Rect.copy rect for rect in clickEl.getClientRects())
-          extend rect, top: rect.top + viewportTop, left: rect.left + viewportLeft
-          flashEl = DomUtils.addFlashRect rect
+        for rect in clickEl.getClientRects()
+          flashEl = DomUtils.addFlashRect Rect.translate rect, viewportLeft, viewportTop
           do (flashEl) -> HintCoordinator.onExit.push -> DomUtils.removeElement flashEl
 
       if windowIsFocused()

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -311,7 +311,7 @@ DomUtils =
     flashEl
 
   # momentarily flash a rectangular border to give user some visual feedback
-  flashRect: (rect, callback) ->
+  flashRect: (rect) ->
     flashEl = @addFlashRect rect
     setTimeout((-> DomUtils.removeElement flashEl), 400)
 

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -311,7 +311,7 @@ DomUtils =
     flashEl
 
   # momentarily flash a rectangular border to give user some visual feedback
-  flashRect: (rect) ->
+  flashRect: (rect, callback) ->
     flashEl = @addFlashRect rect
     setTimeout((-> DomUtils.removeElement flashEl), 400)
 


### PR DESCRIPTION
Commit da2be746332c69326b008f555aec2f1a166de7b0 changed filter hint mode's flash to highlight all lines of text in a clicked link. This PR does the same for alphabet hints, combining the code for both.