### PR TITLE
Fix `isCustomSearchPrimarySuggestion` in `vomnibar.js`

### DIFF
--- a/pages/vomnibar.js
+++ b/pages/vomnibar.js
@@ -202,8 +202,8 @@ class VomnibarUI {
       this.updateSelection();
     } else if (action === "enter") {
       const c = this.completions[this.selection];
-      const isCustomSearchPrimarySuggestion = c && c.isCustomSearchPrimarySuggestion &&
-            this.lastResponse.engine && this.lastResponse.engine.searchUrl;
+      const isCustomSearchPrimarySuggestion = c && c.isPrimarySuggestion &&
+            this.lastReponse.engine && this.lastReponse.engine.searchUrl;
       if ((this.selection === -1) || isCustomSearchPrimarySuggestion) {
         let query = this.input.value.trim();
         // <Enter> on an empty query is a no-op.

--- a/pages/vomnibar.js
+++ b/pages/vomnibar.js
@@ -118,7 +118,7 @@ class VomnibarUI {
   updateSelection() {
     // For custom search engines, we suppress the leading term (e.g. the "w" of "w query terms") within the
     // vomnibar input.
-    if (this.lastReponse.isCustomSearch && (this.customSearchMode == null)) {
+    if (this.lastResponse.isCustomSearch && (this.customSearchMode == null)) {
       const queryTerms = this.input.value.trim().split(/\s+/);
       this.customSearchMode = queryTerms[0];
       this.input.value = queryTerms.slice(1).join(" ");
@@ -203,7 +203,7 @@ class VomnibarUI {
     } else if (action === "enter") {
       const c = this.completions[this.selection];
       const isCustomSearchPrimarySuggestion = c && c.isPrimarySuggestion &&
-            this.lastReponse.engine && this.lastReponse.engine.searchUrl;
+            this.lastResponse.engine && this.lastResponse.engine.searchUrl;
       if ((this.selection === -1) || isCustomSearchPrimarySuggestion) {
         let query = this.input.value.trim();
         // <Enter> on an empty query is a no-op.
@@ -221,7 +221,7 @@ class VomnibarUI {
         // text than that which is included in the URL associated with the primary suggestion.  Therefore, to
         // avoid a race condition, we construct the query from the actual contents of the input (query).
         if (isCustomSearchPrimarySuggestion)
-          query = Utils.createSearchUrl(query, this.lastReponse.engine.searchUrl);
+          query = Utils.createSearchUrl(query, this.lastResponse.engine.searchUrl);
         this.hide(() => Vomnibar.getCompleter().launchUrl(query, openInNewTab));
       } else {
         completion = this.completions[this.selection];
@@ -269,9 +269,9 @@ class VomnibarUI {
     return this.completer.filter({
       query: this.getInputValueAsQuery(),
       seenTabToOpenCompletionList: this.seenTabToOpenCompletionList,
-      callback: lastReponse => {
-        this.lastReponse = lastReponse;
-        const { results } = this.lastReponse;
+      callback: lastResponse => {
+        this.lastResponse = lastResponse;
+        const { results } = this.lastResponse;
         this.completions = results;
         this.selection = (this.completions[0] != null ? this.completions[0].autoSelect : undefined) ? 0 : this.initialSelectionValue;
         // Update completion list with the new suggestions.


### PR DESCRIPTION
During the migration of `vomnibar.js` from coffeescript to javascript, some small changes were introduced:
Before: https://github.com/philc/vimium/blob/478cc8ba4f0aa608b5cd044304221bc11932dd8b/pages/vomnibar.coffee#L162
After:  https://github.com/philc/vimium/blob/478cc8ba4f0aa608b5cd044304221bc11932dd8b/pages/vomnibar.js#L205-L206

1. the value `c.isCustomSearchPrimarySuggestion` is read (while it is never set), instead of `c.isPrimarySuggestion`
2. `this.lastResponse` is used, instead of `this.lastReponse` (which is misspelled everywhere else)

This commit reverts to the old version and fixes the behavior as described in the 'second case' of the comment below this piece of code:
https://github.com/philc/vimium/blob/478cc8ba4f0aa608b5cd044304221bc11932dd8b/pages/vomnibar.js#L218-L222

Fix #3844
Fix #3567