### PR TITLE
Fix dark mode on GitHub

### DIFF
--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -513,3 +513,7 @@ iframe.vimiumNonClickable {
     color: white;
   }
 }
+
+.vimiumUIComponentVisible {
+  color-scheme: light;
+}


### PR DESCRIPTION
Fix #3732
Fix #3797.

I'm not sure this is needed/wanted, because I also see [a comment](https://github.com/philc/vimium/issues/3732#issuecomment-749358383) that this is working as intended.

This PR implements the fix suggested in [this comment](https://github.com/philc/vimium/issues/3732#issuecomment-749997600).

I didn't look into why or how this works, and whether it's desirable in general to always force `color-scheme: light`, but in the week I've been using it I haven't come across negative side effects.

Maybe this destroys automatic theme switching based on browser/OS light/dark mode? In that case this fix isn't optimal, but for me personally this bug was the reason for switching to the git version of Vimium so it would be nice to see this fixed somehow.
