### PR TITLE
unify initing processes of modes

### DIFF
--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -1259,7 +1259,7 @@ class WaitForEnter extends Mode {
 class HoverMode extends Mode {
   constructor(link) {
     super();
-    super.init({name: "hover-mode", singleton: "hover-mode", exitOnEscape: true});
+    this.init({name: "hover-mode", singleton: "hover-mode", exitOnEscape: true});
     this.link = link;
     DomUtils.simulateHover(this.link);
     this.onExit(() => DomUtils.simulateUnhover(this.link));

--- a/content_scripts/mode.js
+++ b/content_scripts/mode.js
@@ -25,6 +25,10 @@
 // Debug only.
 let count = 0;
 
+// Note(2021/07/19):
+// A direct sub-class of `Mode` MUST CALL `this.init(...)` in its constructor.
+// An indirect sub-class of `Mode` MUST CALL `super(options?)` in its constructor.
+// And `new Mode().init(...)` is the only allowed way to call `Mode::init` out of class methods.
 class Mode {
   // This is a function rather than a constructor, becausae often subclasses need to reference `this` when
   // setting up the options argument. `this` can't be referenced in subclasses prior to calling their
@@ -274,7 +278,7 @@ class SuppressAllKeyboardEvents extends Mode {
       name: "suppressAllKeyboardEvents",
       suppressAllKeyboardEvents: true
     };
-    super.init(Object.assign(defaults, options));
+    this.init(Object.assign(defaults, options));
   }
 }
 

--- a/content_scripts/mode_find.js
+++ b/content_scripts/mode_find.js
@@ -5,7 +5,7 @@
 class SuppressPrintable extends Mode {
   constructor(options) {
     super();
-    super.init(options);
+    this.init(options);
     const handler = event => KeyboardUtils.isPrintable(event) ? this.suppressEvent : this.continueBubbling;
     const type = DomUtils.getSelectionType();
 
@@ -94,7 +94,7 @@ class FindMode extends Mode {
       this.scrollY = window.scrollY;
     }
 
-    super.init(Object.assign(options, {
+    this.init(Object.assign(options, {
       name: "find",
       indicator: false,
       exitOnClick: true,

--- a/content_scripts/mode_insert.js
+++ b/content_scripts/mode_insert.js
@@ -45,7 +45,7 @@ class InsertMode extends Mode {
       keydown: handleKeyEvent
     };
 
-    super.init(Object.assign(defaults, options));
+    this.init(Object.assign(defaults, options));
 
     // Only for tests.  This gives us a hook to test the status of the permanently-installed instance.
     if (this.permanent)
@@ -82,7 +82,7 @@ class PassNextKeyMode extends Mode {
     let seenKeyDown = false;
     let keyDownCount = 0;
 
-    super.init({
+    this.init({
       name: "pass-next-key",
       indicator: "Pass next key.",
       // We exit on blur because, once we lose the focus, we can no longer track key events.

--- a/content_scripts/mode_key_handler.js
+++ b/content_scripts/mode_key_handler.js
@@ -12,6 +12,10 @@
 // consists of a (non-empty) list of such mappings.
 
 class KeyHandlerMode extends Mode {
+  constructor(options) {
+    super();
+    this.init(options);
+  }
   setKeyMapping(keyMapping) { this.keyMapping = keyMapping; this.reset(); }
   setPassKeys(passKeys) { this.passKeys = passKeys; this.reset(); }
 

--- a/content_scripts/mode_normal.js
+++ b/content_scripts/mode_normal.js
@@ -47,13 +47,12 @@ class NormalMode extends KeyHandlerMode {
 }
 
 const enterNormalMode = function(count) {
-  const mode = new NormalMode();
-  mode.init({
+  return new NormalMode({
     indicator: "Normal mode (pass keys disabled)",
     exitOnEscape: true,
     singleton: "enterNormalMode",
-    count});
-  return mode;
+    count
+  });
 };
 
 var NormalModeCommands = {
@@ -135,15 +134,11 @@ var NormalModeCommands = {
   },
 
   enterVisualMode() {
-    const mode = new VisualMode();
-    mode.init({userLaunchedMode: true});
-    return mode;
+    new VisualMode({userLaunchedMode: true});
   },
 
   enterVisualLineMode() {
-    const mode = new VisualLineMode();
-    mode.init({userLaunchedMode: true});
-    return mode;
+    new VisualLineMode({userLaunchedMode: true});
   },
 
   enterFindMode() {
@@ -411,8 +406,8 @@ var findAndFollowRel = function(value) {
 
 class FocusSelector extends Mode {
   constructor(hints, visibleInputs, selectedInputIndex) {
-    super(...arguments);
-    super.init({
+    super();
+    this.init({
       name: "focus-selector",
       exitOnClick: true,
       keydown: event => {

--- a/content_scripts/mode_visual.js
+++ b/content_scripts/mode_visual.js
@@ -292,7 +292,7 @@ class VisualMode extends KeyHandlerMode {
       }
 
       if ((DomUtils.getSelectionType(this.selection) !== "Range") && (this.name !== "caret")) {
-        new CaretMode().init();
+        new CaretMode;
         return HUD.showForDuration("No usable selection, entering caret mode...", 2500);
       }
     }
@@ -330,9 +330,7 @@ class VisualMode extends KeyHandlerMode {
     // The find was successfull. If we're in caret mode, then we should now have a selection, so we can
     // drop back into visual mode.
     if ((this.name === "caret") && (this.selection.toString().length > 0)) {
-      const mode = new VisualMode();
-      mode.init();
-      return mode;
+      new VisualMode;
     }
   }
 

--- a/content_scripts/vimium_frontend.js
+++ b/content_scripts/vimium_frontend.js
@@ -54,7 +54,7 @@ class GrabBackFocus extends Mode {
       });
     };
 
-    super.init({
+    this.init({
       name: "grab-back-focus",
       keydown: exitEventHandler
     });
@@ -150,7 +150,6 @@ const installModes = function() {
   // Install the permanent modes. The permanently-installed insert mode tracks focus/blur events, and
   // activates/deactivates itself accordingly.
   normalMode = new NormalMode();
-  normalMode.init();
   // Initialize components upon which normal mode depends.
   Scroller.init();
   FindModeHistory.init();


### PR DESCRIPTION
There's a bug that some `new`-ed modes are never inited, imported when migrating from CoffeeScript to ES6. This PR fixes this by forcing subclasses of `Mode` to call `super.init()` in their constructors.

This fixes #3865, fixes #3866, fixes #3926, fixes #4062 and replaces #3877.