### PR TITLE
[RFC] Add a (painfully) minimal commands listing

### DIFF
--- a/pages/commands.coffee
+++ b/pages/commands.coffee
@@ -9,33 +9,10 @@ compareKeys = (a,b) ->
   if a < b then -1 else if b < a then 1 else 0
 
 window.showTable = (helpPageData) ->
-  article = document.getElementsByTagName("article")[0]
-  article.innerHTML = ""
   for own group, commands of helpPageData
-    groupSection = document.createElement "section"
-    groupSection.className = "group-#{group}"
-
-    groupHeader = document.createElement "h2"
-    groupHeader.appendChild document.createTextNode group
-    groupSection.appendChild groupHeader
-
     for command in commands
-      commandSection = document.createElement "section"
-      commandSection.className = "command-#{command.command}"
-      commandHeader = document.createElement "h3"
-      keysSpan = document.createElement "span"
-      keysSpan.className = "keys"
-      descriptionParagraph = document.createElement "p"
-      descriptionParagraph.className = "description"
+      commandSection = document.getElementsByClassName("command-#{command.command}")[0]
+      keysSpan = commandSection.getElementsByClassName("keys")[0]
 
-      commandHeader.appendChild document.createTextNode command.command + " "
+      keysSpan.innerHTML = ""
       keysSpan.appendChild document.createTextNode (command.keys.join ", ")
-      commandHeader.appendChild keysSpan
-      descriptionParagraph.appendChild document.createTextNode command.description
-
-      commandSection.appendChild commandHeader
-      commandSection.appendChild descriptionParagraph
-
-      groupSection.appendChild commandSection
-
-    article.appendChild groupSection

--- a/pages/commands.coffee
+++ b/pages/commands.coffee
@@ -9,39 +9,33 @@ compareKeys = (a,b) ->
   if a < b then -1 else if b < a then 1 else 0
 
 window.showTable = (helpPageData) ->
-  table = document.getElementById "command-table"
-  table.innerHTML = ""
+  article = document.getElementsByTagName("article")[0]
+  article.innerHTML = ""
   for own group, commands of helpPageData
-    tbody = document.createElement "tbody"
+    groupSection = document.createElement "section"
+    groupSection.className = "group-#{group}"
 
-    headerRow = document.createElement "tr"
-    headerCell = document.createElement "th"
-    headerCell.appendChild document.createTextNode group
-    headerRow.appendChild headerCell
-    tbody.appendChild headerRow
+    groupHeader = document.createElement "h2"
+    groupHeader.appendChild document.createTextNode group
+    groupSection.appendChild groupHeader
 
     for command in commands
-      commandBody = document.createElement "tbody"
-      commandRow = document.createElement "tr"
-      commandCell = document.createElement "th"
-      keysCell = document.createElement "td"
+      commandSection = document.createElement "section"
+      commandSection.className = "command-#{command.command}"
+      commandHeader = document.createElement "h3"
+      keysSpan = document.createElement "span"
+      keysSpan.className = "keys"
+      descriptionParagraph = document.createElement "p"
+      descriptionParagraph.className = "description"
 
-      commandCell.appendChild document.createTextNode command.command
-      keysCell.appendChild document.createTextNode command.keys.join ", "
+      commandHeader.appendChild document.createTextNode command.command + " "
+      keysSpan.appendChild document.createTextNode (command.keys.join ", ")
+      commandHeader.appendChild keysSpan
+      descriptionParagraph.appendChild document.createTextNode command.description
 
-      commandRow.appendChild commandCell
-      commandRow.appendChild keysCell
-      commandBody.appendChild commandRow
+      commandSection.appendChild commandHeader
+      commandSection.appendChild descriptionParagraph
 
-      descriptionRow = document.createElement "tr"
-      descriptionCell = document.createElement "td"
-      descriptionCell.colspan = 2
+      groupSection.appendChild commandSection
 
-      descriptionCell.appendChild document.createTextNode command.description
-
-      descriptionRow.appendChild descriptionCell
-      commandBody.appendChild descriptionRow
-
-      tbody.appendChild commandBody
-
-    table.appendChild tbody
+    article.appendChild groupSection

--- a/pages/commands.coffee
+++ b/pages/commands.coffee
@@ -1,0 +1,47 @@
+window.addEventListener "DOMContentLoaded", (event) ->
+  chrome.storage.local.get "helpPageData", ({helpPageData}) =>
+    showTable helpPageData
+
+# The ordering we show key bindings is alphanumerical, except that special keys sort to the end.
+compareKeys = (a,b) ->
+  a = a.replace "<","~"
+  b = b.replace "<", "~"
+  if a < b then -1 else if b < a then 1 else 0
+
+window.showTable = (helpPageData) ->
+  table = document.getElementById "command-table"
+  table.innerHTML = ""
+  for own group, commands of helpPageData
+    tbody = document.createElement "tbody"
+
+    headerRow = document.createElement "tr"
+    headerCell = document.createElement "th"
+    headerCell.appendChild document.createTextNode group
+    headerRow.appendChild headerCell
+    tbody.appendChild headerRow
+
+    for command in commands
+      commandBody = document.createElement "tbody"
+      commandRow = document.createElement "tr"
+      commandCell = document.createElement "th"
+      keysCell = document.createElement "td"
+
+      commandCell.appendChild document.createTextNode command.command
+      keysCell.appendChild document.createTextNode command.keys.join ", "
+
+      commandRow.appendChild commandCell
+      commandRow.appendChild keysCell
+      commandBody.appendChild commandRow
+
+      descriptionRow = document.createElement "tr"
+      descriptionCell = document.createElement "td"
+      descriptionCell.colspan = 2
+
+      descriptionCell.appendChild document.createTextNode command.description
+
+      descriptionRow.appendChild descriptionCell
+      commandBody.appendChild descriptionRow
+
+      tbody.appendChild commandBody
+
+    table.appendChild tbody

