### PR TITLE
Look at title and aria-label attributes for next/prev link discovery

### DIFF
--- a/content_scripts/mode_normal.js
+++ b/content_scripts/mode_normal.js
@@ -347,7 +347,9 @@ var findAndFollowLink = function(linkStrings) {
     let linkMatches = false;
     for (linkString of linkStrings) {
       if ((link.innerText.toLowerCase().indexOf(linkString) !== -1) ||
-          (link.value && link.value.includes && link.value.includes(linkString))) {
+          (link.value && link.value.includes && link.value.includes(linkString)) ||
+          (link.hasAttribute("title") && link.getAttribute("title").toLowerCase().includes(linkString)) ||
+          (link.hasAttribute("aria-label") && link.getAttribute("aria-label").toLowerCase().includes(linkString))) {
         linkMatches = true;
         break;
       }
@@ -387,7 +389,9 @@ var findAndFollowLink = function(linkStrings) {
           : new RegExp(linkString, "i");
     for (let candidateLink of candidateLinks) {
       if (exactWordRegex.test(candidateLink.innerText) ||
-          (candidateLink.value && exactWordRegex.test(candidateLink.value))) {
+          (candidateLink.value && exactWordRegex.test(candidateLink.value)) ||
+          (link.hasAttribute("title") && exactWordRegex.test(link.getAttribute("title")) ||
+          (link.hasAttribute("aria-label") && exactWordRegex.test(link.getAttribute("aria-label"))))) {
         followLink(candidateLink);
         return true;
       }

--- a/tests/dom_tests/dom_tests.js
+++ b/tests/dom_tests/dom_tests.js
@@ -612,6 +612,22 @@ context("Find prev / next links", () => {
     NormalModeCommands.goNext();
     assert.equal('#first', window.location.hash);
   });
+
+  should("find elements by title", () => {
+    document.getElementById("test-div").innerHTML = `\
+<a title='Next page' href='#first'>unhelpful text</a>\
+`;
+    NormalModeCommands.goNext();
+    assert.equal('#first', window.location.hash);
+  });
+
+  should("find elements by aria-label", () => {
+    document.getElementById("test-div").innerHTML = `\
+<a aria-label='Next page' href='#first'>unhelpful text</a>\
+`;
+    NormalModeCommands.goNext();
+    assert.equal('#first', window.location.hash);
+  });
 });
 
 context("Key mapping", () => {


### PR DESCRIPTION
## Description
This PR makes Vimium also use the contents of `title` and `aria-label` attributes, if present, to discover potential links to the next/previous page. This is useful for pages like [this Adafruit guide](https://learn.adafruit.com/adafruits-raspberry-pi-lesson-11-ds18b20-temperature-sensing), which uses a Font Awesome icon (`<i class="fa fa-chevron-right">`) to create the arrow on the next page button but also marks up that button with `aria-label="Next page"`.

Tests are included.

Fixes #3739.