### PR TITLE
fixed corrupted firefox build by adding ID to manifest at build

### DIFF
--- a/make.js
+++ b/make.js
@@ -62,6 +62,7 @@ function buildStorePackage() {
   // Chrome considers this key invalid in manifest.json, so we add it during the build phase.
   firefoxManifest["browser_specific_settings"] = {
     gecko: {
+      "id": "vimium@vimium.github.io",
       "strict_min_version": "62.0"
     }
   };


### PR DESCRIPTION
The Firefox build requires an explicit ID set in its manifest.json under the `browser_specific_settings` key as referenced by the docs [here](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) and [here](https://extensionworkshop.com/documentation/develop/extensions-and-the-add-on-id/#when-do-you-need-an-add-on-id). `id` must be set since we're using the `storage` API. Without this an error is thrown that the extension is corrupted. Also, the `application` key is ignored. Here is the browser console logs: 

```
21:27:47.553 1603834067553	addons.xpi	WARN	Ignoring applications property in manifest
21:27:47.556 1603834067555	addons.xpi	WARN	Invalid XPI: Error: Cannot find id for addon /Users/vimium/dist/firefox/vimium-firefox-1.66.zip(resource://gre/modules/addons/XPIInstall.jsm:1539:19) JS Stack trace: loadManifest@XPIInstall.jsm:1539:19
async*init@XPIInstall.jsm:2039:18
createLocalInstall@XPIInstall.jsm:3007:20
getInstallForFile@XPIInstall.jsm:4315:25
XPIProvider[meth]@XPIProvider.jsm:3200:28
promiseCallProvider@AddonManager.jsm:253:31
getInstallForFile/<@AddonManager.jsm:1848:29
getInstallForFile@AddonManager.jsm:1862:7
getInstallForFile@AddonManager.jsm:4056:33
installAddonsFromFilePicker/</<@aboutaddonsCommon.js:274:42
```

This PR addresses this and fixes https://github.com/philc/vimium/issues/3695