### PR TITLE
fix broken isFirefox on pages/*

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -372,7 +372,7 @@ class LinkHintsMode
             Utils.nextTick -> focusThisFrame highlight: true
           else if localHintDescriptor.reason == "Scroll."
             # Tell the scroller that this is the activated element.
-            handlerStack.bubbleEvent "DOMActivate", target: clickEl
+            handlerStack.bubbleEvent (if Utils.isFirefox() then "click" else "DOMActivate"), target: clickEl
           else if localHintDescriptor.reason == "Open."
             clickEl.open = !clickEl.open
           else if DomUtils.isSelectable clickEl

--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -72,6 +72,8 @@ class UIComponent
                 when "setIframeFrameId" then @iframeFrameId = event.data.iframeFrameId
                 when "hide" then @hide()
                 else @handleMessage event
+      if Utils.isFirefox()
+          @postMessage name: "settings", isFirefox: true
 
   # Post a message (if provided), then call continuation (if provided).  We wait for documentReady() to ensure
   # that the @iframePort set (so that we can use @iframePort.use()).

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -11,7 +11,7 @@ browserInfo = browser?.runtime?.getBrowserInfo?()
 Utils =
   isFirefox: do ->
     # NOTE(mrmr1993): This test only works in the background page, this is overwritten by isEnabledForUrl for
-    # content scripts.
+    # content scripts, and the "settings" message from UIComponent is for pages like HUD.
     isFirefox = false
     browserInfo?.then? (browserInfo) ->
       isFirefox = browserInfo?.name == "Firefox"

--- a/pages/hud.coffee
+++ b/pages/hud.coffee
@@ -127,5 +127,7 @@ handlers =
     window.parent.focus()
     UIComponentServer.postMessage {name: "pasteResponse", data}
 
+  settings: ({ isFirefox }) -> Utils.isFirefox = -> isFirefox
+
 UIComponentServer.registerHandler ({data}) -> handlers[data.name ? data]? data
 FindModeHistory.init()


### PR DESCRIPTION
The commit 9005144cd02fab59577c24f50aae279f4160ce06 which modified #3460 may not work, because `Utils.isFirefox` was always `false` unless in Vimium's background / content_scripts page. So this PR passes the result of `isFirefox` from content scripts to `pages/*.html`, including the HUD.

