### PR TITLE
Fix visual mode caret mode fallback

### DIFF
--- a/content_scripts/mode_visual.js
+++ b/content_scripts/mode_visual.js
@@ -318,7 +318,7 @@ class VisualMode extends KeyHandlerMode {
       }
 
       if ((DomUtils.getSelectionType(this.selection) !== "Range") && (this.name !== "caret")) {
-        new CaretMode();
+        new CaretMode().init();
         return HUD.showForDuration("No usable selection, entering caret mode...", 2500);
       }
     }


### PR DESCRIPTION
This fixes #3568

I tried to uncomment the test for this but I got
```
Pass (169/169)
(node:22315) [DEP0016] DeprecationWarning: 'root' is deprecated, use 'global'
Fail "Caret mode: enter caret mode" -  RangeError: Maximum call stack size exceeded
RangeError: Maximum call stack size exceeded
    at getSelection (file:///home/kingfisher/workspace/vimium/tests/dom_tests/dom_test_setup.js:7:25)
    at getSelection (file:///home/kingfisher/workspace/vimium/tests/dom_tests/dom_test_setup.js:7:10)
    at getSelection (file:///home/kingfisher/workspace/vimium/tests/dom_tests/dom_test_setup.js:7:10)
    at getSelection (file:///home/kingfisher/workspace/vimium/tests/dom_tests/dom_test_setup.js:7:10)
    at getSelection (file:///home/kingfisher/workspace/vimium/tests/dom_tests/dom_test_setup.js:7:10)
    at getSelection (file:///home/kingfisher/workspace/vimium/tests/dom_tests/dom_test_setup.js:7:10)
    at getSelection (file:///home/kingfisher/workspace/vimium/tests/dom_tests/dom_test_setup.js:7:10)
    at getSelection (file:///home/kingfisher/workspace/vimium/tests/dom_tests/dom_test_setup.js:7:10)
    at getSelection (file:///home/kingfisher/workspace/vimium/tests/dom_tests/dom_test_setup.js:7:10)
    at getSelection (file:///home/kingfisher/workspace/vimium/tests/dom_tests/dom_test_setup.js:7:10)
Fail "False positives in link-hint: handle false positives" -  function(message) {
  this.name = AssertionError;
  this.message = message;
}: Expected 2 but received 0
Fail (2/110)
```

I can't pinpoint which function causing this so I keep the test commented.
