### PR TITLE
Decode user JavaScript regardless of the existence of whitespace char in it

### DIFF
--- a/lib/dom_utils.js
+++ b/lib/dom_utils.js
@@ -563,9 +563,7 @@ var DomUtils = {
   injectUserScript(text) {
     if (text.slice(0, 11) === "javascript:") {
       text = text.slice(11).trim();
-      if (text.indexOf(" ") < 0) {
-        try { text = decodeURIComponent(text); } catch (error) {}
-      }
+      try { text = decodeURIComponent(text); } catch (error) {}
     }
     const script = document.createElement("script");
     script.textContent = text;


### PR DESCRIPTION
This PR is aimed to make user JavaScripts (aka bookmarklets) more stable.

## Background

Bookmarklets often contain some URL-unsafe characters like `"` or whitespace char. They are normally encoded by Chrome when you save it, but this behavior is not very consistent. AFAIK Chrome tends to partially leave these chars as they are, especially with relatively longer URLs. For instance I have my own bookmarklet like this:

```
javascript:(() => {const enableSelection=()=>{const e=document.body,t=e.parentNode;t.removeChild(e),t.appendChild(e.cloneNode(!0))},writeLyrics=(e,t=!0)=>{if(e)if(console.log(e),t)window.navigator.clipboard.writeText(e);else{const t=document.createElement("textarea");t.textContent=e,document.body.appendChild(t),t.select(),document.execCommand("copy")}},googleSearch=()=>{const e=document.querySelector("div[data-lyricid]");if(!e)return;const t=e.children[1];if(!t)return;const n=Array.from(t.children);return n&&0!==n.length?n.map((e=>e.innerText)).join("\n\n"):void 0},utaNet=()=>{enableSelection();const e=document.getElementById("kashi_area");if(e)return e.innerText};window.location.href.startsWith("https://www.google.com/search")&&writeLyrics(googleSearch(),!1),window.location.href.startsWith("https://www.uta-net.com/song/")&&writeLyrics(utaNet());})()
```

After this bookmarklet is saved once, the URL is now like this:

```
javascript:(() => {const enableSelection=()=>{const e=document.body,t=e.parentNode;t.removeChild(e),t.appendChild(e.cloneNode(!0))},writeLyrics=(e,t=!0)=>{if(e)if(console.log(e),t)window.navigator.clipboard.writeText(e);else{const t=document.createElement("textarea");t.textContent=e,document.body.appendChild(t),t.select(),document.execCommand("copy")}},googleSearch=()=>{const e=document.querySelector("div[data-lyricid]");if(!e)return;const t=e.children[1];if(!t)return;const n=Array.from(t.children);return n&&0!==n.length?n.map((e=%3Ee.innerText)).join(%22\n\n%22):void%200},utaNet=()=%3E{enableSelection();const%20e=document.getElementById(%22kashi_area%22);if(e)return%20e.innerText};window.location.href.startsWith(%22https://www.google.com/search%22)&&writeLyrics(googleSearch(),!1),window.location.href.startsWith(%22https://www.uta-net.com/song/%22)&&writeLyrics(utaNet());})()
```

You can see *untouched* whitespace char in `javascript:(() => {const enab...` and `"` in `...element("textarea");t.tex...` while special chars are somehow correctly encoded in the latter half. This should be a buggy behavior of Chrome, but this is what's going on.

## Why that's problematic for Vimium

In Vimium's Vomnibar bookmarklets with both whitespace chars and encoded chars (because of the reason described above) **are not decoded at all** before the execution, because it checks the non-existence of whitespace chars before `decodeURIComponent`. I'm guessing this is written to test if the URL has encoded chars, but it's in a wrong way. We can safely get rid of the check because `decodeURIComponent` is gonna change nothing at all if the original string has no special chars.

