### PR TITLE
show a log in console if grabBackFocus intercepts a focus

### DIFF
--- a/content_scripts/vimium_frontend.coffee
+++ b/content_scripts/vimium_frontend.coffee
@@ -34,6 +34,7 @@ bgLog = (args...) ->
 # If an input grabs the focus before the user has interacted with the page, then grab it back (if the
 # grabBackFocus option is set).
 class GrabBackFocus extends Mode
+  logged: false
 
   constructor: ->
     exitEventHandler = =>
@@ -73,6 +74,9 @@ class GrabBackFocus extends Mode
 
   grabBackFocus: (element) ->
     return @continueBubbling unless DomUtils.isFocusable element
+    unless @logged or element == document.body
+      @logged = true
+      console.log "An auto-focusing action is blocked by Vimium"
     element.blur()
     @suppressEvent
 


### PR DESCRIPTION
This is a small cookie and let a web developer know why his/her "auto-focus" code fails. I think it's better than blurring all and keeping silent.

This should also help those in troubles like #3251.