### PR TITLE
Explicitly set background colour for input fields

### DIFF
--- a/pages/options.css
+++ b/pages/options.css
@@ -153,6 +153,7 @@ input[type="text"], textarea {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   color: #444;
+  background-color: white;
   font: inherit;
   padding: 3px;
 }


### PR DESCRIPTION
This is a simple solution to #2832 that explicitly sets the background of text input and textareas to white on the options page, which is necessary for users running with a dark theme.  This does not cover the options popup.