--- a/pages/commands.css
+++ b/pages/commands.css
@@ -1,0 +1,27 @@
+body {
+  background: #f4f4f4;
+  color: black;
+}
+
+section.group > h2 {
+  font-weight: 350;
+}
+
+section.command {
+  background: white;
+  box-shadow: 0 -1px 0 rgba(0,0,0,.05),0 0 2px rgba(0,0,0,.1),0 2px 4px rgba(0,0,0,.2);
+}
+
+section.command > * {
+  padding: 16px 16px 0;
+}
+
+section.command span.keys {
+  float: right;
+  display: inline-block;
+  min-width: 50px;
+}
+
+section.command > p.description {
+  padding: 16px;
+}

--- a/pages/commands.html
+++ b/pages/commands.html
@@ -1,0 +1,33 @@
+<html>
+  <head>
+    <title>Vimium Commands</title>
+    <script src="../lib/utils.js"></script>
+    <script src="../lib/keyboard_utils.js"></script>
+    <script src="../lib/dom_utils.js"></script>
+    <script src="../lib/rect.js"></script>
+    <script src="../lib/handler_stack.js"></script>
+    <script src="../lib/settings.js"></script>
+    <script src="../lib/find_mode_history.js"></script>
+    <script src="../content_scripts/mode.js"></script>
+    <script src="../content_scripts/ui_component.js"></script>
+    <script src="../content_scripts/link_hints.js"></script>
+    <script src="../content_scripts/vomnibar.js"></script>
+    <script src="../content_scripts/scroller.js"></script>
+    <script src="../content_scripts/marks.js"></script>
+    <script src="../content_scripts/mode_insert.js"></script>
+    <script src="../content_scripts/mode_find.js"></script>
+    <script src="../content_scripts/mode_key_handler.js"></script>
+    <script src="../content_scripts/mode_visual.js"></script>
+    <script src="../content_scripts/hud.js"></script>
+    <script src="../content_scripts/mode_normal.js"></script>
+    <script src="../content_scripts/vimium_frontend.js"></script>
+    <link rel="stylesheet" type="text/css" href="../content_scripts/vimium.css" />
+
+    <script type="text/javascript" src="commands.js"></script>
+  </head>
+
+  <body>
+    <table id="command-table">
+    </table>
+  </body>
+</html>

--- a/pages/commands.html
+++ b/pages/commands.html
@@ -27,7 +27,8 @@
   </head>
 
   <body>
-    <table id="command-table">
-    </table>
+    <h1>Vimium command listing</h1>
+    <article>
+    </article>
   </body>
 </html>

--- a/pages/commands.html
+++ b/pages/commands.html
@@ -30,45 +30,8 @@
   <body>
     <h1>Vimium command listing</h1>
     <article>
-      <section class="group group-findCommands">
-        <h2>findCommands</h2>
-        <section class="command command-enterFindMode">
-          <h3>enterFindMode <span class="keys"></span></h3>
-          <p class="description">Enter find mode</p>
-        </section>
-        <section class="command command-performFind">
-          <h3>performFind <span class="keys"></span></h3>
-          <p class="description">Cycle forward to the next find match</p>
-        </section>
-        <section class="command command-performBackwardsFind">
-          <h3>performBackwardsFind <span class="keys"></span></h3>
-          <p class="description">Cycle backward to the previous find match</p>
-        </section>
-      </section>
-      <section class="group group-historyNavigation">
-        <h2>historyNavigation</h2>
-        <section class="command command-goBack">
-          <h3>goBack <span class="keys"></span></h3>
-          <p class="description">Go back in history</p>
-        </section>
-        <section class="command command-goForward">
-          <h3>goForward <span class="keys"></span></h3>
-          <p class="description">Go forward in history</p>
-        </section>
-      </section>
-      <section class="group group-misc">
-        <h2>misc</h2>
-        <section class="command command-showHelp">
-          <h3>showHelp <span class="keys"></span></h3>
-          <p class="description">Show help</p>
-        </section>
-        <section class="command command-toggleViewSource">
-          <h3>toggleViewSource <span class="keys"></span></h3>
-          <p class="description">View page source</p>
-        </section>
-      </section>
-      <section class="group group-pageNavigation">
-        <h2>pageNavigation</h2>
+      <section class="group group-scrolling">
+        <h2>Scrolling</h2>
         <section class="command command-scrollDown">
           <h3>scrollDown <span class="keys"></span></h3>
           <p class="description">Scroll down</p>
@@ -117,50 +80,9 @@
           <h3>scrollToRight <span class="keys"></span></h3>
           <p class="description">Scroll all the way to the right</p>
         </section>
-        <section class="command command-reload">
-          <h3>reload <span class="keys"></span></h3>
-          <p class="description">Reload the page</p>
-        </section>
-        <section class="command command-copyCurrentUrl">
-          <h3>copyCurrentUrl <span class="keys"></span></h3>
-          <p class="description">Copy the current URL to the clipboard</p>
-        </section>
-        <section class="command command-openCopiedUrlInCurrentTab">
-          <h3>openCopiedUrlInCurrentTab <span class="keys"></span></h3>
-          <p class="description">Open the clipboard's URL in the current tab</p>
-        </section>
-        <section class="command command-openCopiedUrlInNewTab">
-          <h3>openCopiedUrlInNewTab <span class="keys"></span></h3>
-          <p class="description">Open the clipboard's URL in a new tab</p>
-        </section>
-        <section class="command command-goUp">
-          <h3>goUp <span class="keys"></span></h3>
-          <p class="description">Go up the URL hierarchy</p>
-        </section>
-        <section class="command command-goToRoot">
-          <h3>goToRoot <span class="keys"></span></h3>
-          <p class="description">Go to root of current URL hierarchy</p>
-        </section>
-        <section class="command command-enterInsertMode">
-          <h3>enterInsertMode <span class="keys"></span></h3>
-          <p class="description">Enter insert mode</p>
-        </section>
-        <section class="command command-enterVisualMode">
-          <h3>enterVisualMode <span class="keys"></span></h3>
-          <p class="description">Enter visual mode</p>
-        </section>
-        <section class="command command-enterVisualLineMode">
-          <h3>enterVisualLineMode <span class="keys"></span></h3>
-          <p class="description">Enter visual line mode</p>
-        </section>
-        <section class="command command-passNextKey">
-          <h3>passNextKey <span class="keys"></span></h3>
-          <p class="description">Pass the next key to the page</p>
-        </section>
-        <section class="command command-focusInput">
-          <h3>focusInput <span class="keys"></span></h3>
-          <p class="description">Focus the first text input on the page</p>
-        </section>
+      </section>
+      <section class="group group-link-hints">
+        <h2>Link hints</h2>
         <section class="command command-LinkHints.activateMode">
           <h3>LinkHints.activateMode <span class="keys"></span></h3>
           <p class="description">Open a link in the current tab</p>
