### PR TITLE
Do not open tab for target "_blank".

### DIFF
--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -250,7 +250,7 @@ DomUtils =
     eventSequence = ["mouseover", "mousedown", "mouseup", "click"]
     for event in eventSequence
       defaultActionShouldTrigger = @simulateMouseEvent event, element, modifiers
-      if event == "click" and defaultActionShouldTrigger and Utils.isFirefox()
+      if event == "click" and defaultActionShouldTrigger and Utils.isFirefox() and element.target != "_blank"
         # Firefox doesn't (currently) trigger the default action for modified keys.
         DomUtils.simulateClickDefaultAction element, modifiers
       defaultActionShouldTrigger # return the values returned by each @simulateMouseEvent call.


### PR DESCRIPTION
Fixes #2860.  That issue reports that, when the target is "_blank", Firefox/Vimium ends up opening two tabs.

(I'm not a FF user, myself, so not sure what other side effects this might have.)