### PR TITLE
Add window and incognito options for createTab.

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -188,13 +188,20 @@ BackgroundCommands =
             [if request.tab.incognito then "chrome://newtab" else chrome.runtime.getURL newTabUrl]
           else
             [newTabUrl]
-    urls = request.urls[..].reverse()
-    do openNextUrl = (request) ->
-      if 0 < urls.length
-        TabOperations.openUrlInNewTab (extend request, {url: urls.pop()}), (tab) ->
-          openNextUrl extend request, {tab, tabId: tab.id}
-      else
-        callback request
+    if request.registryEntry.options.incognito or request.registryEntry.options.window
+      windowConfig =
+        url: request.urls
+        focused: true
+        incognito: request.registryEntry.options.incognito ? false
+      chrome.windows.create windowConfig, -> callback request
+    else
+      urls = request.urls[..].reverse()
+      do openNextUrl = (request) ->
+        if 0 < urls.length
+          TabOperations.openUrlInNewTab (extend request, {url: urls.pop()}), (tab) ->
+            openNextUrl extend request, {tab, tabId: tab.id}
+        else
+          callback request
   duplicateTab: mkRepeatCommand (request, callback) ->
     chrome.tabs.duplicate request.tabId, (tab) -> callback extend request, {tab, tabId: tab.id}
   moveTabToNewWindow: ({count, tab}) ->


### PR DESCRIPTION
Add `window` and `incognito` command options for `createTab`.  `createTab` already accepts URLs as command options.

Examples:

    # Just create new windows.
    map X createTab window
    map X createTab incognito

    # Create windows with URLs.
    map X createTab window https://developer.chrome.com/home https://github.com/philc/vimium
    map X createTab incognito URL1 URL2 URL3

`2X` creates two new windows, each with all of the indicated URLs.

`incognito` takes precedence over `window` (if both are present).

Fixes #2825.