@@ -189,6 +111,82 @@
           <h3>LinkHints.activateModeToCopyLinkUrl <span class="keys"></span></h3>
           <p class="description">Copy a link URL to the clipboard</p>
         </section>
+      </section>
+      <section class="group group-searching">
+        <h2>Searching</h2>
+        <section class="command command-enterFindMode">
+          <h3>enterFindMode <span class="keys"></span></h3>
+          <p class="description">Enter find mode</p>
+        </section>
+        <section class="command command-performFind">
+          <h3>performFind <span class="keys"></span></h3>
+          <p class="description">Cycle forward to the next find match</p>
+        </section>
+        <section class="command command-performBackwardsFind">
+          <h3>performBackwardsFind <span class="keys"></span></h3>
+          <p class="description">Cycle backward to the previous find match</p>
+        </section>
+      </section>
+      <section class="group group-modes">
+        <h2>Modes</h2>
+        <section class="command command-enterInsertMode">
+          <h3>enterInsertMode <span class="keys"></span></h3>
+          <p class="description">Enter insert mode</p>
+        </section>
+        <section class="command command-enterVisualMode">
+          <h3>enterVisualMode <span class="keys"></span></h3>
+          <p class="description">Enter visual mode</p>
+        </section>
+        <section class="command command-enterVisualLineMode">
+          <h3>enterVisualLineMode <span class="keys"></span></h3>
+          <p class="description">Enter visual line mode</p>
+        </section>
+        <section class="command command-passNextKey">
+          <h3>passNextKey <span class="keys"></span></h3>
+          <p class="description">Pass the next key to the page</p>
+        </section>
+      </section>
+      <section class="group group-history">
+        <h2>History</h2>
+        <section class="command command-goBack">
+          <h3>goBack <span class="keys"></span></h3>
+          <p class="description">Go back in history</p>
+        </section>
+        <section class="command command-goForward">
+          <h3>goForward <span class="keys"></span></h3>
+          <p class="description">Go forward in history</p>
+        </section>
+      </section>
+      <section class="group group-page">
+        <h2>Page</h2>
+        <section class="command command-reload">
+          <h3>reload <span class="keys"></span></h3>
+          <p class="description">Reload the page</p>
+        </section>
+        <section class="command command-copyCurrentUrl">
+          <h3>copyCurrentUrl <span class="keys"></span></h3>
+          <p class="description">Copy the current URL to the clipboard</p>
+        </section>
+        <section class="command command-openCopiedUrlInCurrentTab">
+          <h3>openCopiedUrlInCurrentTab <span class="keys"></span></h3>
+          <p class="description">Open the clipboard's URL in the current tab</p>
+        </section>
+        <section class="command command-openCopiedUrlInNewTab">
+          <h3>openCopiedUrlInNewTab <span class="keys"></span></h3>
+          <p class="description">Open the clipboard's URL in a new tab</p>
+        </section>
+        <section class="command command-goUp">
+          <h3>goUp <span class="keys"></span></h3>
+          <p class="description">Go up the URL hierarchy</p>
+        </section>
+        <section class="command command-goToRoot">
+          <h3>goToRoot <span class="keys"></span></h3>
+          <p class="description">Go to root of current URL hierarchy</p>
+        </section>
+        <section class="command command-focusInput">
+          <h3>focusInput <span class="keys"></span></h3>
+          <p class="description">Focus the first text input on the page</p>
+        </section>
         <section class="command command-goPrevious">
           <h3>goPrevious <span class="keys"></span></h3>
           <p class="description">Follow the link labeled previous or &lt;</p>
@@ -214,8 +212,8 @@
           <p class="description">Go to a mark</p>
         </section>
       </section>
-      <section class="group group-tabManipulation">
-        <h2>tabManipulation</h2>
+      <section class="group group-tabs">
+        <h2>Tabs</h2>
         <section class="command command-createTab">
           <h3>createTab <span class="keys"></span></h3>
           <p class="description">Create new tab</p>
@@ -285,8 +283,8 @@
           <p class="description">Move tab to the right</p>
         </section>
       </section>
-      <section class="group group-vomnibarCommands">
-        <h2>vomnibarCommands</h2>
+      <section class="group group-vomnibar">
+        <h2>Vomnibar</h2>
         <section class="command command-Vomnibar.activate">
           <h3>Vomnibar.activate <span class="keys"></span></h3>
           <p class="description">Open URL, bookmark or history entry</p>
@@ -314,6 +312,17 @@
         <section class="command command-Vomnibar.activateEditUrlInNewTab">
           <h3>Vomnibar.activateEditUrlInNewTab <span class="keys"></span></h3>
           <p class="description">Edit the current URL and open in a new tab</p>
+        </section>
+      </section>
+      <section class="group group-misc">
+        <h2>Miscellaneous</h2>
+        <section class="command command-showHelp">
+          <h3>showHelp <span class="keys"></span></h3>
+          <p class="description">Show help</p>
+        </section>
+        <section class="command command-toggleViewSource">
+          <h3>toggleViewSource <span class="keys"></span></h3>
+          <p class="description">View page source</p>
         </section>
       </section>
     </article>

--- a/pages/commands.html
+++ b/pages/commands.html
@@ -29,6 +29,292 @@
   <body>
     <h1>Vimium command listing</h1>
     <article>
