### PR TITLE
make message hud non-clickable

### DIFF
--- a/content_scripts/ui_component.coffee
+++ b/content_scripts/ui_component.coffee
@@ -10,11 +10,6 @@ class UIComponent
     @iframeElement.classList.remove removeClass
     unless @iframeElement.classList.contains addClass
       @iframeElement.classList.add addClass
-      if addClass == "vimiumUIComponentVisible"
-        # Force the re-computation of styles, so Chrome sends a visibility change message to the child frame.
-        # This is required to solve focusing issues since Chrome 74. See
-        # https://github.com/philc/vimium/pull/3277#issuecomment-487363284
-        getComputedStyle(@iframeElement).display
 
   constructor: (iframeUrl, className, @handleMessage) ->
     DomUtils.documentReady =>

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -330,7 +330,7 @@ iframe.vimiumHUDFrame {
   right: 20px;
   margin: 0 0 0 -40%;
   border: none;
-  z-index: 2149999998; /* Two less than the reference value. */
+  z-index: 2139999998; /* Two less than the reference value. */
   opacity: 0;
 }
 
@@ -407,7 +407,7 @@ iframe.vomnibarFrame {
   margin: 0 0 0 -40%;
   border: none;
   font-family: sans-serif;
-  z-index: 2149999998; /* Two less than the reference value. */
+  z-index: 2139999998; /* Two less than the reference value. */
 }
 
 div.vimiumFlash {
@@ -429,4 +429,8 @@ iframe.vimiumUIComponentVisible {
 
 iframe.vimiumUIComponentReactivated {
   border: 5px solid yellow;
+}
+
+iframe.vimiumNonClickable {
+  pointer-events: none;
 }

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -413,8 +413,9 @@ DomUtils =
     if not node?
       return null
     if node == sel.anchorNode and sel.focusOffset == sel.anchorOffset
-      # The selection either *is* an element, or is inside an opaque element (eg. <input>).
-      node = node.childNodes[sel.focusOffset]
+      # If the selection is not a caret inside a `#text`, which has no child nodes,
+      # then it either *is* an element, or is inside an opaque element (eg. <input>).
+      node = node.childNodes[sel.focusOffset] || node
     if node.nodeType != Node.ELEMENT_NODE then node.parentElement else node
 
   # Get the element in the DOM hierachy that contains `element`.


### PR DESCRIPTION
This fixes #3496 by giving message HUD `pointer-events: none` to remove it from the result list of `document.elementsFromPoint`.

Also collect code abouting HUD's visibility changes, just for clear logic. I think this should have no impact on Vomnibar and tests has passed on Chrome 80.0.3987.106 and 74.0.3729.169 (x64 version) on my Win 10.