### PR TITLE
fix usage of :read-only on Firefox

### DIFF
--- a/pages/options.css
+++ b/pages/options.css
@@ -143,7 +143,7 @@ input#searchUrl {
   right: -320px;
   width: 320px;
 }
-input:read-only {
+input[type=text]:read-only, input[type=number]:read-only, textarea:read-only {
   background-color: #eee;
   color: #666;
   pointer-events: none;


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/CSS/:read-only, the `:read-only` means all non-editable DOM elements, including `<p>` and event those `<input>` whose `isSelectable` are false.

Spec: https://html.spec.whatwg.org/multipage/semantics-other.html#selector-read-only .

This may fix #3623, fix #3634, fix #3653, fix #3678 and fix #3725.

### Behavior Differences

Firefox 78 begins to support `:read-only` besides `:-moz-read-only`, so the misusage of `:read-only` only causes some differences since it.

Chrome seems to have different opinions, and it doesn't match those `<input>` with `isSelectable()=false` into `:read-only`.

Here's a test page from web-platform-tests: http://wpt.live/html/semantics/selectors/pseudo-classes/readwrite-readonly.html , and you can see Firefox 78 passes all tests while Chrome 83 fails 15 tests.

There're also some related discussions that may help:
* https://bugzilla.mozilla.org/show_bug.cgi?id=1532968#c11
* https://stackoverflow.com/q/62571297/5789722