### PR TITLE
scroller.coffee(performScroll): Fix `h` `l` horizontal scrolling

### DIFF
--- a/content_scripts/scroller.coffee
+++ b/content_scripts/scroller.coffee
@@ -58,7 +58,7 @@ performScroll = (element, direction, amount) ->
   before = element[axisName]
   if typeof element.scrollBy is "function"
     scrollArg = behavior: "instant"
-    scrollArg[if axisName is "x" then "left" else "top"] = amount
+    scrollArg[if direction is "x" then "left" else "top"] = amount
     element.scrollBy scrollArg
   else
     element[axisName] += amount


### PR DESCRIPTION
When scrolling horizontally, `axisName` has value `"scrollLeft"`. Since
this line checks against value `"x"` it would always fail, causing `h`
and `l` to scroll vertically up and down respectively.

Use the `direction` argument in the condition instead, which is set to
`"x"` when scrolling horizontally with `h` and `l`.

This fixes horizontal scrolling using `h` and `l`.