### PR TITLE
Disabled Custom CSS for Vimium UI option

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -33,6 +33,7 @@ Contributors:
   Murph (github: pandeiro)
   Niklas Baumstark <niklas.baumstark@gmail.com> (github: niklasb)
   rodimius
+  Shawn Berg <bergshawnm@gmail.com> (github: bergsm)
   Stephen Blott (github: smblott-github)
   Svein-Erik Larsen <feinom@gmail.com> (github: feinom)
   Tim Morgan <tim@timmorgan.org> (github: seven1m)

--- a/pages/options.coffee
+++ b/pages/options.coffee
@@ -208,7 +208,7 @@ Options =
   grabBackFocus: CheckBoxOption
   searchEngines: TextOption
   searchUrl: NonEmptyTextOption
-  userDefinedLinkHintCss: NonEmptyTextOption
+  #userDefinedLinkHintCss: NonEmptyTextOption
 
 initOptionsPage = ->
   onUpdated = ->

--- a/pages/options.html
+++ b/pages/options.html
@@ -271,6 +271,8 @@ b: http://b.com/?q=%s description
                 <div class="nonEmptyTextOption">
             </td>
           </tr>
+        <!-- CSS for Vimium UI -->
+        <!-- Disabled but leaving the code here in case the feature is requested again
           <tr>
             <td class="caption">CSS for Vimium UI</td>
             <td verticalAlign="top">
@@ -286,7 +288,7 @@ b: http://b.com/?q=%s description
               <div class="nonEmptyTextOption">
             </td>
           </tr>
-
+          -->
           <!-- Vimium Labs -->
           <!--
           Disabled.  But we leave this code here as a template for the next time we need to introduce "Vimium Labs".


### PR DESCRIPTION
This commit disables the Custom CSS for link hints feature from the
advanced options menu, but leaves the code in place.

I ran the tests mentioned in CONTRIBUTING.md and received results identical to the current version. 

This should resolve issue #636. It's an old issue, so I understand if it is no longer relevant.

Thanks for your consideration and let me know if I need to make any changes!