### PR TITLE
Add support for escape map, unmap, ifurlmatches, endif.

### DIFF
--- a/content_scripts/scroller.js
+++ b/content_scripts/scroller.js
@@ -149,6 +149,9 @@ const checkVisibility = function(element) {
   // If the activated element has been scrolled completely offscreen, then subsequent changes in its scroll
   // position will not provide any more visual feedback to the user. Therefore, we deactivate it so that
   // subsequent scrolls affect the parent element.
+  if (!activatedElement) {
+    return false;
+  }
   const rect = activatedElement.getBoundingClientRect();
   if ((rect.bottom < 0) || (rect.top > window.innerHeight) || (rect.right < 0) || (rect.left > window.innerWidth)) {
     return activatedElement = element;

--- a/lib/keyboard_utils.js
+++ b/lib/keyboard_utils.js
@@ -73,16 +73,25 @@ const KeyboardUtils = {
   },
 
   isEscape: (function() {
-    let useVimLikeEscape = true;
-    Utils.monitorChromeStorage("useVimLikeEscape", value => useVimLikeEscape = value);
+    let escapes = {};
+    Utils.monitorChromeStorage("escapes", value => escapes = value);
 
     return function(event) {
-      // <c-[> is mapped to Escape in Vim by default.
+      let filteredEscapes = null;
+      let locationString = window.location.toString();
+      for (urlFilter in escapes) {
+        if (urlFilter != '' && locationString.match(urlFilter)) {
+          filteredEscapes = escapes[urlFilter];
+          break; 
+        }
+      }
+      if (!filteredEscapes) {
+        filteredEscapes = escapes[''];
+      }
       // Escape with a keyCode 229 means that this event comes from IME, and should not be treated as a
       // direct/normal Escape event.  IME will handle the event, not vimium.
       // See https://lists.w3.org/Archives/Public/www-dom/2010JulSep/att-0182/keyCode-spec.html
-      return ((event.key === "Escape") && (event.keyCode !== 229)) ||
-        (useVimLikeEscape && (this.getKeyCharString(event) === "<c-[>"));
+      return (event.keyCode !== 229) && (this.getKeyCharString(event) in filteredEscapes);
     };
   })(),
 


### PR DESCRIPTION
**ifurlmatches and endif only function for escape map/unmap.**

It also logs unparsable lines from config file instead of ignoring them.

This is a proof of concept so it's possible to write something like

```
ifUrlMatches https://colab.research.google.com/.*
  unmap <escape>
  map <s-escape> <escape>
endif
```

This implements https://github.com/philc/vimium/issues/1188.

It doesn't implement full blown support for ifUrlMatches, but only for escape key. This for me gives the biggest benefit.

Something similar could be trivially implemented for other commands if command file is parsed per web page and not globally.

Because this is not implemented I had to add another level of indirection in configuration and store per region mappings. This could be removed in case command file is parsed per web page.

If somebody could move command parsing to be per web page in that case this could be trivially implemented for all commands.

I'm making this PR primarily so I don't lose these code changes since Colab is useless without them with vimium, and vimium is useful for quickly jumping to different headers.

I'm aware of `map <c-]> passNextKey` hack, but this is not a realistic solution for heavily used sites. It is better to just turn off vimium in that case.

If somebody is frustrated like me with vimium interaction with rich web sites and finds this useful, cheers.

If there is a desire to merge this, I can add unit tests, but can't spend much time on this otherwise. 