### PR TITLE
Enable to convert CJK characters on MacOS(Issue#2915)

### DIFF
--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -15,16 +15,30 @@ setTextInInputElement = (inputElement, text) ->
 document.addEventListener "DOMContentLoaded", ->
   DomUtils.injectUserCss() # Manually inject custom user styles.
 
+document.addEventListener "keypress", (event) ->
+  inputElement = document.getElementById "hud-find-input"
+  return unless inputElement?
+
+  if event.key == "Enter"
+    UIComponentServer.postMessage
+      name: "hideFindMode"
+      exitEventIsEnter: event.key == "Enter"
+      exitEventIsEscape: false
+  else
+    return
+
+  DomUtils.suppressEvent event
+  false
+
 document.addEventListener "keydown", (event) ->
   inputElement = document.getElementById "hud-find-input"
   return unless inputElement? # Don't do anything if we're not in find mode.
 
-  if (KeyboardUtils.isBackspace(event) and inputElement.textContent.length == 0) or
-     event.key == "Enter" or KeyboardUtils.isEscape event
+  if (KeyboardUtils.isBackspace(event) and inputElement.textContent.length == 0) or KeyboardUtils.isEscape event
 
     UIComponentServer.postMessage
       name: "hideFindMode"
-      exitEventIsEnter: event.key == "Enter"
+      exitEventIsEnter: false
       exitEventIsEscape: KeyboardUtils.isEscape event
 
   else if event.key == "ArrowUp"

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -117,7 +117,7 @@ class VomnibarUI
       return "down"
     else if (event.type == "keypress")
       if (event.key == "Enter")
-        return "enterPress"
+        return "enter"
     else if KeyboardUtils.isBackspace event
       return "delete"
 
@@ -128,7 +128,7 @@ class VomnibarUI
     return true unless action # pass through
 
     openInNewTab = @forceNewTab || event.shiftKey || event.ctrlKey || event.altKey || event.metaKey
-    if (action == "enterPress")
+    if (action == "enter")
       isCustomSearchPrimarySuggestion = @completions[@selection]?.isPrimarySuggestion and @lastReponse.engine?.searchUrl?
       if @selection == -1 or isCustomSearchPrimarySuggestion
         query = @input.value.trim()

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -115,36 +115,23 @@ class VomnibarUI
     else if (key == "down" ||
         (event.ctrlKey && (key == "j" || key == "n")))
       return "down"
-    else if (event.key == "Enter")
-      return "enter"
+    else if (event == "keydown")
+      if (event.key == "Enter")
+        return "enterDown"
+    else if (event.type == "keypress")
+      if (event.key == "Enter")
+        return "enterPress"
     else if KeyboardUtils.isBackspace event
       return "delete"
 
     null
 
-  onKeydown: (event) =>
-    @lastAction = action = @actionFromKeyEvent event
-    return true unless action # pass through
+  onKeypress: (event) =>
+    action = @actionFromKeyEvent event
+    return true unless action # pass throug
 
     openInNewTab = @forceNewTab || event.shiftKey || event.ctrlKey || event.altKey || event.metaKey
-    if (action == "dismiss")
-      @hide()
-    else if action in [ "tab", "down" ]
-      if action == "tab" and
-        @completer.name == "omni" and
-        not @seenTabToOpenCompletionList and
-        @input.value.trim().length == 0
-          @seenTabToOpenCompletionList = true
-          @update true
-      else if 0 < @completions.length
-        @selection += 1
-        @selection = @initialSelectionValue if @selection == @completions.length
-        @updateSelection()
-    else if (action == "up")
-      @selection -= 1
-      @selection = @completions.length - 1 if @selection < @initialSelectionValue
-      @updateSelection()
-    else if (action == "enter")
+    if (action == "enterPress")
       isCustomSearchPrimarySuggestion = @completions[@selection]?.isPrimarySuggestion and @lastReponse.engine?.searchUrl?
       if @selection == -1 or isCustomSearchPrimarySuggestion
         query = @input.value.trim()
@@ -169,6 +156,36 @@ class VomnibarUI
       else
         completion = @completions[@selection]
         @hide -> completion.performAction openInNewTab
+    else
+      return true # Do not suppress event.
+
+    # It seems like we have to manually suppress the event here and still return true.
+    event.stopImmediatePropagation()
+    event.preventDefault()
+    true
+
+  onKeydown: (event) =>
+    @lastAction = action = @actionFromKeyEvent event
+    return true unless action # pass through
+
+    openInNewTab = @forceNewTab || event.shiftKey || event.ctrlKey || event.altKey || event.metaKey
+    if (action == "dismiss")
+      @hide()
+    else if action in [ "tab", "down" ]
+      if action == "tab" and
+        @completer.name == "omni" and
+        not @seenTabToOpenCompletionList and
+        @input.value.trim().length == 0
+          @seenTabToOpenCompletionList = true
+          @update true
+      else if 0 < @completions.length
+        @selection += 1
+        @selection = @initialSelectionValue if @selection == @completions.length
+        @updateSelection()
+    else if (action == "up")
+      @selection -= 1
+      @selection = @completions.length - 1 if @selection < @initialSelectionValue
+      @updateSelection()
     else if action == "delete"
       if @customSearchMode? and @input.selectionEnd == 0
         # Normally, with custom search engines, the keyword (e,g, the "w" of "w query terms") is suppressed.

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -115,9 +115,6 @@ class VomnibarUI
     else if (key == "down" ||
         (event.ctrlKey && (key == "j" || key == "n")))
       return "down"
-    else if (event == "keydown")
-      if (event.key == "Enter")
-        return "enterDown"
     else if (event.type == "keypress")
       if (event.key == "Enter")
         return "enterPress"
@@ -128,7 +125,7 @@ class VomnibarUI
 
   onKeypress: (event) =>
     action = @actionFromKeyEvent event
-    return true unless action # pass throug
+    return true unless action # pass through
 
     openInNewTab = @forceNewTab || event.shiftKey || event.ctrlKey || event.altKey || event.metaKey
     if (action == "enterPress")
@@ -268,6 +265,7 @@ class VomnibarUI
     @input = @box.querySelector("input")
     @input.addEventListener "input", @onInput
     @input.addEventListener "keydown", @onKeydown
+    @input.addEventListener "keypress", @onKeypress
     @completionList = @box.querySelector("ul")
     @completionList.style.display = ""
 


### PR DESCRIPTION
on isuue #2915 , I enabled to convert CJK characters on MacOS.
I tried on Windows10, Ubuntu16.04, and MacOS(High Sierra). But I could reproduce this problem only on MacOS.

I fixed `pages/vomnibar.coffee` and `pages/hud.coffee`.

This change is based on the feature that typing `Enter` key contains three event, `keydown 13`, `keypress 13`, and `keyup 13`. 
On the other hand, converting CJK words contains `keydown <keycode>` and `keyup 13`, not containing `key press 13`.

This change makes us type successive CJK words on MacOS.

before
![before](https://user-images.githubusercontent.com/27683817/35612347-dd2a75fa-06ab-11e8-9cb8-98e3812cab0e.gif)

after
![after](https://user-images.githubusercontent.com/27683817/35612295-98f275fe-06ab-11e8-969a-5d63405812ca.gif)