+      <section class="group-findCommands">
+        <h2>findCommands</h2>
+        <section class="command-enterFindMode">
+          <h3>enterFindMode <span class="keys"></span></h3>
+          <p class="description">Enter find mode</p>
+        </section>
+        <section class="command-performFind">
+          <h3>performFind <span class="keys"></span></h3>
+          <p class="description">Cycle forward to the next find match</p>
+        </section>
+        <section class="command-performBackwardsFind">
+          <h3>performBackwardsFind <span class="keys"></span></h3>
+          <p class="description">Cycle backward to the previous find match</p>
+        </section>
+      </section>
+      <section class="group-historyNavigation">
+        <h2>historyNavigation</h2>
+        <section class="command-goBack">
+          <h3>goBack <span class="keys"></span></h3>
+          <p class="description">Go back in history</p>
+        </section>
+        <section class="command-goForward">
+          <h3>goForward <span class="keys"></span></h3>
+          <p class="description">Go forward in history</p>
+        </section>
+      </section>
+      <section class="group-misc">
+        <h2>misc</h2>
+        <section class="command-showHelp">
+          <h3>showHelp <span class="keys"></span></h3>
+          <p class="description">Show help</p>
+        </section>
+        <section class="command-toggleViewSource">
+          <h3>toggleViewSource <span class="keys"></span></h3>
+          <p class="description">View page source</p>
+        </section>
+      </section>
+      <section class="group-pageNavigation">
+        <h2>pageNavigation</h2>
+        <section class="command-scrollDown">
+          <h3>scrollDown <span class="keys"></span></h3>
+          <p class="description">Scroll down</p>
+        </section>
+        <section class="command-scrollUp">
+          <h3>scrollUp <span class="keys"></span></h3>
+          <p class="description">Scroll up</p>
+        </section>
+        <section class="command-scrollToTop">
+          <h3>scrollToTop <span class="keys"></span></h3>
+          <p class="description">Scroll to the top of the page</p>
+        </section>
+        <section class="command-scrollToBottom">
+          <h3>scrollToBottom <span class="keys"></span></h3>
+          <p class="description">Scroll to the bottom of the page</p>
+        </section>
+        <section class="command-scrollPageDown">
+          <h3>scrollPageDown <span class="keys"></span></h3>
+          <p class="description">Scroll a half page down</p>
+        </section>
+        <section class="command-scrollPageUp">
+          <h3>scrollPageUp <span class="keys"></span></h3>
+          <p class="description">Scroll a half page up</p>
+        </section>
+        <section class="command-scrollFullPageDown">
+          <h3>scrollFullPageDown <span class="keys"></span></h3>
+          <p class="description">Scroll a full page down</p>
+        </section>
+        <section class="command-scrollFullPageUp">
+          <h3>scrollFullPageUp <span class="keys"></span></h3>
+          <p class="description">Scroll a full page up</p>
+        </section>
+        <section class="command-scrollLeft">
+          <h3>scrollLeft <span class="keys"></span></h3>
+          <p class="description">Scroll left</p>
+        </section>
+        <section class="command-scrollRight">
+          <h3>scrollRight <span class="keys"></span></h3>
+          <p class="description">Scroll right</p>
+        </section>
+        <section class="command-scrollToLeft">
+          <h3>scrollToLeft <span class="keys"></span></h3>
+          <p class="description">Scroll all the way to the left</p>
+        </section>
+        <section class="command-scrollToRight">
+          <h3>scrollToRight <span class="keys"></span></h3>
+          <p class="description">Scroll all the way to the right</p>
+        </section>
+        <section class="command-reload">
+          <h3>reload <span class="keys"></span></h3>
+          <p class="description">Reload the page</p>
+        </section>
+        <section class="command-copyCurrentUrl">
+          <h3>copyCurrentUrl <span class="keys"></span></h3>
+          <p class="description">Copy the current URL to the clipboard</p>
+        </section>
+        <section class="command-openCopiedUrlInCurrentTab">
+          <h3>openCopiedUrlInCurrentTab <span class="keys"></span></h3>
+          <p class="description">Open the clipboard's URL in the current tab</p>
+        </section>
+        <section class="command-openCopiedUrlInNewTab">
+          <h3>openCopiedUrlInNewTab <span class="keys"></span></h3>
+          <p class="description">Open the clipboard's URL in a new tab</p>
+        </section>
+        <section class="command-goUp">
+          <h3>goUp <span class="keys"></span></h3>
+          <p class="description">Go up the URL hierarchy</p>
+        </section>
+        <section class="command-goToRoot">
+          <h3>goToRoot <span class="keys"></span></h3>
+          <p class="description">Go to root of current URL hierarchy</p>
+        </section>
+        <section class="command-enterInsertMode">
+          <h3>enterInsertMode <span class="keys"></span></h3>
+          <p class="description">Enter insert mode</p>
+        </section>
+        <section class="command-enterVisualMode">
+          <h3>enterVisualMode <span class="keys"></span></h3>
+          <p class="description">Enter visual mode</p>
+        </section>
+        <section class="command-enterVisualLineMode">
+          <h3>enterVisualLineMode <span class="keys"></span></h3>
+          <p class="description">Enter visual line mode</p>
+        </section>
+        <section class="command-passNextKey">
+          <h3>passNextKey <span class="keys"></span></h3>
+          <p class="description">Pass the next key to the page</p>
+        </section>
+        <section class="command-focusInput">
+          <h3>focusInput <span class="keys"></span></h3>
+          <p class="description">Focus the first text input on the page</p>
+        </section>
+        <section class="command-LinkHints.activateMode">
+          <h3>LinkHints.activateMode <span class="keys"></span></h3>
+          <p class="description">Open a link in the current tab</p>
+        </section>
+        <section class="command-LinkHints.activateModeToOpenInNewTab">
+          <h3>LinkHints.activateModeToOpenInNewTab <span class="keys"></span></h3>
+          <p class="description">Open a link in a new tab</p>
+        </section>
+        <section class="command-LinkHints.activateModeToOpenInNewForegroundTab">
+          <h3>LinkHints.activateModeToOpenInNewForegroundTab <span class="keys"></span></h3>
+          <p class="description">Open a link in a new tab &amp; switch to it</p>
+        </section>
+        <section class="command-LinkHints.activateModeWithQueue">
+          <h3>LinkHints.activateModeWithQueue <span class="keys"></span></h3>
+          <p class="description">Open multiple links in a new tab</p>
+        </section>
+        <section class="command-LinkHints.activateModeToDownloadLink">
+          <h3>LinkHints.activateModeToDownloadLink <span class="keys"></span></h3>
+          <p class="description">Download link url</p>
+        </section>
+        <section class="command-LinkHints.activateModeToOpenIncognito">
+          <h3>LinkHints.activateModeToOpenIncognito <span class="keys"></span></h3>
+          <p class="description">Open a link in incognito window</p>
+        </section>
+        <section class="command-LinkHints.activateModeToCopyLinkUrl">
+          <h3>LinkHints.activateModeToCopyLinkUrl <span class="keys"></span></h3>
+          <p class="description">Copy a link URL to the clipboard</p>
+        </section>
+        <section class="command-goPrevious">
+          <h3>goPrevious <span class="keys"></span></h3>
+          <p class="description">Follow the link labeled previous or &lt;</p>
+        </section>
+        <section class="command-goNext">
+          <h3>goNext <span class="keys"></span></h3>
+          <p class="description">Follow the link labeled next or &gt;</p>
+        </section>
+        <section class="command-nextFrame">
+          <h3>nextFrame <span class="keys"></span></h3>
+          <p class="description">Select the next frame on the page</p>
+        </section>
+        <section class="command-mainFrame">
+          <h3>mainFrame <span class="keys"></span></h3>
+          <p class="description">Select the page's main/top frame</p>
+        </section>
+        <section class="command-Marks.activateCreateMode">
+          <h3>Marks.activateCreateMode <span class="keys"></span></h3>
+          <p class="description">Create a new mark</p>
+        </section>
+        <section class="command-Marks.activateGotoMode">
+          <h3>Marks.activateGotoMode <span class="keys"></span></h3>
+          <p class="description">Go to a mark</p>
+        </section>
+      </section>
+      <section class="group-tabManipulation">
+        <h2>tabManipulation</h2>
+        <section class="command-createTab">
+          <h3>createTab <span class="keys"></span></h3>
+          <p class="description">Create new tab</p>
+        </section>
+        <section class="command-previousTab">
+          <h3>previousTab <span class="keys"></span></h3>
+          <p class="description">Go one tab left</p>
+        </section>
+        <section class="command-nextTab">
+          <h3>nextTab <span class="keys"></span></h3>
+          <p class="description">Go one tab right</p>
+        </section>
+        <section class="command-visitPreviousTab">
+          <h3>visitPreviousTab <span class="keys"></span></h3>
+          <p class="description">Go to previously-visited tab</p>
+        </section>
+        <section class="command-firstTab">
+          <h3>firstTab <span class="keys"></span></h3>
+          <p class="description">Go to the first tab</p>
+        </section>
+        <section class="command-lastTab">
+          <h3>lastTab <span class="keys"></span></h3>
+          <p class="description">Go to the last tab</p>
+        </section>
+        <section class="command-duplicateTab">
+          <h3>duplicateTab <span class="keys"></span></h3>
+          <p class="description">Duplicate current tab</p>
+        </section>
+        <section class="command-togglePinTab">
+          <h3>togglePinTab <span class="keys"></span></h3>
+          <p class="description">Pin or unpin current tab</p>
+        </section>
+        <section class="command-toggleMuteTab">
+          <h3>toggleMuteTab <span class="keys"></span></h3>
+          <p class="description">Mute or unmute current tab</p>
+        </section>
+        <section class="command-removeTab">
+          <h3>removeTab <span class="keys"></span></h3>
+          <p class="description">Close current tab</p>
+        </section>
+        <section class="command-restoreTab">
+          <h3>restoreTab <span class="keys"></span></h3>
+          <p class="description">Restore closed tab</p>
+        </section>
+        <section class="command-moveTabToNewWindow">
+          <h3>moveTabToNewWindow <span class="keys"></span></h3>
+          <p class="description">Move tab to new window</p>
+        </section>
+        <section class="command-closeTabsOnLeft">
+          <h3>closeTabsOnLeft <span class="keys"></span></h3>
+          <p class="description">Close tabs on the left</p>
+        </section>
+        <section class="command-closeTabsOnRight">
+          <h3>closeTabsOnRight <span class="keys"></span></h3>
+          <p class="description">Close tabs on the right</p>
+        </section>
+        <section class="command-closeOtherTabs">
+          <h3>closeOtherTabs <span class="keys"></span></h3>
+          <p class="description">Close all other tabs</p>
+        </section>
+        <section class="command-moveTabLeft">
+          <h3>moveTabLeft <span class="keys"></span></h3>
+          <p class="description">Move tab to the left</p>
+        </section>
+        <section class="command-moveTabRight">
+          <h3>moveTabRight <span class="keys"></span></h3>
+          <p class="description">Move tab to the right</p>
+        </section>
+      </section>
+      <section class="group-vomnibarCommands">
+        <h2>vomnibarCommands</h2>
+        <section class="command-Vomnibar.activate">
+          <h3>Vomnibar.activate <span class="keys"></span></h3>
+          <p class="description">Open URL, bookmark or history entry</p>
+        </section>
+        <section class="command-Vomnibar.activateInNewTab">
+          <h3>Vomnibar.activateInNewTab <span class="keys"></span></h3>
+          <p class="description">Open URL, bookmark or history entry in a new tab</p>
+        </section>
+        <section class="command-Vomnibar.activateBookmarks">
+          <h3>Vomnibar.activateBookmarks <span class="keys"></span></h3>
+          <p class="description">Open a bookmark</p>
+        </section>
+        <section class="command-Vomnibar.activateBookmarksInNewTab">
+          <h3>Vomnibar.activateBookmarksInNewTab <span class="keys"></span></h3>
+          <p class="description">Open a bookmark in a new tab</p>
+        </section>
+        <section class="command-Vomnibar.activateTabSelection">
+          <h3>Vomnibar.activateTabSelection <span class="keys"></span></h3>
+          <p class="description">Search through your open tabs</p>
+        </section>
+        <section class="command-Vomnibar.activateEditUrl">
+          <h3>Vomnibar.activateEditUrl <span class="keys"></span></h3>
+          <p class="description">Edit the current URL</p>
+        </section>
+        <section class="command-Vomnibar.activateEditUrlInNewTab">
+          <h3>Vomnibar.activateEditUrlInNewTab <span class="keys"></span></h3>
+          <p class="description">Edit the current URL and open in a new tab</p>
+        </section>
+      </section>
     </article>
   </body>
 </html>

