### PR TITLE
use Shadow DOM v1 if it exists

### DIFF
--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -27,7 +27,7 @@ class UIComponent
         seamless: "seamless"
       shadowWrapper = DomUtils.createElement "div"
       # PhantomJS doesn't support createShadowRoot, so guard against its non-existance.
-      @shadowDOM = shadowWrapper.createShadowRoot?() ? shadowWrapper
+      @shadowDOM = shadowWrapper.attachShadow?() ? shadowWrapper.createShadowRoot?() ? shadowWrapper
       @shadowDOM.appendChild styleSheet
       @shadowDOM.appendChild @iframeElement
       @toggleIframeElementClasses "vimiumUIComponentVisible", "vimiumUIComponentHidden"

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -27,7 +27,8 @@ class UIComponent
         seamless: "seamless"
       shadowWrapper = DomUtils.createElement "div"
       # PhantomJS doesn't support createShadowRoot, so guard against its non-existance.
-      @shadowDOM = shadowWrapper.attachShadow?() ? shadowWrapper.createShadowRoot?() ? shadowWrapper
+      @shadowDOM = shadowWrapper.attachShadow?( mode: "open" ) ?
+        shadowWrapper.createShadowRoot?() ? shadowWrapper
       @shadowDOM.appendChild styleSheet
       @shadowDOM.appendChild @iframeElement
       @toggleIframeElementClasses "vimiumUIComponentVisible", "vimiumUIComponentHidden"

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -245,7 +245,10 @@ flashFrame = do ->
       # Create a shadow DOM wrapping the frame so the page's styles don't interfere with ours.
       highlightedFrameElement = DomUtils.createElement "div"
       # PhantomJS doesn't support createShadowRoot, so guard against its non-existance.
-      _shadowDOM = highlightedFrameElement.createShadowRoot?() ? highlightedFrameElement
+      # https://hacks.mozilla.org/2018/10/firefox-63-tricks-and-treats/ says
+      # Firefox 63 has enabled Shadow DOM v1 by default
+      _shadowDOM = highlightedFrameElement.attachShadow?() ?
+        highlightedFrameElement.createShadowRoot?() ? highlightedFrameElement
 
       # Inject stylesheet.
       _styleSheet = DomUtils.createElement "style"

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -247,7 +247,7 @@ flashFrame = do ->
       # PhantomJS doesn't support createShadowRoot, so guard against its non-existance.
       # https://hacks.mozilla.org/2018/10/firefox-63-tricks-and-treats/ says
       # Firefox 63 has enabled Shadow DOM v1 by default
-      _shadowDOM = highlightedFrameElement.attachShadow?() ?
+      _shadowDOM = highlightedFrameElement.attachShadow?( mode: "open" ) ?
         highlightedFrameElement.createShadowRoot?() ? highlightedFrameElement
 
       # Inject stylesheet.


### PR DESCRIPTION
Chrome 70 has deprecated Shadow DOM v0
    and displayed a warning when it's used.
And accroding to https://www.chromestatus.com/features/4507242028072960,
    Shadow DOM v0 will be removed since Chrome 73.

The support for Shadow DOM v1 has been there since Chrome 53 and
    is enabled by default on Firefox 63,
so it's time to use it.

Old support is still needed because Vimium's min_chrome_version is 51.