### PR TITLE
fix a typo influencing HelpDialog and LinkHints

### DIFF
--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -343,6 +343,7 @@ Frames =
 
   registerFrame: ({tabId, frameId, port}) ->
     frameIdsForTab[tabId].push frameId unless frameId in frameIdsForTab[tabId] ?= []
+    (portsForTab[tabId] ?= {})[frameId] = port
 
   unregisterFrame: ({tabId, frameId, port}) ->
     # Check that the port trying to unregister the frame hasn't already been replaced by a new frame


### PR DESCRIPTION
Commit 43c7390f987fea063e7a97cd8b37c7b61d45f615 makes
HelpDialog can not be hinted by LinkHints if only it had been hidden before.

This fixes #3470.