### PR TITLE
Add LinkHints.activateModeToOpenInNewWindow command - open a link in a new window

### DIFF
--- a/background_scripts/commands.coffee
+++ b/background_scripts/commands.coffee
@@ -220,6 +220,7 @@ Commands =
     "Vomnibar.activateEditUrlInNewTab",
     "LinkHints.activateModeToOpenIncognito",
     "LinkHints.activateModeToCopyLinkUrl",
+    "LinkHints.activateModeToOpenInNewWindow",
     "goNext",
     "goPrevious",
     "Marks.activateCreateMode",
@@ -357,6 +358,7 @@ commandDescriptions =
   "LinkHints.activateModeToOpenIncognito": ["Open a link in incognito window"]
   "LinkHints.activateModeToDownloadLink": ["Download link url"]
   "LinkHints.activateModeToCopyLinkUrl": ["Copy a link URL to the clipboard"]
+  "LinkHints.activateModeToOpenInNewWindow": ["Open in a new window"]
 
   enterFindMode: ["Enter find mode", { noRepeat: true }]
   performFind: ["Cycle forward to the next find match"]

--- a/background_scripts/main.coffee
+++ b/background_scripts/main.coffee
@@ -136,15 +136,9 @@ TabOperations =
       # clean position and active, so following `openUrlInNewTab(request)` will create a tab just next to this new tab
       callback extend request, {tab, tabId: tab.id, position: "", active: false}
 
-  # Opens request.url in new window and switches to it.
+  # Opens request.url in new window
   openUrlInNewWindow: (request, callback = (->)) ->
-    winConfig =
-      url: Utils.convertToUrl request.url
-      active: true
-    winConfig.active = request.active if request.active?
-    # Firefox does not support "about:newtab" in chrome.tabs.create.
-    delete winConfig["url"] if winConfig["url"] == Settings.defaults.newTabUrl
-    chrome.windows.create winConfig, callback
+    chrome.windows.create url: Utils.convertToUrl request.url
 
 toggleMuteTab = do ->
   muteTab = (tab) -> chrome.tabs.update tab.id, {muted: !tab.mutedInfo.muted}

--- a/content_scripts/link_hints.coffee
+++ b/content_scripts/link_hints.coffee
@@ -65,9 +65,13 @@ FOCUS_LINK =
   name: "focus"
   indicator: "Focus link"
   linkActivator: (link) -> link.focus()
+OPEN_WINDOW =
+  name: "window"
+  indicator: "Open link in a new window"
+  linkActivator: (link) -> chrome.runtime.sendMessage handler: 'openUrlInNewWindow', url: link.href
 
 availableModes = [OPEN_IN_CURRENT_TAB, OPEN_IN_NEW_BG_TAB, OPEN_IN_NEW_FG_TAB, OPEN_WITH_QUEUE, COPY_LINK_URL,
-  OPEN_INCOGNITO, DOWNLOAD_LINK_URL, COPY_LINK_TEXT, HOVER_LINK, FOCUS_LINK]
+  OPEN_INCOGNITO, DOWNLOAD_LINK_URL, COPY_LINK_TEXT, HOVER_LINK, FOCUS_LINK, OPEN_WINDOW]
 
 HintCoordinator =
   onExit: []
@@ -165,6 +169,7 @@ LinkHints =
   activateModeWithQueue: -> @activateMode 1, mode: OPEN_WITH_QUEUE
   activateModeToOpenIncognito: (count) -> @activateMode count, mode: OPEN_INCOGNITO
   activateModeToDownloadLink: (count) -> @activateMode count, mode: DOWNLOAD_LINK_URL
+  activateModeToOpenInNewWindow: (count) -> @activateMode count, mode: OPEN_WINDOW
 
 class LinkHintsMode
   hintMarkerContainingDiv: null

--- a/content_scripts/mode_normal.coffee
+++ b/content_scripts/mode_normal.coffee
@@ -206,6 +206,7 @@ if LinkHints?
     "LinkHints.activateModeToOpenIncognito": LinkHints.activateModeToOpenIncognito.bind LinkHints
     "LinkHints.activateModeToDownloadLink": LinkHints.activateModeToDownloadLink.bind LinkHints
     "LinkHints.activateModeToCopyLinkUrl": LinkHints.activateModeToCopyLinkUrl.bind LinkHints
+    "LinkHints.activateModeToOpenInNewWindow": LinkHints.activateModeToOpenInNewWindow.bind LinkHints
 
 if Vomnibar?
   extend NormalModeCommands,


### PR DESCRIPTION
This adds a new mode that can be mapped: "LinkHints.activateModeToOpenInNewWindow". When mapped, this opens a link in a new window with focus. Works in both latest chrome and firefox.
Removed seemingly irrelevant code from the existing `openUrlInNewWindow` function.