### PR TITLE
Treat all mapping commands as lower case.

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -20,7 +20,7 @@ Commands =
     unmapAll = false
     for line in configLines.reverse()
       tokens = line.split /\s+/
-      switch tokens[0]
+      switch tokens[0].toLowerCase()
         when "map"
           if 3 <= tokens.length and not unmapAll
             [_, key, command, optionList...] = tokens
@@ -32,7 +32,7 @@ Commands =
         when "unmap"
           if tokens.length == 2
             seen[tokens[1]] = true
-        when "unmapAll"
+        when "unmapall"
           unmapAll = true
         when "mapkey"
           if tokens.length == 3


### PR DESCRIPTION
On the options page, treat all user-defined mapping commands as lower case.

Why?

- `unmapAll` is not very vim-ish, and is inconsistent with `mapkey`.
- If we were to introduce `vmap` for visual mode, then we would get `vUnmapAll`, which is hideous capitalisation.

Possible down side?

- I guess somebody might have disabled a `map` by capitalising it, or disabled `unmapAll` by using strange capitalisation.