### PR TITLE
Avoid crash when document style not found

### DIFF
--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -328,19 +328,22 @@ DomUtils =
     box = document.documentElement
     style = getComputedStyle box
     rect = box.getBoundingClientRect()
-    if style.position == "static" and not /content|paint|strict/.test(style.contain or "")
-      # The margin is included in the client rect, so we need to subtract it back out.
-      marginTop = parseInt style.marginTop
-      marginLeft = parseInt style.marginLeft
-      top: -rect.top + marginTop, left: -rect.left + marginLeft
+    if style == null
+      top: 0, left: 0
     else
-      if Utils.isFirefox()
-        # These are always 0 for documentElement on Firefox, so we derive them from CSS border.
-        clientTop = parseInt style.borderTopWidth
-        clientLeft = parseInt style.borderLeftWidth
+      if style.position == "static" and not /content|paint|strict/.test(style.contain or "")
+        # The margin is included in the client rect, so we need to subtract it back out.
+        marginTop = parseInt style.marginTop
+        marginLeft = parseInt style.marginLeft
+        top: -rect.top + marginTop, left: -rect.left + marginLeft
       else
-        {clientTop, clientLeft} = box
-      top: -rect.top - clientTop, left: -rect.left - clientLeft
+        if Utils.isFirefox()
+          # These are always 0 for documentElement on Firefox, so we derive them from CSS border.
+          clientTop = parseInt style.borderTopWidth
+          clientLeft = parseInt style.borderLeftWidth
+        else
+          {clientTop, clientLeft} = box
+        top: -rect.top - clientTop, left: -rect.left - clientLeft
 
 
   suppressPropagation: (event) ->


### PR DESCRIPTION
Fixes crash when using 'f' in gmail on Firefox, #3146.

The gmail inbox view would initially work, but after finishing loading crash
vimium. Debugging revealed while gmail worked, 'f' would trigger 2 calls of
getViewportTopLeft. After loading the page completely, 'f' would trigger 3
calls of getViewportTopLeft, and crash on the third because 'style' was null.

After handling the case of the 'style' being null (and assuming a viewport top
left location of '0,0' in that case), 'f' works again even when gmail is fully
loaded