### PR TITLE
Instructions for local Vimium Firefox development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,20 @@ install Vimium from source:
 
  1. Install [Coffeescript](http://coffeescript.org/#installation).
  1. Run `cake build` from within your vimium directory. Any coffeescript files you change will now be automatically compiled to Javascript.
+
+### Chrome/Chromium
+
  1. Navigate to `chrome://extensions`
  1. Toggle into Developer Mode
  1. Click on "Load Unpacked Extension..."
  1. Select the Vimium directory.
+
+### Firefox
+
+ 1. Open Firefox
+ 1. Enter "about:debugging" in the URL bar
+ 1. Click "Load Temporary Add-on"
+ 1. Open the Vimium directory and select any file inside.
 
 ## Development tips
 


### PR DESCRIPTION
Add instructions on how to install Vimium from local sources using Firefox.
> _Source for instructions: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Temporary_Installation_in_Firefox_