### PR TITLE
fix broken FindMode on Firefox 86+

### DIFF
--- a/pages/hud.js
+++ b/pages/hud.js
@@ -134,6 +134,8 @@ const handlers = {
     if (countElement == null) // Don't do anything if we're not in find mode.
       return;
 
+    if (Utils.isFirefox())
+      document.getElementById("hud-find-input").focus()
     const countText = matchCount > 0 ?
       ` (${matchCount} Match${matchCount === 1 ? "" : "es"})` : " (No matches)";
     countElement.textContent = showMatchText ? countText : "";


### PR DESCRIPTION
This will fix #3774, fix #3796, fix #3807, fix #3809 and fix #3824.

During my tests on my Win10 x64 + fresh Firefox 86/87, I noticed Firefox throws the `focused` status of HUD's `<span contenteditable>` when a page has executed `window.find`, and then `options.postFindFocus.focus()` makes HUD focused with `document.activeElement=document.body`.

Therefore, this PR focuses `<span id="hud-find-input">` manually. And it works on my computer.
