### PR TITLE
add 'dblclick' event to simulateClick

### DIFF
--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -247,7 +247,7 @@ DomUtils =
             element.setSelectionRange element.value.length, element.value.length
 
   simulateClick: (element, modifiers = {}) ->
-    eventSequence = ["mouseover", "mousedown", "mouseup", "click"]
+    eventSequence = ["mouseover", "mousedown", "mouseup", "click", "dblclick"]
     for event in eventSequence
       defaultActionShouldTrigger =
         if Utils.isFirefox() and Object.keys(modifiers).length == 0 and event == "click" and


### PR DESCRIPTION
Would close #3281.

The rationale behind this is that most places aren't listening for
'dblclick', and the ones that are (https://open.spotify.com is the only
one I can find) don't respond to single clicks.