### PR TITLE
completer: fix a typo causing too many refreshing

### DIFF
--- a/background_scripts/completion.js
+++ b/background_scripts/completion.js
@@ -702,8 +702,8 @@ class MultiCompleter {
 
   cancel(port) {
     for (let c of this.completers)
-      if (c.refresh)
-        c.refresh(port);
+      if (c.cancel)
+        c.cancel(port);
   }
 
   filter(request, onComplete) {


### PR DESCRIPTION
I find a typo making Vomnibar slow down when there're too many bookmarks, which was imported when migrating from CoffeeScript to ES6. And it's very easy to fix.

This typo was included in v1.67, so #3661 seems not related with this, but I think this PR can fix #3886 .