### PR TITLE
Use count prefix for closeTabs___ commands.

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -389,9 +389,9 @@ commandDescriptions =
   togglePinTab: ["Pin or unpin current tab", { background: true, noRepeat: true }]
   toggleMuteTab: ["Mute or unmute current tab", { background: true, noRepeat: true }]
 
-  closeTabsOnLeft: ["Close tabs on the left", {background: true, noRepeat: true}]
-  closeTabsOnRight: ["Close tabs on the right", {background: true, noRepeat: true}]
-  closeOtherTabs: ["Close all other tabs", {background: true, noRepeat: true}]
+  closeTabsOnLeft: ["Close tabs on the left", {background: true}]
+  closeTabsOnRight: ["Close tabs on the right", {background: true}]
+  closeOtherTabs: ["Close all other tabs", {background: true}]
 
   moveTabLeft: ["Move tab to the left", { background: true }]
   moveTabRight: ["Move tab to the right", { background: true }]

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -245,18 +245,18 @@ BackgroundCommands =
       chrome.tabs.reload tab.id, {bypassCache} for tab in tabs[...count]
 
 # Remove tabs before, after, or either side of the currently active tab
-removeTabsRelative = (direction, {tab: activeTab}) ->
+removeTabsRelative = (direction, {count, tab}) ->
   chrome.tabs.query {currentWindow: true}, (tabs) ->
     shouldDelete =
       switch direction
         when "before"
-          (index) -> index < activeTab.index
+          (index) -> 0 < tab.index - index <= count
         when "after"
-          (index) -> index > activeTab.index
+          (index) -> 0 < index - tab.index <= count
         when "both"
-          (index) -> index != activeTab.index
+          (index) -> 0 < Math.abs(tab.index - index) <= count
 
-    chrome.tabs.remove (tab.id for tab in tabs when not tab.pinned and shouldDelete tab.index)
+    chrome.tabs.remove (t.id for t in tabs when not t.pinned and shouldDelete t.index)
 
 # Selects a tab before or after the currently selected tab.
 # - direction: "next", "previous", "first" or "last".


### PR DESCRIPTION
E.g.:

    map cl closeTabsOnRight

    # Close just two tabs on the right.
    2cl

    # Always close all tabs on the right
    map cl closeTabsOnRight count=999999

This is a change to the established behaviour.  However, it is more vim-like, and arguably more elegant.

Feedback on "do"/"don't do" this would be appreciated.

Fixes #2970.