### PR TITLE
Vomnibar: fix a bug preventing ctrl-enter from working

### DIFF
--- a/lib/keyboard_utils.js
+++ b/lib/keyboard_utils.js
@@ -4,7 +4,8 @@ Utils.monitorChromeStorage("mapKeyRegistry", value => { return mapKeyRegistry = 
 const KeyboardUtils = {
   // This maps event.key key names to Vimium key names.
   keyNames: {
-    "ArrowLeft": "left", "ArrowUp": "up", "ArrowRight": "right", "ArrowDown": "down", " ": "space"
+    "ArrowLeft": "left", "ArrowUp": "up", "ArrowRight": "right", "ArrowDown": "down", " ": "space",
+    "\n": "enter" // on a keypress event of Ctrl+Enter, tested on Chrome 92 and Windows 10
   },
 
   init() {

--- a/pages/vomnibar.js
+++ b/pages/vomnibar.js
@@ -160,7 +160,7 @@ class VomnibarUI {
     } else if ((key === "down") ||
         (event.ctrlKey && ((key === "j") || (key === "n")))) {
       return "down";
-    } else if (event.ctrlKey && (event.key === "Enter")) {
+    } else if (event.ctrlKey && (key === "enter")) {
       return "ctrl-enter";
     } else if (event.key === "Enter") {
       return "enter";


### PR DESCRIPTION
Chrome may assign `"\n"` as the `key` property of an `Enter` key,
which made `Ctrl+Enter` not work as expected.

This helps commit 2268e498637bc3190070e3d32146f981a33be726 (see #2914) work well on Windows, and may help #3880
