### PR TITLE
Put newline at the end of exported JSON file

### DIFF
--- a/pages/options.js
+++ b/pages/options.js
@@ -454,7 +454,7 @@ if (global.DomUtils) { // global.DomUtils is not defined when running our tests.
 
     // Create the blob in the background page so it isn't garbage collected when the page closes in FF.
     const bgWin = chrome.extension.getBackgroundPage();
-    const blob = new bgWin.Blob([ JSON.stringify(backup, null, 2) ]);
+    const blob = new bgWin.Blob([ JSON.stringify(backup, null, 2) + "\n" ]);
     $("backupLink").href = bgWin.URL.createObjectURL(blob);
   };
 


### PR DESCRIPTION
# Description
JSON file dgenerated by clicking 'Click to download backup' does not end with newline. This PR fixes it.

I'm managing Vimium configuration using Git. The issue is that Git warns that the JSON file does not have newline at end of file.

```
$ g show HEAD
commit 9e8af5e90a802c6b9e6358f95b326d29e1d9f72b (HEAD -> master)
Author: rhysd <lin90162@yahoo.co.jp>
Date:   Wed Sep 23 19:03:11 2020 +0900

    vimium: hello

diff --git a/vimium-options.json b/vimium-options.json
new file mode 100644
index 0000000..1e6d166
--- /dev/null
+++ b/vimium-options.json
@@ -0,0 +1,26 @@
+{
+  "settingsVersion": "1.66",
+  "exclusionRules": [
+    {
+      "pattern": "https?://mail.google.com/*",
+      "passKeys": ""
+    }
+  ],
+  "filterLinkHints": false,
+  "waitForEnterForFilteredHints": true,
+  "hideHud": false,
+  "keyMappings": "# Store: https://chrome.google.com/webstore/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb?hl=ja\n# Repo: https://github.com/philc/vimium\n# Wiki: https://github.com/philc/vimium/wiki\n\nmap j scrollPageDown\nmap k scrollPageUp\nmap <C-d> scrollPageDown\nmap <C-u> scrollPageUp\nmap <C-f> scrollFullPageDown\nmap <C-b> scrollFullPageUp\nmap i focusInput\nmap I enterInsertMode\nmap t Vomnibar.activateTabSelection\nmap u goBack\nmap <C-r> goForward\nmap <C-j> scrollLeft\nmap <C-k> scrollRight\nmap h previousTab\nmap l nextTab\nmap <C-p> togglePinTab\n\n\n# Disable reload\nunmap r\n# Disable open clipboard URL\nunmap p\n# Disable open clipboard URL in new tab\nunmap P\n# enterInsertMode is mapped to I\nunmap gi\n# unpin is mapped to <C-p>\nunmap <A-p>\n# scrollPage(Down|Up) are mapped to <C-d> and <C-u>\nunmap d",
+  "linkHintCharacters": "sadfjklewcmpgh",
+  "linkHintNumbers": "0123456789",
+  "newTabUrl": "about:newtab",
+  "nextPatterns": "next,more,newer,>,›,→,»,≫,>>",
+  "previousPatterns": "prev,previous,back,older,<,‹,←,«,≪,<<",
+  "regexFindMode": false,
+  "ignoreKeyboardLayout": false,
+  "scrollStepSize": 60,
+  "smoothScroll": false,
+  "grabBackFocus": false,
+  "searchEngines": "w: https://www.wikipedia.org/w/index.php?title=Special:Search&search=%s Wikipedia\ng: https://github.com/search?q=%s GitHub",
+  "searchUrl": "https://www.google.com/search?q=",
+  "userDefinedLinkHintCss": "div > .vimiumHintMarker {\n/* linkhint boxes */\nbackground: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#FFF785),\n  color-stop(100%,#FFC542));\nborder: 1px solid #E3BE23;\n}\n\ndiv > .vimiumHintMarker span {\n/* linkhint text */\ncolor: black;\nfont-weight: bold;\nfont-size: 12px;\n}\n\ndiv > .vimiumHintMarker > .matchingCharacter {\n}"
+}
\ No newline at end of file
```
