### PR TITLE
Fix broken documentComplete

### DIFF
--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -18,7 +18,8 @@ DomUtils =
     [isComplete, callbacks] = [document.readyState == "complete", []]
     unless isComplete
       window.addEventListener "load", (onLoad = forTrusted (event) ->
-        return unless event.target == window
+        # The target is ensured to be on document. See https://w3c.github.io/uievents/#event-type-load
+        return unless event.target == document
         window.removeEventListener "load", onLoad, true
         isComplete = true
         callback() for callback in callbacks


### PR DESCRIPTION
This fixes a typo bug in #3403, which has made the HUD and help dialog disappear.

According to the specifications, a page's final "load" event will always be dispatched onto `document`.