### PR TITLE
fix: ensure find query history in case of always private windows

### DIFF
--- a/lib/find_mode_history.js
+++ b/lib/find_mode_history.js
@@ -18,7 +18,7 @@ const FindModeHistory = {
       this.storage.get(this.key, items => {
         if (!chrome.runtime.lastError) {
           if (items[this.key]) { this.rawQueryList = items[this.key]; }
-          if (this.isIncognitoMode && !items[this.key]) {
+          else if (this.isIncognitoMode) {
             // This is the first incognito tab, so we need to initialize the incognito-mode query history.
             this.storage.get("findModeRawQueryList", items => {
               if (!chrome.runtime.lastError) {
@@ -32,7 +32,7 @@ const FindModeHistory = {
     }
 
     chrome.storage.onChanged.addListener((changes, area) => {
-      if (changes[this.key]) { this.rawQueryList = changes[this.key].newValue; }
+      if (changes[this.key]) { this.rawQueryList = changes[this.key].newValue || []; }
     });
   },
 


### PR DESCRIPTION
## Description
Fixes #3614.

In my observation, `this.rawQueryList` always remains `undefined`, if a user always browses in private/incognito windows.
As per my understanding, this is because of the way it is populated from local storage.

### Changes
Added a fallback when setting it from local storage changes to ensure `this.rawQueryList` is always defined.