### PR TITLE
Fix css injection on Chrome [improved but not perfect]

### DIFF
--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -402,6 +402,9 @@ chrome.webNavigation.onCommitted.addListener(function({tabId, frameId}) {
   };
   const callback = () => chrome.runtime.lastError;
   chrome.tabs.insertCSS(tabId, cssConf, callback);
+  if (Utils.isFirefox()) {
+    return;
+  }
   // Also on "document_end", in order to work around a race condition.
   // See https://github.com/philc/vimium/issues/3418#issuecomment-549160351 .
   cssConf.runAt = "document_end"

--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -400,7 +400,12 @@ chrome.webNavigation.onCommitted.addListener(function({tabId, frameId}) {
     code: Settings.get("userDefinedLinkHintCss"),
     runAt: "document_start"
   };
-  return chrome.tabs.insertCSS(tabId, cssConf, () => chrome.runtime.lastError);
+  const callback = () => chrome.runtime.lastError;
+  chrome.tabs.insertCSS(tabId, cssConf, callback);
+  // Also on "document_end", in order to work around a race condition.
+  // See https://github.com/philc/vimium/issues/3418#issuecomment-549160351 .
+  cssConf.runAt = "document_end"
+  chrome.tabs.insertCSS(tabId, cssConf, callback);
 });
 
 // Symbolic names for the three browser-action icons.


### PR DESCRIPTION
This ensures `userDefinedLinkHintCss` can override those in `vimium.css`, so it can replace #3421, fix #3418, fix #3452 and fix #3956.

As said in https://github.com/philc/vimium/issues/3418#issuecomment-549160351 , during my tests the document about `chrome.tabs.insertCSS` is not correct - the CSS may be used earlier than those defined in `manifest.json`.

Updated (2021/11/16): as said in #3956, CSS inserted at `document_start` may be used earlier even on a top iframe on Chrome 95+Win10.