### PR TITLE
No clipboardWrite permission for Chrome Store version.

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -75,6 +75,7 @@ task "package", "Builds a zip file for submission to the Chrome store. The outpu
     blacklist.map((item) -> ["--exclude", "#{item}"]))
 
   spawn "rsync", rsyncOptions, false, true
+  spawn "sed", "-i /clipboardWrite/d dist/vimium/manifest.json".split /\s+/
   spawn "zip", ["-r", "dist/vimium-#{vimium_version}.zip", "dist/vimium"], false, true
 
   spawn "zip", "-r -FS dist/vimium-ff-#{vimium_version}.zip background_scripts Cakefile content_scripts CONTRIBUTING.md CREDITS icons lib


### PR DESCRIPTION
Following on from #2601, it would be better if we do not unnecessarily require *all* Chrome Store users to reactivate Vimium, when that really isn't required.

@mrmr1993 reported elsewhere that requesting permissions dynamically was unlikely to work.

So, here, we just hack the manifest for the Chrome Store version.