### PR TITLE
Add CodeMirror as special case in InsertMode

### DIFF
--- a/content_scripts/mode_insert.coffee
+++ b/content_scripts/mode_insert.coffee
@@ -20,8 +20,13 @@ class InsertMode extends Mode
         new PassNextKeyMode
 
       else if event.type == 'keydown' and KeyboardUtils.isEscape(event)
-        activeElement.blur() if DomUtils.isFocusable activeElement
-        @exit() unless @permanent
+        # Special-case so that CodeMirror's Vim keyMap and Vimium can co-exist on one page.
+        # Without this, Vimium would never let a CodeMirror's editor return to Normal mode.
+        if DomUtils.isCodeMirror activeElement
+          return @passEventToPage
+        else
+          activeElement.blur() if DomUtils.isFocusable activeElement
+          @exit() unless @permanent
 
       else
         return @passEventToPage

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -205,6 +205,12 @@ DomUtils =
   isFocusable: (element) ->
     element and (@isEditable(element) or @isEmbed element)
 
+  isCodeMirror: (element) ->
+    if element.classList.contains('CodeMirror')
+      return true
+    else
+      return element.parentNode && DomUtils.isCodeMirror element.parentNode
+
   isDOMDescendant: (parent, child) ->
     node = child
     while (node != null)

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -206,7 +206,7 @@ DomUtils =
     element and (@isEditable(element) or @isEmbed element)
 
   isCodeMirror: (element) ->
-    if element.classList.contains('CodeMirror')
+    if element.className.split(" ").indexOf("CodeMirror") >= 0
       return true
     else
       return element.parentNode && DomUtils.isCodeMirror element.parentNode


### PR DESCRIPTION
CodeMirror (a code editor component that can be embedded in web pages)
implements a simple Vim emulation mode. It supports navigating the text
with Vim normal-mode operators, and also editing text with insert-mode
operators. In particular, CodeMirror supports pressing ESC to go from
Insert mode to Normal mode.

To Vimium (and the DOM), CodeMirror appears as an editable, focusable
element. This means that when you press ESC in a CodeMirror editor,
Vimium will blur CodeMirror's focus. This prevents CodeMirror users from
using Vim mode.

This change allows CodeMirror's Vim keymap and Vimium to co-exist on the
same page. Without this, Vimium will never let a CodeMirror's editor
return to Normal mode. If we're inside a CodeMirror editor, instead of
trapping the ESC, we pass it through to the editor.

This has the slight drawback that you'll need to use the mouse to take
focus away from CodeMirror. I consider this preferable, because it
makes CodeMirror feel as close to Vim while it does have your focus.

For more context:

- <https://github.com/philc/vimium/issues/2734>

To reproduce and play around with the existing CodeMirror behavior:

- <https://codemirror.net/demo/vim.html>

Also, I'm happy to pursue alternative workarounds to this! Looking
forward to hearing your thoughts.