### PR TITLE
Fix some issues of global mark

### DIFF
--- a/background_scripts/marks.js
+++ b/background_scripts/marks.js
@@ -71,8 +71,11 @@ const Marks = {
   },
 
   // Focus an existing tab and scroll to the given position within it.
-  gotoPositionInTab({ tabId, scrollX, scrollY, markName }) {
-    chrome.tabs.update(tabId, { active: true }, () => chrome.tabs.sendMessage(tabId, {name: "setScrollPosition", scrollX, scrollY}));
+  gotoPositionInTab({ tabId, scrollX, scrollY }) {
+    chrome.tabs.update(tabId, { active: true }, (tab) => {
+      chrome.windows.update(tab.windowId, { focused: true });
+      chrome.tabs.sendMessage(tabId, {name: "setScrollPosition", scrollX, scrollY});
+    });
   },
 
   // The tab we're trying to find no longer exists.  We either find another tab with a matching URL and use it,

--- a/content_scripts/marks.js
+++ b/content_scripts/marks.js
@@ -39,7 +39,7 @@ const Marks = {
     let shiftKey = event.shiftKey;
     if (this.currentRegistryEntry.options.swap)
       shiftKey = !shiftKey;
-    return shiftKey && this.previousPositionRegisters.includes(keyChar);
+    return shiftKey && !this.previousPositionRegisters.includes(keyChar);
   },
 
   activateCreateMode(count, {registryEntry}) {


### PR DESCRIPTION
* fix a bug that `m` could not create global marks when <kbd>Shift</kbd> is held on
* fix that `Marks.activateGotoMode` did not focus her inactive windows

This will fix #3599