### PR TITLE
Make FOCUS_LINK LinkHint mode available to Vimium via sl keybinding.

### DIFF
--- a/background_scripts/commands.js
+++ b/background_scripts/commands.js
@@ -315,6 +315,7 @@ const defaultKeyMappings = {
   "F": "LinkHints.activateModeToOpenInNewTab",
   "<a-f>": "LinkHints.activateModeWithQueue",
   "yf": "LinkHints.activateModeToCopyLinkUrl",
+  "sl": "LinkHints.activateModeToFocusLinkUrl",
 
   // Using find
   "/": "enterFindMode",
@@ -403,6 +404,7 @@ const commandDescriptions = {
   "LinkHints.activateModeToOpenIncognito": ["Open a link in incognito window"],
   "LinkHints.activateModeToDownloadLink": ["Download link url"],
   "LinkHints.activateModeToCopyLinkUrl": ["Copy a link URL to the clipboard"],
+  "LinkHints.activateModeToFocusLinkUrl": ["Place focus on element"],
 
   enterFindMode: ["Enter find mode", { noRepeat: true }],
   performFind: ["Cycle forward to the next find match"],

--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -243,7 +243,8 @@ var LinkHints = {
   activateModeToCopyLinkUrl(count) { this.activateMode(count, {mode: COPY_LINK_URL}); },
   activateModeWithQueue() { this.activateMode(1, {mode: OPEN_WITH_QUEUE}); },
   activateModeToOpenIncognito(count) { this.activateMode(count, {mode: OPEN_INCOGNITO}); },
-  activateModeToDownloadLink(count) { this.activateMode(count, {mode: DOWNLOAD_LINK_URL}); }
+  activateModeToDownloadLink(count) { this.activateMode(count, {mode: DOWNLOAD_LINK_URL}); },
+  activateModeToFocusLinkUrl() { this.activateMode(1, {mode: FOCUS_LINK}); }
 };
 
 class LinkHintsMode {


### PR DESCRIPTION
Defaulted to `sl` shortcut since `f` is taken.

`sl` stands for "Spotlight link".  (Yes, I used thesaurus.com to find
synonyms for focus.)

## Description
Provide a rationale for this PR, and a reference to the corresponding issue, if there is one.

This PR makes more sites accessible to users who can't use their hands, like me.  I recently rejoined Slack for a potential job and I prefer to browse the global "All Unread" section in the morning to catch up.  Navigating is a PITA, however, as my Pixelbook isn't as hackable as Linux to make it more user friendly; I use `xkbset` to map F7 to toggle MouseKeys mode on my Linux desktop.

This will also help me navigate more sites, like Manning and PacktPub.  If an area of a page requires focus to scroll up/down with j/k, its unusable to me.  (Thank you HTML5.)

There are several other sites this will help with.  Those three were the first to come to mind who may be able to sponsor Vimium.