### PR TITLE
allow mapkey to 'enter' (v. isEnterMap, <c-]> by default)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist
 jscoverage.json
 tags
 .cake_task_cache
+pack.ps1
+.nvimrc

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,3 @@ dist
 jscoverage.json
 tags
 .cake_task_cache
-pack.ps1
-.nvimrc

--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -116,6 +116,8 @@ Commands =
     # Inform `KeyboardUtils.isEscape()` whether `<c-[>` should be interpreted as `Escape` (which it is by
     # default).
     chrome.storage.local.set useVimLikeEscape: "<c-[>" not of keyStateMapping
+    # Same for `KeyboardUtils.isEnter()` of `<c-]>`.
+    chrome.storage.local.set useVimAdjacentEnter: "<c-]>" not of keyStateMapping
 
   # Build the "helpPageData" data structure which the help page needs and place it in Chrome storage.
   prepareHelpPageData: ->

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -261,7 +261,7 @@ class LinkHintsMode
         # knows not to restart hints mode.
         @hintMode.exit event
 
-    else if event.key == "Enter"
+    else if event.key == "Enter" || KeyboardUtils.isEnterMap event
       # Activate the active hint, if there is one.  Only FilterHints uses an active hint.
       HintCoordinator.sendMessage "activateActiveHintMarker" if @markerMatcher.activeHintMarker
 
@@ -878,7 +878,7 @@ class WaitForEnter extends Mode
 
     @push
       keydown: (event) =>
-        if event.key == "Enter"
+        if event.key == "Enter" || KeyboardUtils.isEnterMap event
           @exit()
           callback true # true -> isSuccess.
         else if KeyboardUtils.isEscape event

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -261,7 +261,7 @@ class LinkHintsMode
         # knows not to restart hints mode.
         @hintMode.exit event
 
-    else if event.key == "Enter" || KeyboardUtils.isEnterMap event
+    else if KeyboardUtils.isEnter event
       # Activate the active hint, if there is one.  Only FilterHints uses an active hint.
       HintCoordinator.sendMessage "activateActiveHintMarker" if @markerMatcher.activeHintMarker
 
@@ -878,7 +878,7 @@ class WaitForEnter extends Mode
 
     @push
       keydown: (event) =>
-        if event.key == "Enter" || KeyboardUtils.isEnterMap event
+        if KeyboardUtils.isEnter event
           @exit()
           callback true # true -> isSuccess.
         else if KeyboardUtils.isEscape event

--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -23,7 +23,7 @@ class InsertMode extends Mode
         activeElement.blur() if DomUtils.isFocusable activeElement
         @exit() unless @permanent
 
-      else if event.type == 'keydown' and KeyboardUtils.isEnterMap(event)
+      else if event.type == 'keydown' and (KeyboardUtils.isEnter(event) and event.key != "Enter")
         if DomUtils.isFocusable activeElement
             activeElement.form.submit() if activeElement.form?
             activeElement.blur()

--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -23,6 +23,12 @@ class InsertMode extends Mode
         activeElement.blur() if DomUtils.isFocusable activeElement
         @exit() unless @permanent
 
+      else if event.type == 'keydown' and KeyboardUtils.isEnterMap(event)
+        if DomUtils.isFocusable activeElement
+            activeElement.form.submit() if activeElement.form?
+            activeElement.blur()
+        @exit() unless @permanent
+
       else
         return @passEventToPage
 

--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -43,7 +43,6 @@ class KeyHandlerMode extends Mode
   onKeydown: (event) ->
     keyChar = KeyboardUtils.getKeyCharString event
     isEscape = KeyboardUtils.isEscape event
-    isEnterMap = KeyboardUtils.isEnterMap event
     if isEscape and (@countPrefix != 0 or @keyState.length != 1)
       DomUtils.consumeKeyup event, => @reset()
     # If the help dialog loses the focus, then Escape should hide it; see point 2 in #2045.
@@ -52,7 +51,7 @@ class KeyHandlerMode extends Mode
       @suppressEvent
     else if isEscape
       @continueBubbling
-    else if isEnterMap
+    else if KeyboardUtils.isEnter(event) and event != "Enter"
       # XXX NormalMode.simulateClick on a clickable element here?
       @continueBubbling
     else if @isMappedKey keyChar

