### PR TITLE
Use a Vimium class to detect click listeners.

### DIFF
--- a/content_scripts/injected.coffee
+++ b/content_scripts/injected.coffee
@@ -1,6 +1,3 @@
-# NOTE(smblott) Disabled pending resolution of #2997.
-return
-
 # The code in `injectedCode()`, below, is injected into the page's own execution context.
 #
 # This is based on method 2b here: http://stackoverflow.com/a/9517879, and
@@ -17,7 +14,7 @@ injectedCode = () ->
   addEventListener = (type, listener, useCapture) ->
     if type == "click" and this instanceof EL
       unless this instanceof Anchor # Just skip <a>.
-        try @setAttribute "_vimium-has-onclick-listener", ""
+        this.classList.add "__vimiumPageClickListenerDetected"
     _addEventListener?.apply this, arguments
 
   newToString = () ->

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -706,9 +706,8 @@ LocalHints =
         isClickable = true
         reason = "Open."
 
-    # NOTE(smblott) Disabled pending resolution of #2997.
-    # # Detect elements with "click" listeners installed with `addEventListener()`.
-    # isClickable ||= element.hasAttribute "_vimium-has-onclick-listener"
+    # Detect elements with "click" listeners installed with `addEventListener()`.
+    isClickable ||= element.classList.contains "__vimiumPageClickListenerDetected"
 
     # An element with a class name containing the text "button" might be clickable.  However, real clickables
     # are often wrapped in elements with such class names.  So, when we find clickables based only on their


### PR DESCRIPTION
5745bb344959a61297fc16e00bb6de0a2a8744d9 disabled our detection of click listeners added with `addEventListener` (see #2997 and #3002).

This PR proposes using the CSS class list to inform Vimium that an element has a click listener (instead of a custom attribute).