### PR TITLE
FindMode: clear focus of HUD iframe on exit

### DIFF
--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -5,7 +5,6 @@
 HUD =
   tween: null
   hudUI: null
-  _displayElement: null
   findMode: null
   abandon: -> @hudUI?.hide false
 
@@ -113,6 +112,11 @@ HUD =
 
   unfocusIfFocused: ->
     document.activeElement.blur() if document.activeElement == @hudUI?.iframeElement
+
+  clearFocus: ->
+    if @hudUI?.showing
+      @hudUI.iframeElement.blur()
+      window.focus()
 
 class Tween
   opacity: 0

--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -111,9 +111,6 @@ HUD =
     @pasteListener data
 
   unfocusIfFocused: ->
-    document.activeElement.blur() if document.activeElement == @hudUI?.iframeElement
-
-  giveUpFocus: ->
     # On Firefox, if an <iframe> disappears when it's focused, then it will keep "focused",
     # which means keyboard events will always be dispatched to the HUD iframe
     if @hudUI?.showing

--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -114,7 +114,9 @@ HUD =
     document.activeElement.blur() if document.activeElement == @hudUI?.iframeElement
 
   giveUpFocus: ->
-    if @hudUI.showing
+    # On Firefox, if an <iframe> disappears when it's focused, then it will keep "focused",
+    # which means keyboard events will always be dispatched to the HUD iframe
+    if @hudUI?.showing
       @hudUI.iframeElement.blur()
       window.focus()
 

--- a/content_scripts/hud.coffee
+++ b/content_scripts/hud.coffee
@@ -113,8 +113,8 @@ HUD =
   unfocusIfFocused: ->
     document.activeElement.blur() if document.activeElement == @hudUI?.iframeElement
 
-  clearFocus: ->
-    if @hudUI?.showing
+  giveUpFocus: ->
+    if @hudUI.showing
       @hudUI.iframeElement.blur()
       window.focus()
 

--- a/content_scripts/mode_find.coffee
+++ b/content_scripts/mode_find.coffee
@@ -78,6 +78,7 @@ class FindMode extends Mode
     HUD.showFindMode this
 
   exit: (event) ->
+    HUD.giveUpFocus()
     super()
     FindMode.handleEscape() if event
 

--- a/content_scripts/mode_find.coffee
+++ b/content_scripts/mode_find.coffee
@@ -78,7 +78,7 @@ class FindMode extends Mode
     HUD.showFindMode this
 
   exit: (event) ->
-    HUD.giveUpFocus()
+    HUD.unfocusIfFocused()
     super()
     FindMode.handleEscape() if event
 


### PR DESCRIPTION
On Firefox, if an `<iframe>` disappears when it's focused, then it will keep focused. This feature has caused the 2nd problem in #3245 .

This PR should fix #3245 , and it works well on my Firefox 69 (stable x64) + Win 10.

As for Firefox 67, there's still some incorrect results about colors of selection text after FindMode has exited, but I think it's because of inner bugs of Firefox - this PR works well enough on Firefox 69...

