### PR TITLE
Use `chrome.tabs.executeScript` when encountering javascript bookmarks

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -97,7 +97,10 @@ do ->
 TabOperations =
   # Opens the url in the current tab.
   openUrlInCurrentTab: (request) ->
-    chrome.tabs.update request.tabId, url: Utils.convertToUrl request.url
+    if Utils.hasJavascriptPrefix request.url
+      chrome.tabs.executeScript request.tabId, {code: request.url}
+    else
+      chrome.tabs.update request.tabId, url: Utils.convertToUrl request.url
 
   # Opens request.url in new tab and switches to it.
   openUrlInNewTab: (request, callback = (->)) ->


### PR DESCRIPTION
This PR changes the behavior of `openUrlInCurrentTab` to use `chrome.tabs.executeScript` whenever it encounters a JavaScript bookmark. `chrome.tabs.update` does not support this anymore, resulting in an error whenever trying this.

Tested in Both Chrome and Firefox :smile: 