### PR TITLE
Escape [ and ] in hostname in popup.

### DIFF
--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -181,7 +181,9 @@ class ExclusionRulesOnPopupOption extends ExclusionRulesOption
     if /^https?:\/\/./.test @url
       # The common use case is to disable Vimium at the domain level.
       # Generate "https?://www.example.com/*" from "http://www.example.com/path/to/page.html".
-      "https?:/" + @url.split("/",3)[1..].join("/") + "/*"
+      # Note: IPV6 host addresses will contain "[" and "]" (which must be escaped).
+      hostname = @url.split("/",3)[1..].join("/").replace("[", "\\[").replace "]", "\\]"
+      "https?:/" + hostname + "/*"
     else if /^[a-z]{3,}:\/\/./.test @url
       # Anything else which seems to be a URL.
       @url.split("/",3).join("/") + "/*"


### PR DESCRIPTION
From URL:

    http://[fe80::cce4:1680:e720:eacb]:8080/index.html

generate:

    https?://\[fe80::cce4:1680:e720:eacb\]:8080/*

in the popup (note that `[` and `]` are now escaped).

Fixes #2967.