### PR TITLE
Execute "javascript:" URLs by injecting them into the page itself.

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -97,7 +97,11 @@ do ->
 TabOperations =
   # Opens the url in the current tab.
   openUrlInCurrentTab: (request) ->
-    chrome.tabs.update request.tabId, url: Utils.convertToUrl request.url
+    if Utils.hasJavascriptPrefix request.url
+      {tabId, frameId} = request
+      chrome.tabs.sendMessage tabId, {frameId, name: "executeScript", script: request.url}
+    else
+      chrome.tabs.update request.tabId, url: Utils.convertToUrl request.url
 
   # Opens request.url in new tab and switches to it.
   openUrlInNewTab: (request, callback = (->)) ->

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -132,6 +132,7 @@ initializePreDomReady = ->
       NormalModeCommands[registryEntry.command] sourceFrameId, registryEntry if DomUtils.isTopFrame()
     linkHintsMessage: (request) -> HintCoordinator[request.messageType] request
     showMessage: (request) -> HUD.showForDuration request.message, 2000
+    executeScript: (request) -> DomUtils.injectUserScript request.script
 
   chrome.runtime.onMessage.addListener (request, sender, sendResponse) ->
     request.isTrusted = true

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -433,6 +433,13 @@ DomUtils =
       style.textContent = Settings.get "userDefinedLinkHintCss"
       document.head.appendChild style
 
+  # Inject user Javascript.
+  injectUserScript: (text) ->
+    text = text[11..] if text[...11] == "javascript:"
+    script = document.createElement "script"
+    script.textContent = text
+    document.head.appendChild script
+
 root = exports ? (window.root ?= {})
 root.DomUtils = DomUtils
 extend window, root unless exports?


### PR DESCRIPTION
OK, @gdh1995... like this?

Since `chrome.tabs.update()` no longer supports `javascript:` URLs, here we inject them into the page itself.

Replaces #3167.
Replaces #3209.
Fixes #3178.