### PR TITLE
Add shift to list of modifier keys in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Keyboard Bindings
 -----------------
 
 Modifier keys are specified as `<c-x>`, `<m-x>`, and `<a-x>` for ctrl+x, meta+x, and alt+x
-respectively. See the next section for how to customize these bindings.
+respectively. For shift+x and ctrl-shift-x, just type `X` and `<c-X>`. See the next section for how to customize these bindings.
 
 Once you have Vimium installed, you can see this list of key bindings at any time by typing `?`.
 


### PR DESCRIPTION
This is the most logical place to look for the information; I know it also says it further down the README but that's less clearly signposted.