### PR TITLE
Fix frozen search mode

### DIFF
--- a/content_scripts/hud.js
+++ b/content_scripts/hud.js
@@ -121,7 +121,7 @@ const HUD = {
     if (exitEventIsEnter) {
       FindMode.handleEnter();
       if (FindMode.query.hasResults)
-        postExit = () => new PostFindMode;
+        postExit = () => newPostFindMode();
     } else if (exitEventIsEscape) {
       // We don't want FindMode to handle the click events that FindMode.handleEscape can generate, so we
       // wait until the mode is closed before running it.

--- a/content_scripts/mode_find.js
+++ b/content_scripts/mode_find.js
@@ -32,6 +32,13 @@ class SuppressPrintable extends Mode {
 //      inheriting from SuppressPrintable.
 //   3. If the very-next keystroke is Escape, then drop immediately into insert mode.
 //
+var newPostFindMode = function() {
+  if (!document.activeElement || !DomUtils.isEditable(document.activeElement))
+    return;
+
+  return new PostFindMode();
+}
+
 class PostFindMode extends SuppressPrintable {
   constructor() {
     const element = document.activeElement;
@@ -46,9 +53,6 @@ class PostFindMode extends SuppressPrintable {
       keypress(event) { return InsertMode.suppressEvent(event); },
       keyup(event) { return InsertMode.suppressEvent(event); }
     });
-
-    if (!document.activeElement || !DomUtils.isEditable(document.activeElement))
-      return;
 
     // If the very-next keydown is Escape, then exit immediately, thereby passing subsequent keys to the
     // underlying insert-mode instance.
@@ -284,7 +288,7 @@ class FindMode extends Mode {
 
     if (FindMode.query.hasResults) {
       focusFoundLink();
-      return new PostFindMode();
+      return newPostFindMode();
     } else {
       return HUD.showForDuration(`No matches for '${FindMode.query.rawQuery}'`, 1000);
     }

--- a/content_scripts/mode_insert.js
+++ b/content_scripts/mode_insert.js
@@ -67,7 +67,7 @@ class InsertMode extends Mode {
     return activeElement;
   }
 
-  static suppressEvent(event) { this.suppressedEvent = event; }
+  static suppressEvent(event) { return this.suppressedEvent = event; }
 }
 
 // This allows PostFindMode to suppress the permanently-installed InsertMode instance.


### PR DESCRIPTION
Fix #3557.

See the next post for the up-to-date fix. Below the line is the description of the previous fix.

---

During the coffeescript -> javascript migration, some lines that disable the PostFindMode early on were (unintentionally?) swapped in https://github.com/philc/vimium/commit/01895d8233766772a8b896c3b948359e786c4fdd.
Because of this, PostFindMode was entered after pressing enter, blocking all keypresses until a mouseclick in the window happens, or the browser window is unfocussed and focussed again.

This reverses them back to their order in the original coffeescript.

My testing shows that searching now works again.

On 2nd thoughts, this fix does introduce javascript errors, and those errors are likely why the broken behavior isn't triggered.