### PR TITLE
Detect click listeners for link hints.

### DIFF
--- a/content_scripts/injected.coffee
+++ b/content_scripts/injected.coffee
@@ -1,0 +1,20 @@
+# The code in `injectedCode()`, below, is injected into the page's own execution context.
+#
+# This is based on method 2b here: http://stackoverflow.com/a/9517879, and
+# @mrmr1993's #1167.
+
+window.vimiumOnClickAttributeName = "_vimium-has-onclick-listener"
+
+injectedCode = (vimiumOnClickAttributeName) ->
+  # Note the presence of "click" listeners installed with `addEventListener()` (for link hints).
+  _addEventListener = Element::addEventListener
+
+  Element::addEventListener = (type, listener, useCapture) ->
+    @setAttribute vimiumOnClickAttributeName, "" if type == "click"
+    _addEventListener.apply this, arguments
+
+script = document.createElement "script"
+script.textContent = "(#{injectedCode.toString()})('#{vimiumOnClickAttributeName}')"
+(document.head || document.documentElement).appendChild script
+script.remove()
+

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -706,6 +706,9 @@ LocalHints =
         isClickable = true
         reason = "Open."
 
+    # Detect elements with "click" listeners installed with `addEventListener()`.
+    isClickable ||= element.hasAttribute vimiumOnClickAttributeName
+
     # An element with a class name containing the text "button" might be clickable.  However, real clickables
     # are often wrapped in elements with such class names.  So, when we find clickables based only on their
     # class name, we mark them as unreliable.

--- a/manifest.json
+++ b/manifest.json
@@ -70,6 +70,12 @@
       "match_about_blank": true
     },
     {
+      "matches": ["<all_urls>"],
+      "js": ["content_scripts/injected.js"],
+      "run_at": "document_start",
+      "all_frames": true
+    },
+    {
       "matches": ["file:///", "file:///*/"],
       "css": ["content_scripts/file_urls.css"],
       "run_at": "document_start",

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -51,6 +51,7 @@ activateLinkHintsMode = ->
 # link hinting modes.
 #
 createGeneralHintTests = (isFilteredMode) ->
+  window.vimiumOnClickAttributeName = "does-not-matter"
 
   context "Link hints",
 


### PR DESCRIPTION
This is a simpler version of #1167.  It detects clickable elements with listeners added with `addEventListener()`.

It includes some of @mrmr1993's ideas from #1167 (in fact, it's mostly those ideas tweaked into a slightly different form).