### PR TITLE
Add special scrolling element for Telegram

### DIFF
--- a/content_scripts/scroller.js
+++ b/content_scripts/scroller.js
@@ -413,7 +413,8 @@ var specialScrollingElementMap = {
   'twitter.com': 'div.permalink-container div.permalink[role=main]',
   'reddit.com': '#overlayScrollContainer',
   'new.reddit.com': '#overlayScrollContainer',
-  'www.reddit.com': '#overlayScrollContainer'
+  'www.reddit.com': '#overlayScrollContainer',
+  'web.telegram.org': '.MessageList',
 };
 
 global.Scroller = Scroller;


### PR DESCRIPTION
This PR provide special scrolling element for Telegram.
Vimium can't find the necessary element for scrolling after loading page, because Telegram is a SPA and its scrolling element is nested in the DOM structure