--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -52,8 +52,9 @@ class KeyHandlerMode extends Mode
     else if isEscape
       @continueBubbling
     else if KeyboardUtils.isEnter(event) and event != "Enter"
-      # XXX NormalMode.simulateClick on a clickable element here?
-      @continueBubbling
+      element = DomUtils.getSelectionFocusElement()
+      DomUtils.simulateClick(element) if element?
+      @supressEvent
     else if @isMappedKey keyChar
       @handleKeyChar keyChar
       @suppressEvent

--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -51,10 +51,6 @@ class KeyHandlerMode extends Mode
       @suppressEvent
     else if isEscape
       @continueBubbling
-    else if KeyboardUtils.isEnter(event) and event.key != "Enter"
-      element = DomUtils.getSelectionFocusElement()
-      DomUtils.simulateClick(element) if element?
-      @supressEvent
     else if @isMappedKey keyChar
       @handleKeyChar keyChar
       @suppressEvent
@@ -62,6 +58,10 @@ class KeyHandlerMode extends Mode
       digit = parseInt keyChar
       @reset if @keyState.length == 1 then @countPrefix * 10 + digit else digit
       @suppressEvent
+    else if KeyboardUtils.isEnter(event) and event.key != "Enter"
+      element = DomUtils.getSelectionFocusElement()
+      DomUtils.simulateClick(element) if element?
+      @supressEvent
     else
       @reset() if keyChar
       @continueBubbling

--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -51,7 +51,7 @@ class KeyHandlerMode extends Mode
       @suppressEvent
     else if isEscape
       @continueBubbling
-    else if KeyboardUtils.isEnter(event) and event != "Enter"
+    else if KeyboardUtils.isEnter(event) and event.key != "Enter"
       element = DomUtils.getSelectionFocusElement()
       DomUtils.simulateClick(element) if element?
       @supressEvent

--- a/content_scripts/mode_key_handler.coffee
+++ b/content_scripts/mode_key_handler.coffee
@@ -43,6 +43,7 @@ class KeyHandlerMode extends Mode
   onKeydown: (event) ->
     keyChar = KeyboardUtils.getKeyCharString event
     isEscape = KeyboardUtils.isEscape event
+    isEnterMap = KeyboardUtils.isEnterMap event
     if isEscape and (@countPrefix != 0 or @keyState.length != 1)
       DomUtils.consumeKeyup event, => @reset()
     # If the help dialog loses the focus, then Escape should hide it; see point 2 in #2045.
@@ -50,6 +51,9 @@ class KeyHandlerMode extends Mode
       HelpDialog.toggle()
       @suppressEvent
     else if isEscape
+      @continueBubbling
+    else if isEnterMap
+      # XXX NormalMode.simulateClick on a clickable element here?
       @continueBubbling
     else if @isMappedKey keyChar
       @handleKeyChar keyChar

--- a/content_scripts/mode_visual.coffee
+++ b/content_scripts/mode_visual.coffee
@@ -229,6 +229,7 @@ class VisualMode extends KeyHandlerMode
       "W": keyMapping.w
       "<c-e>": command: (count) -> Scroller.scrollBy "y", count * Settings.get("scrollStepSize"), 1, false
       "<c-y>": command: (count) -> Scroller.scrollBy "y", -count * Settings.get("scrollStepSize"), 1, false
+      "<c-]>": command: () => @yank()
 
     super extend options,
       name: options.name ? "visual"

--- a/content_scripts/mode_visual.coffee
+++ b/content_scripts/mode_visual.coffee
@@ -258,7 +258,7 @@ class VisualMode extends KeyHandlerMode
       _name: "#{@id}/enter/click"
       # Yank on <Enter>.
       keypress: (event) =>
-        if event.key == "Enter" || KeyboardUtils.isEnterMap event
+        if event.key == "Enter"
           unless event.metaKey or event.ctrlKey or event.altKey or event.shiftKey
             @yank()
             return @suppressEvent

--- a/content_scripts/mode_visual.coffee
+++ b/content_scripts/mode_visual.coffee
@@ -258,7 +258,7 @@ class VisualMode extends KeyHandlerMode
       _name: "#{@id}/enter/click"
       # Yank on <Enter>.
       keypress: (event) =>
