### PR TITLE
Make the reload command accept a count.

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -336,7 +336,7 @@ commandDescriptions =
   scrollFullPageDown: ["Scroll a full page down"]
   scrollFullPageUp: ["Scroll a full page up"]
 
-  reload: ["Reload the page", { noRepeat: true }]
+  reload: ["Reload the page", { background: true }]
   toggleViewSource: ["View page source", { noRepeat: true }]
 
   copyCurrentUrl: ["Copy the current URL to the clipboard", { noRepeat: true }]

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -235,6 +235,15 @@ BackgroundCommands =
     tabIds = BgUtils.tabRecency.getTabsByRecency().filter (tabId) -> tabId != tab.id
     if 0 < tabIds.length
       selectSpecificTab id: tabIds[(count-1) % tabIds.length]
+  reload: ({count, tabId, registryEntry, tab: {windowId}})->
+    bypassCache = registryEntry.options.hard ? false
+    chrome.tabs.query {windowId}, (tabs) ->
+      position = do ->
+        for tab, index in tabs
+          return index if tab.id == tabId
+      tabs = [tabs[position...]..., tabs[...position]...]
+      count = Math.min count, tabs.length
+      chrome.tabs.reload tab.id, {bypassCache} for tab in tabs[...count]
 
 # Remove tabs before, after, or either side of the currently active tab
 removeTabsRelative = (direction, {tab: activeTab}) ->

--- a/content_scripts/mode_normal.coffee
+++ b/content_scripts/mode_normal.coffee
@@ -59,10 +59,7 @@ NormalModeCommands =
   scrollLeft: (count) -> Scroller.scrollBy "x", -1 * Settings.get("scrollStepSize") * count
   scrollRight: (count) -> Scroller.scrollBy "x", Settings.get("scrollStepSize") * count
 
-  # Page state.
-  reload: (count, options) ->
-    hard = options.registryEntry.options.hard ? false
-    window.location.reload(hard)
+  # Tab navigation: back, forward.
   goBack: (count) -> history.go(-count)
   goForward: (count) -> history.go(count)
 


### PR DESCRIPTION
Move the `reload` command to the background page and make it accept a count prefix.

Fixes #674.

Although the demand for this is low and the use cases limited, it is a very vim-ish extension to the existing command.