### PR TITLE
findNext: check last FindMode query correctly

### DIFF
--- a/content_scripts/mode_find.coffee
+++ b/content_scripts/mode_find.coffee
@@ -56,6 +56,7 @@ class PostFindMode extends SuppressPrintable
 class FindMode extends Mode
   @query:
     rawQuery: ""
+    parsedQuery: ""
     matchCount: 0
     hasResults: false
 
@@ -219,12 +220,13 @@ class FindMode extends Mode
 
   @findNext: (backwards) ->
     # Bail out if we don't have any query text.
-    unless FindMode.query.rawQuery and 0 < FindMode.query.rawQuery.length
+    nextQuery = FindMode.getQuery backwards
+    unless nextQuery
       HUD.showForDuration "No query to find.", 1000
       return
 
     Marks.setPreviousPosition()
-    FindMode.query.hasResults = FindMode.execute null, {backwards}
+    FindMode.query.hasResults = FindMode.execute nextQuery, {backwards}
 
     if FindMode.query.hasResults
       focusFoundLink()

--- a/content_scripts/mode_visual.coffee
+++ b/content_scripts/mode_visual.coffee
@@ -300,7 +300,11 @@ class VisualMode extends KeyHandlerMode
   find: (count, backwards) =>
     initialRange = @selection.getRangeAt(0).cloneRange()
     for [0...count] by 1
-      unless FindMode.execute null, {colorSelection: false, backwards}
+      nextQuery = FindMode.getQuery backwards
+      unless nextQuery
+        HUD.showForDuration "No query to find.", 1000
+        return
+      unless FindMode.execute nextQuery, {colorSelection: false, backwards}
         @movement.setSelectionRange initialRange
         HUD.showForDuration("No matches for '#{FindMode.query.rawQuery}'", 1000)
         return


### PR DESCRIPTION
This is to fix #3217 and replace commit 7c77b9bef6720283b04f6253b5e3cec0c7612b15 - the commit checked `FindMode.query.rawQuery` directly and might mistakenly ignore find mode history.