### PR TITLE
Cache keydown events while launching link hints.

### DIFF
--- a/content_scripts/mode.coffee
+++ b/content_scripts/mode.coffee
@@ -198,6 +198,17 @@ class SuppressAllKeyboardEvents extends Mode
       suppressAllKeyboardEvents: true
     super extend defaults, options
 
+class CacheAllKeydownEvents extends SuppressAllKeyboardEvents
+  constructor: (options = {}) ->
+    @keydownEvents = keydownEvents = []
+    defaults =
+      name: "cacheAllKeydownEvents"
+      keydown: (event) -> keydownEvents.push event
+    super extend defaults, options
+
+  replayKeydownEvents: ->
+    handlerStack.bubbleEvent "keydown", event for event in @keydownEvents
+
 root = exports ? (window.root ?= {})
-extend root, {Mode, SuppressAllKeyboardEvents}
+extend root, {Mode, SuppressAllKeyboardEvents, CacheAllKeydownEvents}
 extend window, root unless exports?


### PR DESCRIPTION
Launching link hints can sometimes be slow.  For filtered hints, the user already knows what to type - but must nevertheless wait until the hints have been calculated and rendered.

Here, we cache intervening keydown events, and replay them once hints-mode proper is launched.  This should make improve usability (in the case of filtered hints).

Fixes #3050.