### PR TITLE
Fixed Reddit scrolling

### DIFF
--- a/content_scripts/scroller.coffee
+++ b/content_scripts/scroller.coffee
@@ -327,6 +327,7 @@ specialScrollingElementMap =
   'twitter.com': 'div.permalink-container div.permalink[role=main]'
   'reddit.com': '#overlayScrollContainer'
   'new.reddit.com': '#overlayScrollContainer'
+  'www.reddit.com': '#overlayScrollContainer'
 
 root = exports ? (window.root ?= {})
 root.Scroller = Scroller


### PR DESCRIPTION
Vimium handles scrolling on reddit's redesign by applying special properties to the site. These properties have been applied to reddit.com and new.reddit.com, but not www.reddit.com. I added this to the special list.

I didn't run the technical tests mentioned in CONTRIBUTING.md because my computer doesn't know what npm is, but I figured it wasn't necessary for such a small fix.

I did change the relevant .json file in the source installed on my computer, and tested scrolling, It worked perfectly.

This should solve Issue  #3119 and Issue #3295 (and possibly other duplicate issues).

Thanks for your consideration.