### PR TITLE
not prevent click events since Firefox 96

### DIFF
--- a/lib/dom_utils.js
+++ b/lib/dom_utils.js
@@ -320,8 +320,11 @@ var DomUtils = {
     const eventSequence = ["mouseover", "mousedown", "mouseup", "click"];
     const result = [];
     for (let event of eventSequence) {
+      const mayBeBlocked =
+        event === "click" && Utils.isFirefox() && !navigator.userAgentData &&
+            parseInt((navigator.userAgent.match(/\bFirefox\/(\d+)/) || [0, 96])[1]) < 96
       const defaultActionShouldTrigger =
-        Utils.isFirefox() && (Object.keys(modifiers).length === 0) && (event === "click") &&
+        mayBeBlocked && (Object.keys(modifiers).length === 0) &&
             (element.target === "_blank") && element.href &&
             !element.hasAttribute("onclick") && !element.hasAttribute("_vimium-has-onclick-listener") ?
           // Simulating a click on a target "_blank" element triggers the Firefox popup blocker.
@@ -329,7 +332,7 @@ var DomUtils = {
           true
         :
           this.simulateMouseEvent(event, element, modifiers);
-      if ((event === "click") && defaultActionShouldTrigger && Utils.isFirefox()) {
+      if (mayBeBlocked && defaultActionShouldTrigger) {
         // Firefox doesn't (currently) trigger the default action for modified keys.
         if ((0 < Object.keys(modifiers).length) || (element.target === "_blank")) {
           DomUtils.simulateClickDefaultAction(element, modifiers);


### PR DESCRIPTION
It seems Firefox 96 allows extensions to trigger native click behaviors.
See https://github.com/philc/vimium/issues/3964 for reports.

Although this is not listed in https://www.mozilla.org/en-US/firefox/96.0/releasenotes/,
I think it's safe enough to skip preventing since Firefox 96.

This will fix #3964, fix #3979, fix #3986 and fix https://github.com/philc/vimium/issues/3579#issuecomment-981237048