--- a/pages/commands.html
+++ b/pages/commands.html
@@ -23,294 +23,295 @@
     <script src="../content_scripts/vimium_frontend.js"></script>
     <link rel="stylesheet" type="text/css" href="../content_scripts/vimium.css" />
 
+    <link rel="stylesheet" type="text/css" href="commands.css" />
     <script type="text/javascript" src="commands.js"></script>
   </head>
 
   <body>
     <h1>Vimium command listing</h1>
     <article>
-      <section class="group-findCommands">
+      <section class="group group-findCommands">
         <h2>findCommands</h2>
-        <section class="command-enterFindMode">
+        <section class="command command-enterFindMode">
           <h3>enterFindMode <span class="keys"></span></h3>
           <p class="description">Enter find mode</p>
         </section>
-        <section class="command-performFind">
+        <section class="command command-performFind">
           <h3>performFind <span class="keys"></span></h3>
           <p class="description">Cycle forward to the next find match</p>
         </section>
-        <section class="command-performBackwardsFind">
+        <section class="command command-performBackwardsFind">
           <h3>performBackwardsFind <span class="keys"></span></h3>
           <p class="description">Cycle backward to the previous find match</p>
         </section>
       </section>
-      <section class="group-historyNavigation">
+      <section class="group group-historyNavigation">
         <h2>historyNavigation</h2>
