### PR TITLE
make the hooked addEventListener looks native

### DIFF
--- a/content_scripts/injected.coffee
+++ b/content_scripts/injected.coffee
@@ -5,12 +5,31 @@
 
 injectedCode = () ->
   # Note the presence of "click" listeners installed with `addEventListener()` (for link hints).
-  _addEventListener = Element::addEventListener
+  _addEventListener = EventTarget::addEventListener
+  _toString = Function::toString
+  # Note some pages may override Element (see https://github.com/gdh1995/vimium-plus/issues/11)
+  EL = if typeof Element == "function" then Element else HTMLElement
+  Anchor = HTMLAnchorElement
 
-  Element::addEventListener = (type, listener, useCapture) ->
-    if type == "click"
-      try @setAttribute "_vimium-has-onclick-listener", ""
+  addEventListener = (type, listener, useCapture) ->
+    if type == "click" and this instanceof EL
+      try
+        unless this instanceof Anchor # just skip <a>
+          @setAttribute "_vimium-has-onclick-listener", ""
     _addEventListener?.apply this, arguments
+
+  newToString = () ->
+    real = if this == newToString then _toString else
+      if this == addEventListener then _addEventListener else
+      this
+    _toString.apply real, arguments
+
+  EventTarget::addEventListener = addEventListener
+  # Libraries like Angular/Zone and CKEditor check if element.addEventListener is native,
+  # so here we hook it to tell outsides it is exactly native.
+  # This idea is from https://github.com/angular/zone.js/pull/686,
+  # and see more discussions in https://github.com/ckeditor/ckeditor5-build-classic/issues/34
+  Function::toString = newToString
 
 script = document.createElement "script"
 script.textContent = "(#{injectedCode.toString()})()"


### PR DESCRIPTION
This hooks addEventListener in a much better way to fix #2884 and #2900, and should replace #2933. The idea is from https://github.com/angular/zone.js/pull/686.