### PR TITLE
Add option to enable Javascript URLs

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -97,7 +97,10 @@ do ->
 TabOperations =
   # Opens the url in the current tab.
   openUrlInCurrentTab: (request) ->
-    chrome.tabs.update request.tabId, url: Utils.convertToUrl request.url
+    if Utils.hasJavascriptPrefix request.url
+      chrome.tabs.executeScript request.tabId, {code: request.url}
+    else
+      chrome.tabs.update request.tabId, url: Utils.convertToUrl request.url
 
   # Opens request.url in new tab and switches to it.
   openUrlInNewTab: (request, callback = (->)) ->

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -98,7 +98,11 @@ TabOperations =
   # Opens the url in the current tab.
   openUrlInCurrentTab: (request) ->
     if Utils.hasJavascriptPrefix request.url
-      chrome.tabs.executeScript request.tabId, {code: request.url}
+      if Settings.get "allowJavascriptURLs"
+        chrome.tabs.executeScript request.tabId, {code: request.url}
+      else
+        {tabId, frameId} = request
+        chrome.tabs.sendMessage tabId, {frameId, name: "showMessage", message: "Javascript disabled (see the options page)."}
     else
       chrome.tabs.update request.tabId, url: Utils.convertToUrl request.url
 

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -198,6 +198,7 @@ Settings =
     optionsPage_showAdvancedOptions: false
     passNextKeyKeys: []
     ignoreKeyboardLayout: false
+    allowJavascriptURLs: false
 
 Settings.init()
 

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -209,6 +209,7 @@ Options =
   searchEngines: TextOption
   searchUrl: NonEmptyTextOption
   userDefinedLinkHintCss: NonEmptyTextOption
+  allowJavascriptURLs: CheckBoxOption
 
 initOptionsPage = ->
   onUpdated = ->

--- a/pages/options.html
+++ b/pages/options.html
@@ -223,6 +223,21 @@ b: http://b.com/?q=%s description
             </td>
           </tr>
           <tr>
+            <td class="caption"></td>
+            <td verticalAlign="top" class="booleanOption">
+              <div class="help">
+                <div class="example">
+		  Javascript URLs launched by Vimium execute with
+		  Vimium's elevated permissions.
+                </div>
+              </div>
+              <label>
+                <input id="allowJavascriptURLs" type="checkbox"/>
+                Allow Javascript URLs
+              </label>
+            </td>
+          </tr>
+          <tr>
             <td class="caption">Previous patterns</td>
             <td verticalAlign="top">
                 <div class="help">


### PR DESCRIPTION
This is an idea for resolving #3178 (and includes #3167).

1. Wholly disabling Javascript would be unpopular.
2. Apparently as of Chrome 71, `chrome.tabs.update` can no longer be used to open Javascript URLs (hence #3178).
3. #3167 fixes this by using `chrome.tabs.executeScript` instead.
4. Unfortunately, with #3167 the Javascript now executes in Vimium's context, hence with Vimium's elevated permissions.  To enable #3167 behind users' backs would be irresponsible.

So this PR proposes:
- Take #3167 as is, however...
- Disable Javascript URLs, but add an option on the options page for users to re-enable them.

The option looks like this:

![image](https://user-images.githubusercontent.com/2641335/50444513-bef6b500-0900-11e9-9838-8cc14608e8e4.png)

The default (which everybody will inherit) is `false`.

Fixes #3178.
Fixes #3167.