### PR TITLE
Fixed failing build by rewriting path.join call in phantom_runner

### DIFF
--- a/tests/dom_tests/phantom_runner.coffee
+++ b/tests/dom_tests/phantom_runner.coffee
@@ -21,7 +21,7 @@ page.onError = (msg, trace) ->
 page.onResourceError = (resourceError) ->
   console.log(resourceError.errorString)
 
-testfile = path.join(path.dirname(system.args[0]), 'dom_tests.html')
+testfile = path.dirname(system.args[0]) + '/dom_tests.html'
 page.open testfile, (status) ->
   if status != 'success'
     console.log 'Unable to load tests.'


### PR DESCRIPTION
Builds have been failing for a while due to some issue inside the path/util modules. A better solution would be to figure out what the issue with util.isString was, but I couldn't figure that out and this still works for joining paths ;)