### PR TITLE
fix a crash on network errors

### DIFF
--- a/background_scripts/completion_search.coffee
+++ b/background_scripts/completion_search.coffee
@@ -48,18 +48,12 @@ CompletionSearch =
     xhr = new XMLHttpRequest()
     xhr.open "GET", url, true
     xhr.timeout = 2500
-    finished = 0
-    # Note(gdh1995): Maybe the 2 events below are not needed, but I just leave it unchanged for robustness
-    xhr.ontimeout = xhr.onerror = ->
-      finished++
-      if finished == 1
-        callback null
-
+    # According to https://xhr.spec.whatwg.org/#request-error-steps,
+    # readystatechange always gets called whether a request succeeds or not,
+    # and the `readyState == 4` means an associated `state` is "done", which is true even if any error happens
     xhr.onreadystatechange = ->
       if xhr.readyState == 4
-        finished++
-        if finished == 1
-          callback if xhr.status == 200 then xhr else null
+        callback if xhr.status == 200 then xhr else null
     xhr.send()
 
   # Look up the completion engine for this searchUrl.  Because of DummyCompletionEngine, we know there will

--- a/background_scripts/completion_search.coffee
+++ b/background_scripts/completion_search.coffee
@@ -48,12 +48,19 @@ CompletionSearch =
     xhr = new XMLHttpRequest()
     xhr.open "GET", url, true
     xhr.timeout = 2500
-    xhr.ontimeout = xhr.onerror = -> callback null
-    xhr.send()
+    finished = 0
+    # Note(gdh1995): Maybe the 2 events below are not needed, but I just leave it unchanged for robustness
+    xhr.ontimeout = xhr.onerror = ->
+      finished++
+      if finished == 1
+        callback null
 
     xhr.onreadystatechange = ->
       if xhr.readyState == 4
-        callback if xhr.status == 200 then xhr else null
+        finished++
+        if finished == 1
+          callback if xhr.status == 200 then xhr else null
+    xhr.send()
 
   # Look up the completion engine for this searchUrl.  Because of DummyCompletionEngine, we know there will
   # always be a match.


### PR DESCRIPTION
I think #3380 is because some code might call `fetch's callback` in `AsyncDataFetcher` twice, and after reviewing code I find such a bug may be to blame.

Although this fix may be not enough, it does no harm and can be merged directly.