### PR TITLE
Fix scrolling issue on quickly changing directions

### DIFF
--- a/content_scripts/scroller.js
+++ b/content_scripts/scroller.js
@@ -190,6 +190,8 @@ const CoreScroller = {
       },
       keyup: event => {
         return handlerStack.alwaysContinueBubbling(() => {
+          // Ignore keyup events from unrelated keys.
+          if (this.lastEvent && this.lastEvent.key != event.key) return;
           this.keyIsDown = false;
           this.time += 1;
         });


### PR DESCRIPTION
(patch developed and tested on newest Firefox in Windows 10)

The current version has a problem when quickly changing scrolling directions, namely that *any* key up event stops the scroll.

Imagine a user scrolling down a page by holding J, then wanting to scroll up to see something that they missed, by holding K. If they are anything like me there's a good chance they'll press the K key before completely release the J key. Here's the chain of events:

```
press J
   |                       scrolling down...
   |                       scrolling down...
   |                       scrolling down...
   |         press K       scroll up!
   |            |          scrolling up...
   |            |          scrolling up...
release J       |          stop scrolling!
                |          not scrolling...
                |          not scrolling...
                v
```

This is very frustrating and inconsistent with every other program I tested (Firefox, Notepad, SublimeText, Windows Explorer).

This patch changes the keyup handler to only stop scrolling if the keyup event matches the one that started the scrolling behavior.

## Description
Provide a rationale for this PR, and a reference to the corresponding issue, if there is one.

Please review the "Which pull requests get merged?" section in `CONTRIBUTING.md`.
