### PR TITLE
Add options to control selection for focusInput.

### DIFF
--- a/content_scripts/mode_normal.coffee
+++ b/content_scripts/mode_normal.coffee
@@ -140,7 +140,7 @@ NormalModeCommands =
     nextStrings = nextPatterns.split(",").filter( (s) -> s.trim().length )
     findAndFollowRel("next") || findAndFollowLink(nextStrings)
 
-  focusInput: (count) ->
+  focusInput: (count, {registryEntry}) ->
     # Focus the first input element on the page, and create overlays to highlight all the input elements, with
     # the currently-focused element highlighted specially. Tabbing will shift focus to the next input element.
     # Pressing any other key will remove the overlays and the special tab behavior.
@@ -195,7 +195,7 @@ NormalModeCommands =
 
       hint
 
-    new FocusSelector hints, visibleInputs, selectedInputIndex
+    new FocusSelector hints, visibleInputs, selectedInputIndex, registryEntry.options
 
 if LinkHints?
   extend NormalModeCommands,
@@ -323,7 +323,7 @@ findAndFollowRel = (value) ->
         return true
 
 class FocusSelector extends Mode
-  constructor: (hints, visibleInputs, selectedInputIndex) ->
+  constructor: (hints, visibleInputs, selectedInputIndex, options) ->
     super
       name: "focus-selector"
       exitOnClick: true
@@ -333,7 +333,7 @@ class FocusSelector extends Mode
           selectedInputIndex += hints.length + (if event.shiftKey then -1 else 1)
           selectedInputIndex %= hints.length
           hints[selectedInputIndex].classList.add 'internalVimiumSelectedInputHint'
-          DomUtils.simulateSelect visibleInputs[selectedInputIndex].element
+          DomUtils.simulateSelect visibleInputs[selectedInputIndex].element, options.select ? null
           @suppressEvent
         else unless event.key == "Shift"
           @exit()
@@ -344,7 +344,7 @@ class FocusSelector extends Mode
       id: "vimiumInputMarkerContainer"
       className: "vimiumReset"
 
-    DomUtils.simulateSelect visibleInputs[selectedInputIndex].element
+    DomUtils.simulateSelect visibleInputs[selectedInputIndex].element, options.select ? null
     if visibleInputs.length == 1
       @exit()
       return

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -227,7 +227,7 @@ DomUtils =
       else
         false
 
-  simulateSelect: (element) ->
+  simulateSelect: (element, selectionType = null) ->
     # If element is already active, then we don't move the selection.  However, we also won't get a new focus
     # event.  So, instead we pretend (to any active modes which care, e.g. PostFindMode) that element has been
     # clicked.
@@ -235,7 +235,7 @@ DomUtils =
       handlerStack.bubbleEvent "click", target: element
     else
       element.focus()
-      if element.tagName.toLowerCase() != "textarea"
+      if element.tagName.toLowerCase() != "textarea" and not selectionType?
         # If the cursor is at the start of the (non-textarea) element's contents, send it to the end. Motivation:
         # * the end is a more useful place to focus than the start,
         # * this way preserves the last used position (except when it's at the beginning), so the user can
@@ -245,6 +245,23 @@ DomUtils =
         try
           if element.selectionStart == 0 and element.selectionEnd == 0
             element.setSelectionRange element.value.length, element.value.length
+
+    if selectionType? and selectionType in ["all", "start", "end"]
+      @selectAll element
+      switch selectionType
+        when "end" then window.getSelection().collapseToEnd()
+        when "start" then window.getSelection().collapseToStart()
+
+  # Select all of the text within an element.
+  selectAll: (element) ->
+    if element.select?
+      element.select()
+    else
+      range = document.createRange()
+      range.selectNodeContents element
+      sel = window.getSelection()
+      sel.removeAllRanges()
+      sel.addRange range
 
   simulateClick: (element, modifiers = {}) ->
     eventSequence = ["mouseover", "mousedown", "mouseup", "click"]

--- a/tests/dom_tests/dom_tests.coffee
+++ b/tests/dom_tests/dom_tests.coffee
@@ -437,29 +437,29 @@ context "Input focus",
     document.getElementById("test-div").innerHTML = ""
 
   should "focus the first element", ->
-    NormalModeCommands.focusInput 1
+    NormalModeCommands.focusInput 1, registryEntry: options: {}
     assert.equal "first", document.activeElement.id
 
   should "focus the nth element", ->
-    NormalModeCommands.focusInput 100
+    NormalModeCommands.focusInput 100, registryEntry: options: {}
     assert.equal "third", document.activeElement.id
 
   should "activate insert mode on the first element", ->
-    NormalModeCommands.focusInput 1
+    NormalModeCommands.focusInput 1, registryEntry: options: {}
     assert.isTrue InsertMode.permanentInstance.isActive()
 
   should "activate insert mode on the first element", ->
-    NormalModeCommands.focusInput 100
+    NormalModeCommands.focusInput 100, registryEntry: options: {}
     assert.isTrue InsertMode.permanentInstance.isActive()
 
   should "activate the most recently-selected input if the count is 1", ->
-    NormalModeCommands.focusInput 3
-    NormalModeCommands.focusInput 1
+    NormalModeCommands.focusInput 3, registryEntry: options: {}
+    NormalModeCommands.focusInput 1, registryEntry: options: {}
     assert.equal "third", document.activeElement.id
 
   should "not trigger insert if there are no inputs", ->
     document.getElementById("test-div").innerHTML = ""
-    NormalModeCommands.focusInput 1
+    NormalModeCommands.focusInput 1, registryEntry: options: {}
     assert.isFalse InsertMode.permanentInstance.isActive()
 
 # TODO: these find prev/next link tests could be refactored into unit tests which invoke a function which has


### PR DESCRIPTION
This implements the suggestion in [this comment](https://github.com/philc/vimium/issues/2969#issuecomment-368491430).

Examples:

    map X focusInput select=all
    map X focusInput select=start
    map X focusInput select=end

Fixes #2969.