### PR TITLE
Add 'Bookmarks blacklist' setting

### DIFF
--- a/background_scripts/completion.coffee
+++ b/background_scripts/completion.coffee
@@ -244,13 +244,14 @@ class BookmarkCompleter
 
   # Recursive helper for `traverseBookmarks`.
   traverseBookmarksRecursive: (bookmark, results, parent={pathAndTitle:""}) ->
-    bookmark.pathAndTitle =
-      if bookmark.title and not (parent.pathAndTitle == "" and @ignoreTopLevel[bookmark.title])
-        parent.pathAndTitle + @folderSeparator + bookmark.title
-      else
-        parent.pathAndTitle
-    results.push bookmark
-    bookmark.children.forEach((child) => @traverseBookmarksRecursive child, results, bookmark) if bookmark.children
+    if bookmark.title not in Settings.get("bookmarksBlacklist").split(",").filter( (s) -> s.trim().length )
+      bookmark.pathAndTitle =
+        if bookmark.title and not (parent.pathAndTitle == "" and @ignoreTopLevel[bookmark.title])
+          parent.pathAndTitle + @folderSeparator + bookmark.title
+        else
+          parent.pathAndTitle
+      results.push bookmark
+      bookmark.children.forEach((child) => @traverseBookmarksRecursive child, results, bookmark) if bookmark.children
 
   computeRelevancy: (suggestion) ->
     RankingUtils.wordRelevancy(suggestion.queryTerms, suggestion.shortUrl ? suggestion.url, suggestion.title)

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -167,6 +167,7 @@ Settings =
     previousPatterns: "prev,previous,back,older,<,\u2039,\u2190,\xab,\u226a,<<"
     # "\bnext\b,\bmore\b,>,›,→,»,≫,>>"
     nextPatterns: "next,more,newer,>,\u203a,\u2192,\xbb,\u226b,>>"
+    bookmarksBlacklist: ""
     # default/fall back search engine
     searchUrl: "https://www.google.com/search?q="
     # put in an example search engine

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -201,6 +201,7 @@ Options =
   newTabUrl: NonEmptyTextOption
   nextPatterns: NonEmptyTextOption
   previousPatterns: NonEmptyTextOption
+  bookmarksBlacklist: TextOption
   regexFindMode: CheckBoxOption
   ignoreKeyboardLayout: CheckBoxOption
   scrollStepSize: NumberOption

--- a/pages/options.css
+++ b/pages/options.css
@@ -117,7 +117,7 @@ textarea#userDefinedLinkHintCss, textarea#keyMappings, textarea#searchEngines {
   min-height: 140px;
   white-space: pre;
 }
-input#previousPatterns, input#nextPatterns {
+input#previousPatterns, input#nextPatterns, input#bookmarksBlacklist {
   width: 100%;
 }
 input#newTabUrl {

--- a/pages/options.html
+++ b/pages/options.html
@@ -247,6 +247,17 @@ b: http://b.com/?q=%s description
             </td>
           </tr>
           <tr>
+            <td class="caption">Bookmarks</br>blacklist</td>
+            <td verticalAlign="top">
+                <div class="help">
+                  <div class="example">
+                    Comma separated list of case sensitive folder names used to blacklist bookmarks.
+                  </div>
+                </div>
+                <input id="bookmarksBlacklist" type="text" />
+            </td>
+          </tr>
+          <tr>
             <td class="caption">New tab URL</td>
             <td verticalAlign="top">
                 <div class="help">


### PR DESCRIPTION
Allows specifying bookmark folders whose contents should not be included in the bookmark vomnibar search