### PR TITLE
on vomnibar hiding, blur input first

### DIFF
--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -57,6 +57,7 @@ class VomnibarUI
   # This ensures that the vomnibar is actually hidden before any new tab is created, and avoids flicker after
   # opening a link in a new tab then returning to the original tab (see #1485).
   hide: (@onHiddenCallback = null) ->
+    @input.blur()
     UIComponentServer.postMessage "hide"
     @reset()
 


### PR DESCRIPTION
This simple PR should fix the IME status issue in #2924, and because it does nothing harmful, I think we can merge it immediately even though it has only been tested by my Chrome (ver 5x and 64) on Windows 10.