### PR TITLE
Remove reference to deleted file

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -68,13 +68,6 @@
       "match_about_blank": true
     },
     {
-      "matches": ["<all_urls>"],
-      "js": ["content_scripts/injected.js"],
-      "run_at": "document_start",
-      "all_frames": true,
-      "match_about_blank": true
-    },
-    {
       "matches": ["file:///", "file:///*/"],
       "css": ["content_scripts/file_urls.css"],
       "run_at": "document_start",


### PR DESCRIPTION
## Description

injected.js was deleted in a previous commit, but the manifest still references it.