-        <section class="command-goBack">
+        <section class="command command-goBack">
           <h3>goBack <span class="keys"></span></h3>
           <p class="description">Go back in history</p>
         </section>
-        <section class="command-goForward">
+        <section class="command command-goForward">
           <h3>goForward <span class="keys"></span></h3>
           <p class="description">Go forward in history</p>
         </section>
       </section>
-      <section class="group-misc">
+      <section class="group group-misc">
         <h2>misc</h2>
-        <section class="command-showHelp">
+        <section class="command command-showHelp">
           <h3>showHelp <span class="keys"></span></h3>
           <p class="description">Show help</p>
         </section>
-        <section class="command-toggleViewSource">
+        <section class="command command-toggleViewSource">
           <h3>toggleViewSource <span class="keys"></span></h3>
           <p class="description">View page source</p>
         </section>
       </section>
-      <section class="group-pageNavigation">
+      <section class="group group-pageNavigation">
         <h2>pageNavigation</h2>
-        <section class="command-scrollDown">
+        <section class="command command-scrollDown">
           <h3>scrollDown <span class="keys"></span></h3>
           <p class="description">Scroll down</p>
         </section>
-        <section class="command-scrollUp">
+        <section class="command command-scrollUp">
           <h3>scrollUp <span class="keys"></span></h3>
           <p class="description">Scroll up</p>
         </section>
-        <section class="command-scrollToTop">
+        <section class="command command-scrollToTop">
           <h3>scrollToTop <span class="keys"></span></h3>
           <p class="description">Scroll to the top of the page</p>
         </section>
-        <section class="command-scrollToBottom">
+        <section class="command command-scrollToBottom">
           <h3>scrollToBottom <span class="keys"></span></h3>
           <p class="description">Scroll to the bottom of the page</p>
         </section>
-        <section class="command-scrollPageDown">
+        <section class="command command-scrollPageDown">
           <h3>scrollPageDown <span class="keys"></span></h3>
           <p class="description">Scroll a half page down</p>
         </section>
-        <section class="command-scrollPageUp">
+        <section class="command command-scrollPageUp">
           <h3>scrollPageUp <span class="keys"></span></h3>
           <p class="description">Scroll a half page up</p>
         </section>
-        <section class="command-scrollFullPageDown">
+        <section class="command command-scrollFullPageDown">
           <h3>scrollFullPageDown <span class="keys"></span></h3>
           <p class="description">Scroll a full page down</p>
         </section>
-        <section class="command-scrollFullPageUp">
+        <section class="command command-scrollFullPageUp">
           <h3>scrollFullPageUp <span class="keys"></span></h3>
           <p class="description">Scroll a full page up</p>
         </section>
-        <section class="command-scrollLeft">
+        <section class="command command-scrollLeft">
           <h3>scrollLeft <span class="keys"></span></h3>
           <p class="description">Scroll left</p>
         </section>
-        <section class="command-scrollRight">
+        <section class="command command-scrollRight">
           <h3>scrollRight <span class="keys"></span></h3>
           <p class="description">Scroll right</p>
         </section>
-        <section class="command-scrollToLeft">
+        <section class="command command-scrollToLeft">
           <h3>scrollToLeft <span class="keys"></span></h3>
           <p class="description">Scroll all the way to the left</p>
         </section>
-        <section class="command-scrollToRight">
+        <section class="command command-scrollToRight">
           <h3>scrollToRight <span class="keys"></span></h3>
           <p class="description">Scroll all the way to the right</p>
         </section>
-        <section class="command-reload">
+        <section class="command command-reload">
           <h3>reload <span class="keys"></span></h3>
           <p class="description">Reload the page</p>
         </section>
-        <section class="command-copyCurrentUrl">
+        <section class="command command-copyCurrentUrl">
           <h3>copyCurrentUrl <span class="keys"></span></h3>
           <p class="description">Copy the current URL to the clipboard</p>
         </section>
