### PR TITLE
on FindMode exiting, blur input first

### DIFF
--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -27,6 +27,7 @@ onKeyEvent = (event) ->
   if (KeyboardUtils.isBackspace(event) and inputElement.textContent.length == 0) or
      event.key == "Enter" or KeyboardUtils.isEscape event
 
+    inputElement.blur()
     UIComponentServer.postMessage
       name: "hideFindMode"
       exitEventIsEnter: event.key == "Enter"


### PR DESCRIPTION
This is a complement of #2932 (on vomnibar hiding, blur input first).

The issue that IME is not turned off only occurs when a host frame is not Vimium's and the HUD iframe is in an independent system process (e.g. since Chrome 58).