### PR TITLE
fix broken copy, paste and showFindMode since Chrome 74

### DIFF
--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -33,6 +33,7 @@ HUD =
   showFindMode: (@findMode = null) ->
     DomUtils.documentComplete =>
       @init()
+      @hudUI.toggleIframeElementClasses "vimiumUIComponentHidden", "vimiumUIComponentVisible"
       @hudUI.activate name: "showFindMode"
       @tween.fade 1.0, 150
 
@@ -92,7 +93,8 @@ HUD =
   copyToClipboard: (text) ->
     DomUtils.documentComplete =>
       @init()
-      @hudUI?.postMessage {name: "copyToClipboard", data: text}
+      @hudUI.toggleIframeElementClasses "vimiumUIComponentHidden", "vimiumUIComponentVisible"
+      @hudUI.postMessage {name: "copyToClipboard", data: text}
 
   pasteFromClipboard: (@pasteListener) ->
     DomUtils.documentComplete =>

--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -93,6 +93,7 @@ HUD =
   copyToClipboard: (text) ->
     DomUtils.documentComplete =>
       @init()
+      # Chrome 74 only acknowledges text selection when a frame has been visible. See more in #3277 .
       @hudUI.toggleIframeElementClasses "vimiumUIComponentHidden", "vimiumUIComponentVisible"
       @hudUI.postMessage {name: "copyToClipboard", data: text}
 

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -8,7 +8,10 @@ class UIComponent
 
   toggleIframeElementClasses: (removeClass, addClass) ->
     @iframeElement.classList.remove removeClass
-    @iframeElement.classList.add addClass
+    unless @iframeElement.classList.contains addClass
+      @iframeElement.classList.add addClass
+      if addClass == "vimiumUIComponentVisible"
+        getComputedStyle(@iframeElement).display
 
   constructor: (iframeUrl, className, @handleMessage) ->
     DomUtils.documentReady =>

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -11,6 +11,9 @@ class UIComponent
     unless @iframeElement.classList.contains addClass
       @iframeElement.classList.add addClass
       if addClass == "vimiumUIComponentVisible"
+        # Force to re-compute styles, so Chrome sends a visibility change message to the child frame at once.
+        # This block is to solve focusing issues since Chrome 74, and detailed explanation and trace is in
+        # https://github.com/philc/vimium/pull/3277#issuecomment-487363284
         getComputedStyle(@iframeElement).display
 
   constructor: (iframeUrl, className, @handleMessage) ->

--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -86,7 +86,7 @@ handlers =
     countElement.id = "hud-match-count"
     countElement.style.float = "right"
     hud.appendChild countElement
-    inputElement.focus()
+    Utils.setTimeout 0, -> inputElement.focus()
 
     findMode =
       historyIndex: -1
@@ -104,14 +104,14 @@ handlers =
       " (No matches)"
     countElement.textContent = if showMatchText then countText else ""
 
-  copyToClipboard: (data) ->
+  copyToClipboard: (data) -> Utils.setTimeout 0, ->
     focusedElement = document.activeElement
     Clipboard.copy data
     focusedElement?.focus()
     window.parent.focus()
     UIComponentServer.postMessage {name: "unfocusIfFocused"}
 
-  pasteFromClipboard: ->
+  pasteFromClipboard: -> Utils.setTimeout 0, ->
     focusedElement = document.activeElement
     data = Clipboard.paste()
     focusedElement?.focus()

--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -86,7 +86,7 @@ handlers =
     countElement.id = "hud-match-count"
     countElement.style.float = "right"
     hud.appendChild countElement
-    Utils.setTimeout 0, -> inputElement.focus()
+    Utils.setTimeout 17, -> inputElement.focus()
 
     findMode =
       historyIndex: -1
@@ -104,14 +104,14 @@ handlers =
       " (No matches)"
     countElement.textContent = if showMatchText then countText else ""
 
-  copyToClipboard: (data) -> Utils.setTimeout 0, ->
+  copyToClipboard: (data) -> Utils.setTimeout 17, ->
     focusedElement = document.activeElement
     Clipboard.copy data
     focusedElement?.focus()
     window.parent.focus()
     UIComponentServer.postMessage {name: "unfocusIfFocused"}
 
-  pasteFromClipboard: -> Utils.setTimeout 0, ->
+  pasteFromClipboard: -> Utils.setTimeout 17, ->
     focusedElement = document.activeElement
     data = Clipboard.paste()
     focusedElement?.focus()

--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -1,5 +1,11 @@
 findMode = null
 
+# Chrome creates a unique port for each MessageChannel,
+# so there's a race condition between JavaScript messages of Vimium and browser messages during style recomputation.
+# This constant is to ensure all messages have been received and handled
+# See more in https://github.com/philc/vimium/pull/3277#discussion_r283080348
+TIME_TO_WAIT_FOR_IPC_MESSAGES = 17
+
 # Set the input element's text, and move the cursor to the end.
 setTextInInputElement = (inputElement, text) ->
   inputElement.textContent = text
@@ -86,7 +92,7 @@ handlers =
     countElement.id = "hud-match-count"
     countElement.style.float = "right"
     hud.appendChild countElement
-    Utils.setTimeout 17, -> inputElement.focus()
+    Utils.setTimeout TIME_TO_WAIT_FOR_IPC_MESSAGES, -> inputElement.focus()
 
     findMode =
       historyIndex: -1
@@ -104,14 +110,14 @@ handlers =
       " (No matches)"
     countElement.textContent = if showMatchText then countText else ""
 
-  copyToClipboard: (data) -> Utils.setTimeout 17, ->
+  copyToClipboard: (data) -> Utils.setTimeout TIME_TO_WAIT_FOR_IPC_MESSAGES, ->
     focusedElement = document.activeElement
     Clipboard.copy data
     focusedElement?.focus()
     window.parent.focus()
     UIComponentServer.postMessage {name: "unfocusIfFocused"}
 
-  pasteFromClipboard: -> Utils.setTimeout 17, ->
+  pasteFromClipboard: -> Utils.setTimeout TIME_TO_WAIT_FOR_IPC_MESSAGES, ->
     focusedElement = document.activeElement
     data = Clipboard.paste()
     focusedElement?.focus()


### PR DESCRIPTION
During tests I found that a setTimeout is needed, ~~although I haven't found why~~.

This can fix #3260, fix #3292, fix #3297, fix #3298, fix #3302, fix #3307, fix #3311, fix #3313 and fix #3315 .