### PR TITLE
link reachability: pass <area>

### DIFF
--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -658,7 +658,7 @@ LocalHints =
         map = document.querySelector "map[name=\"#{mapName}\"]"
         if map and imgClientRects.length > 0
           areas = map.getElementsByTagName "area"
-          areasAndRects = DomUtils.getClientRectsForAreas imgClientRects[0], areas
+          areasAndRects = DomUtils.getClientRectsForAreas imgClientRects[0], areas, element
           visibleElements.push areasAndRects...
 
     # Check aria properties to see if the element should be ignored.
@@ -851,6 +851,11 @@ LocalHints =
       # Check middle of element first, as this is perhaps most likely to return true.
       elementFromMiddlePoint = LocalHints.getElementFromPoint(rect.left + (rect.width * 0.5), rect.top + (rect.height * 0.5))
       if elementFromMiddlePoint && (element.contains(elementFromMiddlePoint) or elementFromMiddlePoint.contains(element))
+        nonOverlappingElements.push visibleElement
+        continue
+      if elementFromMiddlePoint && element.localName == "area" && elementFromMiddlePoint == visibleElement.image
+        # Sometimes root.elementsFromPoint returns the bound <img> instead of an <area>, see #3493
+        # Note: This ignores covering among a group of <area>s, which should have very little impact
         nonOverlappingElements.push visibleElement
         continue
 

--- a/lib/dom_utils.coffee
+++ b/lib/dom_utils.coffee
@@ -155,7 +155,7 @@ DomUtils =
   # Get the client rects for the <area> elements in a <map> based on the position of the <img> element using
   # the map. Returns an array of rects.
   #
-  getClientRectsForAreas: (imgClientRect, areas) ->
+  getClientRectsForAreas: (imgClientRect, areas, imgElement) ->
     rects = []
     for area in areas
       coords = area.coords.split(",").map((coord) -> parseInt(coord, 10))
@@ -179,7 +179,7 @@ DomUtils =
       rect = Rect.translate (Rect.create x1, y1, x2, y2), imgClientRect.left, imgClientRect.top
       rect = @cropRectToVisible rect
 
-      rects.push {element: area, rect: rect} if rect and not isNaN rect.top
+      rects.push {element: area, rect: rect, image: imgElement} if rect and not isNaN rect.top
     rects
 
   #


### PR DESCRIPTION
This fixes #3493 by passing <area> elements and ignoring a small edge case.

Tested on Chrome 80 and Firefox 72, Win 10 x64.