### PR TITLE
Send mouse events that bubble across shadow DOM

### DIFF
--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -282,9 +282,17 @@ DomUtils =
         @simulateMouseEvent "mouseout", undefined, modifiers
         lastHoveredElement = element
 
-      mouseEvent = document.createEvent("MouseEvents")
-      mouseEvent.initMouseEvent(event, true, true, window, 1, 0, 0, 0, 0, modifiers.ctrlKey, modifiers.altKey,
-      modifiers.shiftKey, modifiers.metaKey, 0, null)
+      mouseEvent = new MouseEvent event, {
+        bubbles: true
+        cancelable: true
+        composed: true
+        view: window
+        detail: 1
+        ctrlKey: modifiers.ctrlKey
+        altKey: modifiers.altKey
+        shiftKey: modifiers.shiftKey
+        metaKey: modifiers.metaKey
+      }
       # Debugging note: Firefox will not execute the element's default action if we dispatch this click event,
       # but Webkit will. Dispatching a click on an input box does not seem to focus it; we do that separately
       element.dispatchEvent(mouseEvent)


### PR DESCRIPTION
The latest version of Gerrit has been redesigned so that the link elements don't actually handle mouse events. They're instead handled by other elements a few layers of shadow DOM up. Events created by initMouseEvent don't have `composed` set, so they won't bubble up shadow DOM. This sets `composed` using the MouseEvent constructor.

Also initMouseEvent is deprecated according to MDN.

Link: https://fuchsia-review.googlesource.com/