### PR TITLE
Fix Firefox focus switch for find mode

### DIFF
--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -31,6 +31,9 @@ HUD =
       @tween.fade 1.0, 150
 
   showFindMode: (@findMode = null) ->
+    # On Firefox, we can only steal focus from the main document if nothing is focused.
+    document.activeElement?.blur() if Utils.isFirefox()
+
     DomUtils.documentComplete =>
       @init()
       @hudUI.activate name: "showFindMode"


### PR DESCRIPTION
> _Fixes #3106_

Firefox won't allow us to change focus to our search HUD _unless_ nothing is currently focused in the current webpage document (`document.activeElement` on the main page).

If I had to guess, it seems like Firefox prioritizes the brower's focus to the main page first, and then, if it doesn't find anything to focus there, goes down the document chain, finding Vimium's DOM with a valid `document.activeElement` set next.