### PR TITLE
Fix createTab incognito and createTab window commands with no URLs on Firefox

### DIFF
--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -271,10 +271,15 @@ const BackgroundCommands = {
     }
 
     if (request.registryEntry.options.incognito || request.registryEntry.options.window) {
+      // Firefox does not support about:newtab in chrome.windows.create.
+      const legalUrls = request.urls.filter((url) => url !== Settings.defaults.newTabUrl);
       const windowConfig = {
-        url: request.urls,
+        url: legalUrls,
         incognito: request.registryEntry.options.incognito || false
       };
+      if (windowConfig.url.length === 0) {
+        delete windowConfig.url;
+      }
       return chrome.windows.create(windowConfig, () => callback(request));
     } else {
       let openNextUrl;


### PR DESCRIPTION
## Description
Currently, user-defined mappings for `createTab incognito` and `createTab window` with no URL parameters fail on Firefox, e.g.:

```
map X createTab incognito
map X createTab window
```

This is because these commands try to call `chrome.windows.create` with `about:newtab` as a URL parameter, which is illegal in Firefox. The solution is to instead call `chrome.windows.create` with the URL parameter omitted, which makes it default to the Firefox's home page (for `createTab window`) or `about:privatebrowsing` (for `createTab incognito`). A similar solution is already in place for the basic `createTab` command:

https://github.com/philc/vimium/blob/bdf654aebe6f570f427c5f7bc9592cad86e642b5/background_scripts/main.js#L181-L183