### PR TITLE
another solution to fix enterFindMode can not grab focus

### DIFF
--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -91,7 +91,9 @@ handlers =
     countElement.id = "hud-match-count"
     countElement.style.float = "right"
     hud.appendChild countElement
-    Utils.setTimeout TIME_TO_WAIT_FOR_IPC_MESSAGES, -> inputElement.focus()
+    Utils.setTimeout TIME_TO_WAIT_FOR_IPC_MESSAGES, ->
+      window.focus() # on Firefox this line grabs focus back to this HUD
+      inputElement.focus()
 
     findMode =
       historyIndex: -1


### PR DESCRIPTION
This is to fix #3106 and replace #3127.

Compared with #3127, this PR is more acurate since the old one only grabs focus before HUD begins to load.