### PR TITLE
Handle scrolling on Reddit redesign

### DIFF
--- a/content_scripts/scroller.coffee
+++ b/content_scripts/scroller.coffee
@@ -319,6 +319,15 @@ if DomUtils.isTopFrame() and window.location.host == "twitter.com"
         activatedElement = element ? getScrollingElement()
         func arguments...
 
+if DomUtils.isTopFrame() and window.location.host in ["reddit.com", "new.reddit.com"]
+  for method in ["scrollTo", "scrollBy"]
+    do ->
+      func = Scroller[method]
+      Scroller[method] = ->
+        element = document.getElementById "overlayScrollContainer"
+        activatedElement = element ? getScrollingElement()
+        func arguments...
+
 root = exports ? (window.root ?= {})
 root.Scroller = Scroller
 extend window, root unless exports?

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -297,6 +297,7 @@ checkIfEnabledForUrl = do ->
     {isEnabledForUrl, passKeys, frameIsFocused, isFirefox} = response
     Utils.isFirefox = -> isFirefox
     installModes() unless normalMode
+    Scroller.init() # TODO hack to bust Scroller.activatedElement caching
     normalMode.setPassKeys passKeys
     # Hide the HUD if we're not enabled.
     HUD.hide true, false unless isEnabledForUrl


### PR DESCRIPTION
This PR adds support for scrolling the through the new Reddit post popups, introduced during the ongoing Reddit redesign effort.

Before scrolling with j and k would scroll the background, instead of the foreground article:

![before](https://user-images.githubusercontent.com/583503/44896683-09f01b00-acc7-11e8-8af2-5deda3566e1c.gif)

With the changes in this PR, it will now scroll the popup post correctly:

![after](https://user-images.githubusercontent.com/583503/44896687-0bb9de80-acc7-11e8-8763-4868cebb8ccb.gif)

## Implementation notes

Unfortunately `document.scrollingElement` will always return the document's body, meaning we never reach our fallback codes that could handle edge-cases like this.

The solution implemented in this PR is ad-hoc, which is subpar to say the least. It is based on a recent similar fix for Twitter.

If this solution is acceptable for now, I'm willing to refactor these two ad-hoc to reduce code duplication.
I could move them into an external configuration file instead, as the only variables are the URLs affected, and how to find the scrollable element.