### PR TITLE
Allow javascript: URLs for custom search engines.

### DIFF
--- a/background_scripts/bg_utils.coffee
+++ b/background_scripts/bg_utils.coffee
@@ -102,7 +102,8 @@ SearchEngines =
             keyword = tokens[0].split(":")[0]
             searchUrl = tokens[1]
             description = tokens[2..].join(" ") || "search (#{keyword})"
-            engines[keyword] = {keyword, searchUrl, description} if Utils.hasFullUrlPrefix searchUrl
+            if Utils.hasFullUrlPrefix(searchUrl) or Utils.hasJavascriptPrefix searchUrl
+              engines[keyword] = {keyword, searchUrl, description}
 
         callback engines
 

--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -167,6 +167,7 @@ class VomnibarUI
         # avoid a race condition, we construct the query from the actual contents of the input (query).
         query = Utils.createSearchUrl query, @lastReponse.engine.searchUrl if isCustomSearchPrimarySuggestion
         @hide ->
+          openInNewTab &&= not Utils.hasJavascriptPrefix query
           chrome.runtime.sendMessage
             handler: if openInNewTab then "openUrlInNewTab" else "openUrlInCurrentTab"
             url: query


### PR DESCRIPTION
For example, search the current site:

    site: javascript:location='http://www.google.com/search?num=100&q=site:'+escape(location.hostname)+'+%s'

Apparently an example like this has been on the Wiki for four years, but it has not been supported.

However, the change is so trivial that it's worth doing anyway.

Fixes #2956.