### PR TITLE
Use hash (too) for local marks.

### DIFF
--- a/content_scripts/marks.coffee
+++ b/content_scripts/marks.coffee
@@ -15,7 +15,7 @@ Marks =
     "vimiumMark|#{window.location.href.split('#')[0]}|#{keyChar}"
 
   getMarkString: ->
-    JSON.stringify scrollX: window.scrollX, scrollY: window.scrollY
+    JSON.stringify scrollX: window.scrollX, scrollY: window.scrollY, hash: window.location.hash
 
   setPreviousPosition: ->
     markString = @getMarkString()
@@ -84,7 +84,10 @@ Marks =
               if markString?
                 @setPreviousPosition()
                 position = JSON.parse markString
-                window.scrollTo position.scrollX, position.scrollY
+                if position.hash and position.scrollX == 0 and position.scrollY == 0
+                  window.location.hash = position.hash
+                else
+                  window.scrollTo position.scrollX, position.scrollY
                 @showMessage "Jumped to local mark", keyChar
               else
                 @showMessage "Local mark not set", keyChar


### PR DESCRIPTION
First, I *very rarely* use local marks.  They just don't seem as useful in a browser as they are in a text editor.

However, on a page like GMail, I do often want to jump back and forward between my labels.  These are different location hashes (anchors).

The idea here is to make local marks useful for this case.

If the scroll positions (X and Y) are both 0, and the hash (anchor) is present in the mark and non-empty, then change the hash instead of scrolling.

On first tests, this appears to work nicely for changing labels in GMail.  I'm sure there are other uses.

This change shouldn't interfere with use cases where the user has scrolled within the page.