### PR TITLE
Chore: small refactor for user agent detection

### DIFF
--- a/lib/keyboard_utils.js
+++ b/lib/keyboard_utils.js
@@ -9,19 +9,38 @@ const KeyboardUtils = {
   },
 
   init() {
-    // TODO(philc): Remove this guard clause once Deno has a userAgent.
-    // https://github.com/denoland/deno/issues/14362
-    // As of 2022-04-30, Deno does not have userAgent defined on navigator.
-    if (navigator.userAgent == null) {
-      this.platform = "Unknown";
-      return;
-    }
-    if (navigator.userAgent.indexOf("Mac") !== -1) {
-      this.platform = "Mac";
-    } else if (navigator.userAgent.indexOf("Linux") !== -1) {
-      this.platform = "Linux";
+    if (navigator.userAgentData) {
+      /**
+       * navigator.userAgentData is supported by Chrome + Edge
+       * @see https://caniuse.com/mdn-api_navigator_useragentdata
+       */
+      const { userAgentData: { platform } } = navigator;
+      if (platform.indexOf("macOS") !== -1) {
+        this.platform = "Mac";
+      } else if (platform.indexOf("Linux") !== -1) {
+        this.platform = "Linux";
+      } else {
+        this.platform = "Windows";
+      }
     } else {
-      this.platform = "Windows";
+      // TODO(philc): Remove this guard clause once Deno has a userAgent.
+      // https://github.com/denoland/deno/issues/14362
+      // As of 2022-04-30, Deno does not have userAgent defined on navigator.
+      if (navigator.userAgent == null) {
+        this.platform = "Unknown";
+        return;
+      }
+      
+      /**
+       * For older browsers, use legacy navigator.userAgent
+       */
+      if (navigator.userAgent.indexOf("Mac") !== -1) {
+        this.platform = "Mac";
+      } else if (navigator.userAgent.indexOf("Linux") !== -1) {
+        this.platform = "Linux";
+      } else {
+        this.platform = "Windows";
+      }
     }
   },
 


### PR DESCRIPTION
As a Vimium user who spends time in Chrome DevTools I've been finding it mildly irksome to repeatedly experience the following warning in Chrome v96.0.4642.0 (and likely newer).
![image](https://user-images.githubusercontent.com/182515/133419489-577b27a1-ec8f-4639-9884-a1d754eac520.png)

## Description
It seems the 'classic' way of accessing user agent info has been deprecated. Fortunately the revised [user agent API](https://blog.chromium.org/2021/05/update-on-user-agent-string-reduction.html) still contains the platform info that `keyboard_utils.js` apparently needs, so this PR is an attempt at using the new approach and thus avoiding the warning.

### Note 
I have not tested this thoroughly. While I believe it should provide the minimum necessary changes to squelch the warning, please test in whatever ways are appropriate.