### PR TITLE
Dont encode '%S'

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -131,7 +131,7 @@ Utils =
   # It would be better to pull the default search engine from chrome itself.  However, chrome does not provide
   # an API for doing so.
   createSearchUrl: (query, searchUrl = Settings.get("searchUrl")) ->
-    searchUrl += "%s" if -1 == searchUrl.indexOf("%s") + searchUrl.indexOf("%S")
+    searchUrl += "%s" unless ['%s', '%S'].some (token) -> searchUrl.indexOf(token) >= 0
     searchUrl = searchUrl.replace /%S/g, query
     searchUrl.replace /%s/g, @createSearchQuery query
 

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -131,7 +131,8 @@ Utils =
   # It would be better to pull the default search engine from chrome itself.  However, chrome does not provide
   # an API for doing so.
   createSearchUrl: (query, searchUrl = Settings.get("searchUrl")) ->
-    searchUrl += "%s" unless 0 <= searchUrl.indexOf "%s"
+    searchUrl += "%s" if -1 == searchUrl.indexOf("%s") + searchUrl.indexOf("%S")
+    searchUrl = searchUrl.replace /%S/g, query
     searchUrl.replace /%s/g, @createSearchQuery query
 
   # Extract a query from url if it appears to be a URL created from the given search URL.

--- a/pages/options.html
+++ b/pages/options.html
@@ -82,6 +82,7 @@ b: http://b.com/?q=%s description
 " this is a comment
 # this is also a comment</pre>
                   %s is replaced with the search terms. <br/>
+                  Use %S if you don't want the search terms <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent">URI Encoded</a>
                   For search completion, see <a href="completion_engines.html" target="_blank">here</a>.
                 </div>
               </div>

--- a/tests/unit_tests/utils_test.coffee
+++ b/tests/unit_tests/utils_test.coffee
@@ -50,18 +50,16 @@ context "convertToUrl",
     assert.equal "https://www.google.com/search?q=go+ogle.com", Utils.convertToUrl("go ogle.com")
     assert.equal "https://www.google.com/search?q=%40twitter", Utils.convertToUrl("@twitter")
 
+context "createSearchUrl",
+  should "replace %S without encoding", ->
+    assert.equal "https://www.github.com/philc/vimium/pulls", Utils.createSearchUrl "vimium/pulls", "https://www.github.com/philc/%S"
+
 context "extractQuery",
   should "extract queries from search URLs", ->
     assert.equal "bbc sport 1", Utils.extractQuery "https://www.google.ie/search?q=%s", "https://www.google.ie/search?q=bbc+sport+1"
     assert.equal "bbc sport 2", Utils.extractQuery "http://www.google.ie/search?q=%s", "https://www.google.ie/search?q=bbc+sport+2"
     assert.equal "bbc sport 3", Utils.extractQuery "https://www.google.ie/search?q=%s", "http://www.google.ie/search?q=bbc+sport+3"
     assert.equal "bbc sport 4", Utils.extractQuery "https://www.google.ie/search?q=%s", "http://www.google.ie/search?q=bbc+sport+4&blah"
-
-  should "replace %S without encoding", ->
-    assert.equal "vimium/pulls", Utils.extractQuery "https://www.github.com/philc/%S", "https://www.github.com/philc/vimium/pulls"
-
-  should "extract not queries from incorrect search URLs", ->
-    assert.isFalse Utils.extractQuery "https://www.google.ie/search?q=%s&foo=bar", "https://www.google.ie/search?q=bbc+sport"
 
 context "hasChromePrefix",
   should "detect chrome prefixes of URLs", ->

--- a/tests/unit_tests/utils_test.coffee
+++ b/tests/unit_tests/utils_test.coffee
@@ -57,6 +57,9 @@ context "extractQuery",
     assert.equal "bbc sport 3", Utils.extractQuery "https://www.google.ie/search?q=%s", "http://www.google.ie/search?q=bbc+sport+3"
     assert.equal "bbc sport 4", Utils.extractQuery "https://www.google.ie/search?q=%s", "http://www.google.ie/search?q=bbc+sport+4&blah"
 
+  should "replace %S without encoding", ->
+    assert.equal "vimium/pulls", Utils.extractQuery "https://www.github.com/philc/%S", "https://www.github.com/philc/vimium/pulls"
+
   should "extract not queries from incorrect search URLs", ->
     assert.isFalse Utils.extractQuery "https://www.google.ie/search?q=%s&foo=bar", "https://www.google.ie/search?q=bbc+sport"
 


### PR DESCRIPTION
Hello, this addresses https://github.com/philc/vimium/issues/3130 / https://github.com/philc/vimium/issues/2580

It adds support for using `%S` instead of / in addition to `%s` in search engine completion.
`%S` tokens will not be URI encoded.

Example use-case:

```
gh: https://www.github.com/%S Github
```

and using `philc/vimium`to resolve to `https://www.github.com/philc/vimium` instead of `https://www.github.com/philc%2Fvimium`