### PR TITLE
Remove unnecessary style at <input> for selecting backup file

### DIFF
--- a/pages/options.html
+++ b/pages/options.html
@@ -338,7 +338,7 @@ b: http://b.com/?q=%s description
                     Choose a backup file to restore, then click <i>Save Changes</i>, below, to confirm.
                   </div>
                 </div>
-              <input id="chooseFile" type="file" accept=".json" style="width: 200px;"/>
+              <input id="chooseFile" type="file" accept=".json" />
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
## Description

With Japanese locale, `<input>` for selecting backup file is a bit broken. The message is squashed by '...' since its width is not sufficient. This is because `width: 200px` is set on the element.

<img width="346" alt="スクリーンショット 2020-09-23 19 39 17" src="https://user-images.githubusercontent.com/823277/94002422-d7954700-fdd4-11ea-960e-e6c98932779e.png">

However, the style seems not necessary. I confirmed removing the style fixed this issue and did not break any other UI.

<img width="384" alt="スクリーンショット 2020-09-23 19 44 16" src="https://user-images.githubusercontent.com/823277/94002695-2fcc4900-fdd5-11ea-9525-37d6a79c3571.png">
