### PR TITLE
customizable page up/down overlap

### DIFF
--- a/content_scripts/scroller.js
+++ b/content_scripts/scroller.js
@@ -346,7 +346,11 @@ const Scroller = {
     // continuous scrolls, and is just an optimization.
     if (!CoreScroller.wouldNotInitiateScroll()) {
       const element = findScrollableElement(activatedElement, direction, amount, factor);
-      const elementAmount = factor * getDimension(element, direction, amount);
+      let elementAmount = factor * getDimension(element, direction, amount);
+      const pageOverlap = Settings.get('pageOverlap');
+      if (direction === "y" && elementAmount > 3 * pageOverlap) {
+        elementAmount -= pageOverlap;
+      }
       return CoreScroller.scroll(element, direction, elementAmount, continuous);
     }
   },

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -176,6 +176,7 @@ const Settings = {
   // Default values for all settings.
   defaults: {
     scrollStepSize: 60,
+    pageOverlap: 100,
     smoothScroll: true,
     keyMappings: "# Insert your preferred key mappings here.",
     linkHintCharacters: "sadfjklewcmpgh",

--- a/pages/options.css
+++ b/pages/options.css
@@ -107,7 +107,8 @@ input#linkHintNumbers {
 input#linkHintCharacters {
   width: 100%;
 }
-input#scrollStepSize {
+input#scrollStepSize,
+input#pageOverlap {
   width: 50px;
   margin-right: 3px;
   padding-left: 3px;

--- a/pages/options.html
+++ b/pages/options.html
@@ -103,6 +103,17 @@ b: http://b.com/?q=%s description
               <input id="scrollStepSize" type="number" />px
             </td>
           </tr>
+          <tr>
+            <td class="caption">Page up/down overlap</td>
+            <td>
+                <div class="help">
+                  <div class="example">
+                    The size for overlap when page up/down.
+                  </div>
+                </div>
+              <input id="pageOverlap" type="number" />px
+            </td>
+          </tr>
           <tr id="linkHintCharactersContainer">
             <td class="caption">Characters used<br/> for link hints</td>
             <td verticalAlign="top">

--- a/pages/options.js
+++ b/pages/options.js
@@ -251,6 +251,7 @@ const Options = {
   regexFindMode: CheckBoxOption,
   ignoreKeyboardLayout: CheckBoxOption,
   scrollStepSize: NumberOption,
+  pageOverlap: NumberOption,
   smoothScroll: CheckBoxOption,
   grabBackFocus: CheckBoxOption,
   searchEngines: TextOption,


### PR DESCRIPTION
## Description
fix issue#3601, by leaving an overlap(customizable, default 100px, works well on my mbp 15) between paging up/down, so that on page like google search result or youtube, the banner fixed at top of viewport will not hide some content after paging up/down.

It would be nice that the scrollable element or window have some attribute to "tell" browser/vimium the height of banner in the element or on the viewport, so that browser/vimium can leave overlap with more accurate pixels, but that is not the scope of this issue.

