### PR TITLE
added option to fix choppy firefox scroll

### DIFF
--- a/content_scripts/scroller.js
+++ b/content_scripts/scroller.js
@@ -61,7 +61,7 @@ const performScroll = function(element, direction, amount) {
   const axisName = scrollProperties[direction].axisName;
   const before = element[axisName];
   if (element.scrollBy) {
-    const scrollArg = {behavior: "instant"};
+    const scrollArg = {behavior: Settings.get("scrollBehaviorSmooth") ? "smooth" : "instant"};
     scrollArg[direction === "x" ? "left" : "top"] = amount;
     element.scrollBy(scrollArg);
   } else {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -177,6 +177,7 @@ const Settings = {
   defaults: {
     scrollStepSize: 60,
     smoothScroll: true,
+    scrollBehaviorSmooth: false,
     keyMappings: "# Insert your preferred key mappings here.",
     linkHintCharacters: "sadfjklewcmpgh",
     linkHintNumbers: "0123456789",

--- a/pages/options.html
+++ b/pages/options.html
@@ -141,6 +141,20 @@ b: http://b.com/?q=%s description
             <td verticalAlign="top" class="booleanOption">
               <div class="help">
                 <div class="example">
+                  Fixes choppy scroll in Firefox when privacy.resistFingerprinting is set true
+                </div>
+              </div>
+              <label>
+                <input id="scrollBehaviorSmooth" type="checkbox"/>
+                Use alternative smooth scroll (Firefox fix)
+              </label>
+            </td>
+          </tr>
+          <tr>
+            <td class="caption"></td>
+            <td verticalAlign="top" class="booleanOption">
+              <div class="help">
+                <div class="example">
                   In link-hint mode, this option lets you select a link by typing its text.
                 </div>
               </div>

--- a/pages/options.js
+++ b/pages/options.js
@@ -252,6 +252,7 @@ const Options = {
   ignoreKeyboardLayout: CheckBoxOption,
   scrollStepSize: NumberOption,
   smoothScroll: CheckBoxOption,
+  scrollBehaviorSmooth: CheckBoxOption,
   grabBackFocus: CheckBoxOption,
   searchEngines: TextOption,
   searchUrl: NonEmptyTextOption,


### PR DESCRIPTION
**Problem:** Fake timestamps are provided to Vimium when `privacy.resistFingerprinting` is set `true` in Firefox which results in choppy and unpredictable scrolling. 
**Solution:** Added option for alternative smooth scroll using native `scrollBy` toggling between options `smooth` and `instant`

Fixes https://github.com/philc/vimium/issues/3641