-        if event.key == "Enter"
+        if event.key == "Enter" || KeyboardUtils.isEnterMap event
           unless event.metaKey or event.ctrlKey or event.altKey or event.shiftKey
             @yank()
             return @suppressEvent

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -220,8 +220,8 @@ DomUtils =
       node and @isDOMDescendant element, node
     else
       if DomUtils.getSelectionType(selection) == "Range" and selection.isCollapsed
-	      # The selection is inside the Shadow DOM of a node. We can check the node it registers as being
-	      # before, since this represents the node whose Shadow DOM it's inside.
+        # The selection is inside the Shadow DOM of a node. We can check the node it registers as being
+        # before, since this represents the node whose Shadow DOM it's inside.
         containerNode = selection.anchorNode.childNodes[selection.anchorOffset]
         element == containerNode # True if the selection is inside the Shadow DOM of our element.
       else

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -68,8 +68,13 @@ KeyboardUtils =
       # <c-[> is mapped to Escape in Vim by default.
       event.key == "Escape" or (useVimLikeEscape and @getKeyCharString(event) == "<c-[>")
 
-  isEnter: (event) ->
-    event.key == "Enter" or @getKeyCharString(event) == "<c-]>"
+  isEnter: do ->
+    useVimAdjacentEnter = true
+    Utils.monitorChromeStorage "useVimAdjacentEnter", (value) -> useVimAdjacentEnter = value
+
+    (event) ->
+      # We treat <c-]> as a simulacrum for enter.
+      event.key == "Enter" or (useVimAdjacentEnter and @getKeyCharString(event) == "<c-]>")
 
   isBackspace: (event) ->
     event.key in ["Backspace", "Delete"]

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -68,6 +68,9 @@ KeyboardUtils =
       # <c-[> is mapped to Escape in Vim by default.
       event.key == "Escape" or (useVimLikeEscape and @getKeyCharString(event) == "<c-[>")
 
+  isEnterMap: (event) ->
+    @getKeyCharString(event) == "<c-]>"
+
   isBackspace: (event) ->
     event.key in ["Backspace", "Delete"]
 

--- a/lib/keyboard_utils.coffee
+++ b/lib/keyboard_utils.coffee
@@ -68,8 +68,8 @@ KeyboardUtils =
       # <c-[> is mapped to Escape in Vim by default.
       event.key == "Escape" or (useVimLikeEscape and @getKeyCharString(event) == "<c-[>")
 
-  isEnterMap: (event) ->
-    @getKeyCharString(event) == "<c-]>"
+  isEnter: (event) ->
+    event.key == "Enter" or @getKeyCharString(event) == "<c-]>"
 
   isBackspace: (event) ->
     event.key in ["Backspace", "Delete"]

--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -20,12 +20,11 @@ document.addEventListener "keydown", (event) ->
   return unless inputElement? # Don't do anything if we're not in find mode.
 
   if (KeyboardUtils.isBackspace(event) and inputElement.textContent.length == 0) or
-     event.key == "Enter" or KeyboardUtils.isEnterMap(event) or
-     KeyboardUtils.isEscape event
+     KeyboardUtils.isEnter(event) or KeyboardUtils.isEscape event
 
     UIComponentServer.postMessage
       name: "hideFindMode"
-      exitEventIsEnter: event.key == "Enter" or KeyboardUtils.isEnterMap event
+      exitEventIsEnter: KeyboardUtils.isEnter event
       exitEventIsEscape: KeyboardUtils.isEscape event
 
   else if event.key == "ArrowUp"

--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -20,11 +20,12 @@ document.addEventListener "keydown", (event) ->
   return unless inputElement? # Don't do anything if we're not in find mode.
 
   if (KeyboardUtils.isBackspace(event) and inputElement.textContent.length == 0) or
-     event.key == "Enter" or KeyboardUtils.isEscape event
+     event.key == "Enter" or KeyboardUtils.isEnterMap event or
+     KeyboardUtils.isEscape event
 
     UIComponentServer.postMessage
       name: "hideFindMode"
-      exitEventIsEnter: event.key == "Enter"
+      exitEventIsEnter: event.key == "Enter" or KeyboardUtils.isEnterMap event
       exitEventIsEscape: KeyboardUtils.isEscape event
 
   else if event.key == "ArrowUp"

--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -20,7 +20,7 @@ document.addEventListener "keydown", (event) ->
   return unless inputElement? # Don't do anything if we're not in find mode.
 
   if (KeyboardUtils.isBackspace(event) and inputElement.textContent.length == 0) or
