### PR TITLE
Issue #3054

### DIFF
--- a/pages/vomnibar.coffee
+++ b/pages/vomnibar.coffee
@@ -262,7 +262,7 @@ class VomnibarUI
       @input.focus()
       event.stopImmediatePropagation()
     # A click anywhere else hides the vomnibar.
-    document.body.addEventListener "click", => @hide()
+    document.addEventListener "click", => @hide()
 
 #
 # Sends requests to a Vomnibox completer on the background page.


### PR DESCRIPTION
Vombinar frame's body has zero height but the frame has almost full screen height, so `document.body.addEventListener "click"` is useless. We should use `document.addEventListener "click"` instead.