### PR TITLE
Add option to exit insert mode on activating a tab

### DIFF
--- a/content_scripts/mode.js
+++ b/content_scripts/mode.js
@@ -75,6 +75,7 @@ class Mode {
       keydown: this.options.keydown || null,
       keypress: this.options.keypress || null,
       keyup: this.options.keyup || null,
+      focus: this.options.focus || null,
       indicator: () => {
         // Update the mode indicator.  Setting @options.indicator to a string shows a mode indicator in the
         // HUD.  Setting @options.indicator to 'false' forces no mode indicator.  If @options.indicator is

--- a/content_scripts/mode_insert.js
+++ b/content_scripts/mode_insert.js
@@ -25,11 +25,7 @@ class InsertMode extends Mode {
       if (Settings.get("passNextKeyKeys").includes(keyString)) {
         new PassNextKeyMode();
       } else if ((event.type === 'keydown') && KeyboardUtils.isEscape(event)) {
-        if (DomUtils.isFocusable(activeElement))
-          activeElement.blur();
-
-        if (!this.permanent)
-          this.exit();
+        this.removeFocusAndExit();
 
       } else {
         return this.passEventToPage;
@@ -42,7 +38,12 @@ class InsertMode extends Mode {
       name: "insert",
       indicator: !this.permanent && !Settings.get("hideHud")  ? "Insert mode" : null,
       keypress: handleKeyEvent,
-      keydown: handleKeyEvent
+      keydown: handleKeyEvent,
+      focus: (event) => {
+        if (Settings.get("removeFocusAfterSwitchingTabs") && event && event.target === window) {            
+          this.removeFocusAndExit();
+        }
+      }
     };
 
     super.init(Object.assign(defaults, options));
@@ -65,6 +66,19 @@ class InsertMode extends Mode {
     while (activeElement && activeElement.shadowRoot && activeElement.shadowRoot.activeElement)
       activeElement = activeElement.shadowRoot.activeElement;
     return activeElement;
+  }
+
+  removeFocusAndExit(element) {
+    element = element || this.getActiveElement();
+
+    if (element == null)
+      return;
+
+    if (DomUtils.isFocusable(element))
+      element.blur();
+
+    if (!this.permanent)
+      this.exit();
   }
 
   static suppressEvent(event) { return this.suppressedEvent = event; }

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -247,7 +247,8 @@ w: https://www.wikipedia.org/w/index.php?title=Special:Search&search=%s Wikipedi
     helpDialog_showAdvancedCommands: false,
     optionsPage_showAdvancedOptions: false,
     passNextKeyKeys: [],
-    ignoreKeyboardLayout: false
+    ignoreKeyboardLayout: false,
+    removeFocusAfterSwitchingTabs: false
   }
 };
 

--- a/pages/options.html
+++ b/pages/options.html
@@ -223,6 +223,21 @@ b: http://b.com/?q=%s description
             </td>
           </tr>
           <tr>
+            <td class="caption"></td>
+            <td verticalAlign="top" class="booleanOption">
+              <div class="help">
+                <div class="example">
+                  Force insert mode exit after activating a tab. Enables flawless next\prev
+                  tab navigation.
+                </div>
+              </div>
+              <label>
+                <input id="removeFocusAfterSwitchingTabs" type="checkbox"/>
+                Remove the focus from an input after switching between tabs.
+              </label>
+            </td>
+          </tr>
+          <tr>
             <td class="caption">Previous patterns</td>
             <td verticalAlign="top">
                 <div class="help">

--- a/pages/options.js
+++ b/pages/options.js
@@ -250,6 +250,7 @@ const Options = {
   previousPatterns: NonEmptyTextOption,
   regexFindMode: CheckBoxOption,
   ignoreKeyboardLayout: CheckBoxOption,
+  removeFocusAfterSwitchingTabs: CheckBoxOption,
   scrollStepSize: NumberOption,
   smoothScroll: CheckBoxOption,
   grabBackFocus: CheckBoxOption,


### PR DESCRIPTION
## Description
Hi,

This PR adds an advanced option that allows exit insert mode after focusing on a tab.

### Why is this important?

Previously, when a user enters an insert mode and switches a tab using a mouse, then after using Vimium's `J/K` keyboard shortcuts for switching tabs it will NOT exit the insert mode, effectively not allowing a user to switch to the next tab (from a one with an active insert mode), until a user manually exits the insert mode (e.g. by pressing `Escape`). It was always counterintuitive for me and prevented me from using those hotkeys because sometimes they weren't working and I wasn't curious enough to ask why and eager enough to find a solution to avoid it.

P.S.: fixing unit tests is still in progress~