### PR TITLE
delay window.focus() when needed

### DIFF
--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -93,7 +93,7 @@ class UIComponent
                 handler: "sendMessageToFrames",
                 message: name: "focusFrame", frameId: @options.sourceFrameId, forceFocusThisFrame: true
             else
-              Utils.setTimeout 0, -> window.focus()
+              Utils.nextTick -> window.focus()
         @options = null
         @postMessage "hidden" # Inform the UI component that it is hidden.
 

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -93,7 +93,7 @@ class UIComponent
                 handler: "sendMessageToFrames",
                 message: name: "focusFrame", frameId: @options.sourceFrameId, forceFocusThisFrame: true
             else
-              window.focus()
+              Utils.setTimeout 0, -> window.focus()
         @options = null
         @postMessage "hidden" # Inform the UI component that it is hidden.
 

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -232,7 +232,7 @@ Frame =
 setScrollPosition = ({ scrollX, scrollY }) ->
   DomUtils.documentReady ->
     if DomUtils.isTopFrame()
-      Utils.setTimeout 0, ->
+      Utils.nextTick ->
         window.focus()
         document.body.focus()
         if 0 < scrollX or 0 < scrollY
@@ -276,7 +276,7 @@ focusThisFrame = (request) ->
       # next frame instead.  This affects sites like Google Inbox, which have many tiny iframes. See #1317.
       chrome.runtime.sendMessage handler: "nextFrame"
       return
-  Utils.setTimeout 0, ->
+  Utils.nextTick ->
     window.focus()
     # On Firefox, window.focus doesn't always draw focus back from a child frame (bug 554039).
     # We blur the active element if it is an iframe, which gives the window back focus as intended.

--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -232,11 +232,12 @@ Frame =
 setScrollPosition = ({ scrollX, scrollY }) ->
   DomUtils.documentReady ->
     if DomUtils.isTopFrame()
-      window.focus()
-      document.body.focus()
-      if 0 < scrollX or 0 < scrollY
-        Marks.setPreviousPosition()
-        window.scrollTo scrollX, scrollY
+      Utils.setTimeout 0, ->
+        window.focus()
+        document.body.focus()
+        if 0 < scrollX or 0 < scrollY
+          Marks.setPreviousPosition()
+          window.scrollTo scrollX, scrollY
 
 flashFrame = do ->
   highlightedFrameElement = null
@@ -275,11 +276,12 @@ focusThisFrame = (request) ->
       # next frame instead.  This affects sites like Google Inbox, which have many tiny iframes. See #1317.
       chrome.runtime.sendMessage handler: "nextFrame"
       return
-  window.focus()
-  # On Firefox, window.focus doesn't always draw focus back from a child frame (bug 554039).
-  # We blur the active element if it is an iframe, which gives the window back focus as intended.
-  document.activeElement.blur() if document.activeElement.tagName.toLowerCase() == "iframe"
-  flashFrame() if request.highlight
+  Utils.setTimeout 0, ->
+    window.focus()
+    # On Firefox, window.focus doesn't always draw focus back from a child frame (bug 554039).
+    # We blur the active element if it is an iframe, which gives the window back focus as intended.
+    document.activeElement.blur() if document.activeElement.tagName.toLowerCase() == "iframe"
+    flashFrame() if request.highlight
 
 # Used by focusInput command.
 root.lastFocusedInput = do ->


### PR DESCRIPTION
On Chrome, if an extension's content script call window.focus()
  during Port.onMessage handlers, then Chrome will activate the tab.
Therefore there's a race condition between:
* `tabs.update(tabId, {active:true}` in `main.coffee`
* and `focusThisFrame -> window.focus()` in `vimium_frontend.coffee`

In my tests, a `setTimeout` is just enough to avoid this activating, so this PR should fix #3242.