### PR TITLE
Add %su option for encoding with %20 for space

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -167,9 +167,9 @@ var Utils = {
 
   // Map a search query to its URL encoded form. The query may be either a string or an array of strings.
   // E.g. "BBC Sport" -> "BBC+Sport".
-  createSearchQuery(query) {
+  createSearchQuery(query, withDelimiter='+') {
     if (typeof(query) === "string") { query = query.split(/\s+/); }
-    return query.map(encodeURIComponent).join("+");
+    return query.map(encodeURIComponent).join(withDelimiter);
   },
 
   // Create a search URL from the given :query (using either the provided search URL, or the default one).
@@ -179,6 +179,7 @@ var Utils = {
     if (searchUrl == null) { searchUrl = Settings.get("searchUrl"); }
     if (!['%s', '%S'].some(token => searchUrl.indexOf(token) >= 0)) { searchUrl += "%s"; }
     searchUrl = searchUrl.replace(/%S/g, query);
+    searchUrl = searchUrl.replace(/%su/g, this.createSearchQuery(query, '%20'))
     return searchUrl.replace(/%s/g, this.createSearchQuery(query));
   },
 

--- a/tests/unit_tests/utils_test.js
+++ b/tests/unit_tests/utils_test.js
@@ -57,6 +57,10 @@ context("convertToUrl",
 context("createSearchUrl",
   should("replace %S without encoding", () => {
     assert.equal("https://www.github.com/philc/vimium/pulls", Utils.createSearchUrl("vimium/pulls", "https://www.github.com/philc/%S"))
+  }),
+  should("replace %su with %20", () => {
+    assert.equal("https://www.rottentomatoes.com/search?search=alice%20in%20wonderland",
+    Utils.createSearchUrl("alice in wonderland", "https://www.rottentomatoes.com/search?search=%su"))
   })
 );
 


### PR DESCRIPTION
Please see original issue here: https://github.com/philc/vimium/issues/3583

Some websites require spaces to be encoded as "%20" instead of "+".

One example is **https://www.rottentomatoes.com/search?search=alice%20in%20wonderland**

Added a delimiter parameter for spacing which defaults to "+" so as to not break functionality.