### PR TITLE
Implement better Firefox detection so Vimium works on LibreWolf

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,12 +26,7 @@ if (window.browser && browser.runtime && browser.runtime.getBrowserInfo)
 
 var Utils = {
   isFirefox: (function() {
-    // NOTE(mrmr1993): This test only works in the background page, this is overwritten by isEnabledForUrl for
-    // content scripts, and the "settings" message from UIComponent is for pages like HUD.
-    let isFirefox = false;
-    if (browserInfo) {
-      browserInfo.then(browserInfo => isFirefox = browserInfo.name === "Firefox");
-    }
+    const isFirefox = typeof InstallTrigger !== 'undefined';
     return () => isFirefox;
   })(),
 


### PR DESCRIPTION
## Description
I am trying to fix #3758 by re-implement the firefox detection function.

In previous implementation, `Util.isFirefox()` is detecting hardcoded string
from `runtime.getBrowserInfo()`, which cause other Firefox-derived browser
like Librewolf not detected and therefore certain features stop working
on such browsers. This implementation is based on feature detection, so
any Firefox based browser can be detected.