-        <section class="command-openCopiedUrlInCurrentTab">
+        <section class="command command-openCopiedUrlInCurrentTab">
           <h3>openCopiedUrlInCurrentTab <span class="keys"></span></h3>
           <p class="description">Open the clipboard's URL in the current tab</p>
         </section>
-        <section class="command-openCopiedUrlInNewTab">
+        <section class="command command-openCopiedUrlInNewTab">
           <h3>openCopiedUrlInNewTab <span class="keys"></span></h3>
           <p class="description">Open the clipboard's URL in a new tab</p>
         </section>
-        <section class="command-goUp">
+        <section class="command command-goUp">
           <h3>goUp <span class="keys"></span></h3>
           <p class="description">Go up the URL hierarchy</p>
         </section>
-        <section class="command-goToRoot">
+        <section class="command command-goToRoot">
           <h3>goToRoot <span class="keys"></span></h3>
           <p class="description">Go to root of current URL hierarchy</p>
         </section>
-        <section class="command-enterInsertMode">
+        <section class="command command-enterInsertMode">
           <h3>enterInsertMode <span class="keys"></span></h3>
           <p class="description">Enter insert mode</p>
         </section>
-        <section class="command-enterVisualMode">
+        <section class="command command-enterVisualMode">
           <h3>enterVisualMode <span class="keys"></span></h3>
           <p class="description">Enter visual mode</p>
         </section>
-        <section class="command-enterVisualLineMode">
+        <section class="command command-enterVisualLineMode">
           <h3>enterVisualLineMode <span class="keys"></span></h3>
           <p class="description">Enter visual line mode</p>
         </section>
-        <section class="command-passNextKey">
+        <section class="command command-passNextKey">
           <h3>passNextKey <span class="keys"></span></h3>
           <p class="description">Pass the next key to the page</p>
         </section>
-        <section class="command-focusInput">
+        <section class="command command-focusInput">
           <h3>focusInput <span class="keys"></span></h3>
           <p class="description">Focus the first text input on the page</p>
         </section>
-        <section class="command-LinkHints.activateMode">
+        <section class="command command-LinkHints.activateMode">
           <h3>LinkHints.activateMode <span class="keys"></span></h3>
           <p class="description">Open a link in the current tab</p>
         </section>
-        <section class="command-LinkHints.activateModeToOpenInNewTab">
+        <section class="command command-LinkHints.activateModeToOpenInNewTab">
           <h3>LinkHints.activateModeToOpenInNewTab <span class="keys"></span></h3>
           <p class="description">Open a link in a new tab</p>
         </section>
-        <section class="command-LinkHints.activateModeToOpenInNewForegroundTab">
+        <section class="command command-LinkHints.activateModeToOpenInNewForegroundTab">
           <h3>LinkHints.activateModeToOpenInNewForegroundTab <span class="keys"></span></h3>
           <p class="description">Open a link in a new tab &amp; switch to it</p>
         </section>
-        <section class="command-LinkHints.activateModeWithQueue">
+        <section class="command command-LinkHints.activateModeWithQueue">
           <h3>LinkHints.activateModeWithQueue <span class="keys"></span></h3>
           <p class="description">Open multiple links in a new tab</p>
         </section>
-        <section class="command-LinkHints.activateModeToDownloadLink">
+        <section class="command command-LinkHints.activateModeToDownloadLink">
           <h3>LinkHints.activateModeToDownloadLink <span class="keys"></span></h3>
           <p class="description">Download link url</p>
         </section>
-        <section class="command-LinkHints.activateModeToOpenIncognito">
+        <section class="command command-LinkHints.activateModeToOpenIncognito">
           <h3>LinkHints.activateModeToOpenIncognito <span class="keys"></span></h3>
           <p class="description">Open a link in incognito window</p>
         </section>
-        <section class="command-LinkHints.activateModeToCopyLinkUrl">
+        <section class="command command-LinkHints.activateModeToCopyLinkUrl">
           <h3>LinkHints.activateModeToCopyLinkUrl <span class="keys"></span></h3>
           <p class="description">Copy a link URL to the clipboard</p>
         </section>
-        <section class="command-goPrevious">
+        <section class="command command-goPrevious">
           <h3>goPrevious <span class="keys"></span></h3>
           <p class="description">Follow the link labeled previous or &lt;</p>
         </section>
-        <section class="command-goNext">
+        <section class="command command-goNext">
           <h3>goNext <span class="keys"></span></h3>
           <p class="description">Follow the link labeled next or &gt;</p>
         </section>
-        <section class="command-nextFrame">
+        <section class="command command-nextFrame">
           <h3>nextFrame <span class="keys"></span></h3>
           <p class="description">Select the next frame on the page</p>
         </section>
-        <section class="command-mainFrame">
+        <section class="command command-mainFrame">
           <h3>mainFrame <span class="keys"></span></h3>
           <p class="description">Select the page's main/top frame</p>
         </section>
-        <section class="command-Marks.activateCreateMode">
+        <section class="command command-Marks.activateCreateMode">
           <h3>Marks.activateCreateMode <span class="keys"></span></h3>
           <p class="description">Create a new mark</p>
         </section>
-        <section class="command-Marks.activateGotoMode">
+        <section class="command command-Marks.activateGotoMode">
           <h3>Marks.activateGotoMode <span class="keys"></span></h3>
           <p class="description">Go to a mark</p>
         </section>
       </section>
-      <section class="group-tabManipulation">
+      <section class="group group-tabManipulation">
         <h2>tabManipulation</h2>
-        <section class="command-createTab">
+        <section class="command command-createTab">
           <h3>createTab <span class="keys"></span></h3>
           <p class="description">Create new tab</p>
         </section>
-        <section class="command-previousTab">
+        <section class="command command-previousTab">
           <h3>previousTab <span class="keys"></span></h3>
           <p class="description">Go one tab left</p>
         </section>
-        <section class="command-nextTab">
+        <section class="command command-nextTab">
           <h3>nextTab <span class="keys"></span></h3>
           <p class="description">Go one tab right</p>
         </section>
-        <section class="command-visitPreviousTab">
+        <section class="command command-visitPreviousTab">
           <h3>visitPreviousTab <span class="keys"></span></h3>
           <p class="description">Go to previously-visited tab</p>
         </section>
