### PR TITLE
Add CoffeeScript v1 requirement to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Please include the following when reporting an issue:
 Vimium is written in Coffeescript, which compiles to Javascript. To
 install Vimium from source:
 
- 1. Install [Coffeescript](http://coffeescript.org/#installation).
+ 1. Install [Coffeescript 1.X](http://coffeescript.org/#installation) (`npm install --global coffeescript@~1`).
  1. Run `cake build` from within your vimium directory. Any coffeescript files you change will now be automatically compiled to Javascript.
  1. Navigate to `chrome://extensions`
  1. Toggle into Developer Mode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Please include the following when reporting an issue:
 Vimium is written in Coffeescript, which compiles to Javascript. To
 install Vimium from source:
 
- 1. Install [Coffeescript 1.X](http://coffeescript.org/#installation) (`npm install --global coffeescript@~1`).
+ 1. Install [Coffeescript v1](http://coffeescript.org/#installation) (`npm install --global coffeescript@~1`).
  1. Run `cake build` from within your vimium directory. Any coffeescript files you change will now be automatically compiled to Javascript.
  1. Navigate to `chrome://extensions`
  1. Toggle into Developer Mode


### PR DESCRIPTION
Currently `vimium` only works with CoffeeScript v1.

Trying to run it with v2 will produce the following error:
```js
e:\Users\mt\AppData\Roaming\npm\node_modules\coffeescript\lib\coffeescript\optparse.js:147
    shortFlag = shortFlag != null ? shortFlag.match(SHORT_FLAG)[1] : void 0;
                                                               ^

TypeError: Cannot read property '1' of null
```

This PR documents this requirement in the `CONTRIBUTING.md` document.