### PR TITLE
fix that an empty href was translated using the default search engine

### DIFF
--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -286,7 +286,7 @@ DomUtils =
       element.dispatchEvent(mouseEvent)
 
   simulateClickDefaultAction: (element, modifiers = {}) ->
-    return unless element.tagName?.toLowerCase() == "a" and element.href?
+    return unless element.tagName?.toLowerCase() == "a" and element.href
 
     {ctrlKey, shiftKey, metaKey, altKey} = modifiers
 


### PR DESCRIPTION
This fixes #3174 by doing nothing when `<a>.href` is `""` (e.g. `<a>` has no `href` attribute).