-        <section class="command-firstTab">
+        <section class="command command-firstTab">
           <h3>firstTab <span class="keys"></span></h3>
           <p class="description">Go to the first tab</p>
         </section>
-        <section class="command-lastTab">
+        <section class="command command-lastTab">
           <h3>lastTab <span class="keys"></span></h3>
           <p class="description">Go to the last tab</p>
         </section>
-        <section class="command-duplicateTab">
+        <section class="command command-duplicateTab">
           <h3>duplicateTab <span class="keys"></span></h3>
           <p class="description">Duplicate current tab</p>
         </section>
-        <section class="command-togglePinTab">
+        <section class="command command-togglePinTab">
           <h3>togglePinTab <span class="keys"></span></h3>
           <p class="description">Pin or unpin current tab</p>
         </section>
-        <section class="command-toggleMuteTab">
+        <section class="command command-toggleMuteTab">
           <h3>toggleMuteTab <span class="keys"></span></h3>
           <p class="description">Mute or unmute current tab</p>
         </section>
-        <section class="command-removeTab">
+        <section class="command command-removeTab">
           <h3>removeTab <span class="keys"></span></h3>
           <p class="description">Close current tab</p>
         </section>
-        <section class="command-restoreTab">
+        <section class="command command-restoreTab">
           <h3>restoreTab <span class="keys"></span></h3>
           <p class="description">Restore closed tab</p>
         </section>
-        <section class="command-moveTabToNewWindow">
+        <section class="command command-moveTabToNewWindow">
           <h3>moveTabToNewWindow <span class="keys"></span></h3>
           <p class="description">Move tab to new window</p>
         </section>
-        <section class="command-closeTabsOnLeft">
+        <section class="command command-closeTabsOnLeft">
           <h3>closeTabsOnLeft <span class="keys"></span></h3>
           <p class="description">Close tabs on the left</p>
         </section>
-        <section class="command-closeTabsOnRight">
+        <section class="command command-closeTabsOnRight">
           <h3>closeTabsOnRight <span class="keys"></span></h3>
           <p class="description">Close tabs on the right</p>
         </section>
-        <section class="command-closeOtherTabs">
+        <section class="command command-closeOtherTabs">
           <h3>closeOtherTabs <span class="keys"></span></h3>
           <p class="description">Close all other tabs</p>
         </section>
-        <section class="command-moveTabLeft">
+        <section class="command command-moveTabLeft">
           <h3>moveTabLeft <span class="keys"></span></h3>
           <p class="description">Move tab to the left</p>
         </section>
-        <section class="command-moveTabRight">
+        <section class="command command-moveTabRight">
           <h3>moveTabRight <span class="keys"></span></h3>
           <p class="description">Move tab to the right</p>
         </section>
       </section>
-      <section class="group-vomnibarCommands">
+      <section class="group group-vomnibarCommands">
         <h2>vomnibarCommands</h2>
-        <section class="command-Vomnibar.activate">
+        <section class="command command-Vomnibar.activate">
           <h3>Vomnibar.activate <span class="keys"></span></h3>
           <p class="description">Open URL, bookmark or history entry</p>
         </section>
-        <section class="command-Vomnibar.activateInNewTab">
+        <section class="command command-Vomnibar.activateInNewTab">
           <h3>Vomnibar.activateInNewTab <span class="keys"></span></h3>
           <p class="description">Open URL, bookmark or history entry in a new tab</p>
         </section>
-        <section class="command-Vomnibar.activateBookmarks">
+        <section class="command command-Vomnibar.activateBookmarks">
           <h3>Vomnibar.activateBookmarks <span class="keys"></span></h3>
           <p class="description">Open a bookmark</p>
         </section>
-        <section class="command-Vomnibar.activateBookmarksInNewTab">
+        <section class="command command-Vomnibar.activateBookmarksInNewTab">
           <h3>Vomnibar.activateBookmarksInNewTab <span class="keys"></span></h3>
           <p class="description">Open a bookmark in a new tab</p>
         </section>
-        <section class="command-Vomnibar.activateTabSelection">
+        <section class="command command-Vomnibar.activateTabSelection">
           <h3>Vomnibar.activateTabSelection <span class="keys"></span></h3>
           <p class="description">Search through your open tabs</p>
         </section>
-        <section class="command-Vomnibar.activateEditUrl">
+        <section class="command command-Vomnibar.activateEditUrl">
           <h3>Vomnibar.activateEditUrl <span class="keys"></span></h3>
           <p class="description">Edit the current URL</p>
         </section>
-        <section class="command-Vomnibar.activateEditUrlInNewTab">
+        <section class="command command-Vomnibar.activateEditUrlInNewTab">
           <h3>Vomnibar.activateEditUrlInNewTab <span class="keys"></span></h3>
           <p class="description">Edit the current URL and open in a new tab</p>
         </section>


### PR DESCRIPTION
This adds a command listing, complete with the current mappings, as its own dedicated page. This is the absolute minimum start on my idea from #1280, as [requested a few years ago](https://github.com/philc/vimium/issues/1269#issuecomment-68362665). All the other Vimium-like extensions I've tested have some sort of page like this.

In its current state, this is essentially a duplicate of the help dialog, but as a large, unstyled table. If we run with this, we should:
1. style it. (I will need help with this.)
1. add more fleshed-out descriptions to the commands
1. document the options for each command in the descriptions
1. have collapsible descriptions (so that the options don't show by default and overwhelm the command list)
1. document the quirks/issues for each command in the descriptions
1. make the help dialog show only the subset of commands that it does by default, and point to this page for the rest
1. close or re-evaluate #1269
1. make the list searchable

**WARNING:** This is really unattractive and underwhelming. This PR is just to get *something* put together. Currently looks like this:

![screenshot from 2017-11-21 13-48-57](https://user-images.githubusercontent.com/1847343/33075851-c78f3422-cec2-11e7-8f25-f5702cb05193.png)


@smblott-github is this a direction we could move in?