### PR TITLE
Better position for create tab

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -116,7 +116,7 @@ TabOperations =
     switch position
       when "start" then tabIndex = 0
       when "before" then tabIndex = request.tab.index
-      when "end" then tabIndex = null
+      when "end" then tabIndex = (if Utils.isFirefox() then 9999 else null)
       # "after" is the default case when there are no options.
       else tabIndex = request.tab.index + 1
     tabConfig.index = tabIndex

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -116,6 +116,8 @@ TabOperations =
     switch position
       when "start" then tabIndex = 0
       when "before" then tabIndex = request.tab.index
+      # if on Chrome or on Firefox but without openerTabId, `tabs.create` opens a tab at the end.
+      # but on Firefox and with openerTabId, it opens a new tab next to the opener tab
       when "end" then tabIndex = (if Utils.isFirefox() then 9999 else null)
       # "after" is the default case when there are no options.
       else tabIndex = request.tab.index + 1
@@ -130,6 +132,7 @@ TabOperations =
     tabConfig.openerTabId = request.tab.id if canUseOpenerTabId
 
     chrome.tabs.create tabConfig, (tab) ->
+      # clean position and active, so following `openUrlInNewTab(request)` will create a tab just next to this new tab
       callback extend request, {tab, tabId: tab.id, position: "", active: false}
 
   # Opens request.url in new window and switches to it.

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -130,7 +130,7 @@ TabOperations =
     tabConfig.openerTabId = request.tab.id if canUseOpenerTabId
 
     chrome.tabs.create tabConfig, (tab) ->
-      callback extend request, {tab, tabId: tab.id}
+      callback extend request, {tab, tabId: tab.id, position: "", active: false}
 
   # Opens request.url in new window and switches to it.
   openUrlInNewWindow: (request, callback = (->)) ->
@@ -217,10 +217,10 @@ BackgroundCommands =
       chrome.windows.create windowConfig, -> callback request
     else
       urls = request.urls[..].reverse()
-      position = request.registryEntry.options.position
+      request.position ?= request.registryEntry.options.position
       do openNextUrl = (request) ->
         if 0 < urls.length
-          TabOperations.openUrlInNewTab (extend request, {url: urls.pop(), position}), openNextUrl
+          TabOperations.openUrlInNewTab (extend request, {url: urls.pop()}), openNextUrl
         else
           callback request
   duplicateTab: mkRepeatCommand (request, callback) ->


### PR DESCRIPTION
On Chrome the default action of `chrome.tabs.createTab` when `position=null` is to open at the end of tabs, but on Firefox it isn't. So this PR fixes it.

@philc See https://github.com/philc/vimium/issues/2893#issuecomment-572889467. And this PR has been well-tested.