-     event.key == "Enter" or KeyboardUtils.isEnterMap event or
+     event.key == "Enter" or KeyboardUtils.isEnterMap(event) or
      KeyboardUtils.isEscape event
 
     UIComponentServer.postMessage

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -105,6 +105,8 @@ class VomnibarUI
     key = KeyboardUtils.getKeyChar(event)
     if (KeyboardUtils.isEscape(event))
       return "dismiss"
+    else if (KeyboardUtils.isEnterMap(event))
+      return "enter"
     else if (key == "up" ||
         (event.shiftKey && event.key == "Tab") ||
         (event.ctrlKey && (key == "k" || key == "p")))

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -105,8 +105,6 @@ class VomnibarUI
     key = KeyboardUtils.getKeyChar(event)
     if (KeyboardUtils.isEscape(event))
       return "dismiss"
-    else if (KeyboardUtils.isEnterMap(event))
-      return "enter"
     else if (key == "up" ||
         (event.shiftKey && event.key == "Tab") ||
         (event.ctrlKey && (key == "k" || key == "p")))
@@ -116,7 +114,7 @@ class VomnibarUI
     else if (key == "down" ||
         (event.ctrlKey && (key == "j" || key == "n")))
       return "down"
-    else if (event.key == "Enter")
+    else if (event.key == "Enter" || KeyboardUtils.isEnterMap(event))
       return "enter"
     else if KeyboardUtils.isBackspace event
       return "delete"

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -114,7 +114,7 @@ class VomnibarUI
     else if (key == "down" ||
         (event.ctrlKey && (key == "j" || key == "n")))
       return "down"
-    else if (event.key == "Enter" || KeyboardUtils.isEnterMap(event))
+    else if KeyboardUtils.isEnter event
       return "enter"
     else if KeyboardUtils.isBackspace event
       return "delete"

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -125,7 +125,6 @@ class VomnibarUI
     @lastAction = action = @actionFromKeyEvent event
     return true unless action # pass through
 
-    openInNewTab = @forceNewTab || event.shiftKey || event.ctrlKey || event.altKey || event.metaKey
     if (action == "dismiss")
       @hide()
     else if action in [ "tab", "down" ]
@@ -144,6 +143,8 @@ class VomnibarUI
       @selection = @completions.length - 1 if @selection < @initialSelectionValue
       @updateSelection()
     else if (action == "enter")
+      openInNewTab = @forceNewTab || (KeyboardUtils.getKeyCharString(event) != "<c-]>" &&
+        (event.shiftKey || event.ctrlKey || event.altKey || event.metaKey))
       isCustomSearchPrimarySuggestion = @completions[@selection]?.isPrimarySuggestion and @lastReponse.engine?.searchUrl?
       if @selection == -1 or isCustomSearchPrimarySuggestion
         query = @input.value.trim()


### PR DESCRIPTION
Hi!

This allows something such as `mapkey <a-q> <c-]>` to accept input in the vomnibar, or to submit a page's form in insert mode.

**Motive:**

In pentadactyl, for whatever reason, I liked being able to press `qq` to accept input and `jj` to blur focus. In https://github.com/philc/vimium/pull/2306 you made it possible to map something like `alt-j` to blur, which is easier to get used to than pressing escape. For some reason. However, unless I'm mistaken, it's still not possible to map some chord to accept input (`keymap <a-q> <enter>` does nothing).

My maps largely make use of the top left of the keyboard (qwerasdf) for common functions, and without the ability to double-tap q (or similar - `alt-q` in this case) I find myself sometimes reaching over the entire keyboard with my left hand to press enter. I can often get what I want with a few characters and a tap of tab. Let's say, Reddit - `re<Tab>qq`. I made a (personal) fork to implement `qq` in the vomnibar, but on discovering #2306 I thought I'd try to implement it in a more Vimium-y way. So here you go.

I expect you might have issue with:
- My choice of default bind (`C-]`). I just liked that it was adjacent to escape (`C-[`). There's no more thought to it than that; it exists to allow me to remap it with mapkey (and it's out of the way).
- The way I handle it when focus is on a page's input. Obviously a page can handle `Enter` in a variety of ways and this is potentially problematic. As long as users know it's basically a shortcut for "submit" and not actually "enter", I think this works.
- You might want to add a `useVimLikeEscape` analogue for this?
- I might be the only person who does this.