### PR TITLE
fix opening links twice when `privacy.resistFingerprinting` is enabled or on Firefox 91.6+

### DIFF
--- a/content_scripts/vimium_frontend.js
+++ b/content_scripts/vimium_frontend.js
@@ -269,8 +269,11 @@ var Frame = {
     return HintCoordinator[request.messageType](request);
   },
 
-  registerFrameId({chromeFrameId}) {
-    frameId = (root.frameId = (window.frameId = chromeFrameId));
+  registerFrameId(request) {
+    frameId = (root.frameId = (window.frameId = request.chromeFrameId));
+    if (Utils.isFirefox()) {
+      Utils.firefoxVersion = () => request.firefoxVersion
+    }
     // We register a frame immediately only if it is focused or its window isn't tiny.  We register tiny
     // frames later, when necessary.  This affects focusFrame() and link hints.
     if (windowIsFocused() || !DomUtils.windowIsTooSmall()) {

--- a/lib/dom_utils.js
+++ b/lib/dom_utils.js
@@ -322,9 +322,7 @@ var DomUtils = {
     for (let event of eventSequence) {
       // In firefox prior to 96, simulating a click on an element would be blocked. In 96+,
       // extensions can trigger native click listeners on elements. See #3985.
-      const mayBeBlocked =
-        event === "click" && Utils.isFirefox() && !navigator.userAgentData &&
-            parseInt((navigator.userAgent.match(/\bFirefox\/(\d+)/) || [0, 96])[1]) < 96
+      const mayBeBlocked = event === "click" && Utils.isFirefox() && parseInt(Utils.firefoxVersion()) < 96
       const defaultActionShouldTrigger =
         mayBeBlocked && (Object.keys(modifiers).length === 0) &&
             (element.target === "_blank") && element.href &&

--- a/lib/dom_utils.js
+++ b/lib/dom_utils.js
@@ -323,6 +323,7 @@ var DomUtils = {
       // In firefox prior to 96, simulating a click on an element would be blocked. In 96+,
       // extensions can trigger native click listeners on elements. See #3985.
       const mayBeBlocked = event === "click" && Utils.isFirefox() && parseInt(Utils.firefoxVersion()) < 96
+          && /^91\.[0-5](\.|$)/.test(Utils.firefoxVersion())
       const defaultActionShouldTrigger =
         mayBeBlocked && (Object.keys(modifiers).length === 0) &&
             (element.target === "_blank") && element.href &&

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,8 +17,8 @@ if (window.forTrusted == null) {
   });
 }
 
-// TODO(philc): The comment below about its usage doesn't make sense to me. Can we replace this with
-// window.navigator?
+// Note(gdh1995): Info in navigator is not reliable, because sometimes browsers will provide fake values.
+// For example, when `privacy.resistFingerprinting` is enabled on `about:config` of Firefox.
 let browserInfo = null;
 if (window.browser && browser.runtime && browser.runtime.getBrowserInfo)
   browserInfo = browser.runtime.getBrowserInfo();
@@ -31,13 +31,17 @@ var Utils = {
     return () => isFirefox;
   })(),
 
+  // NOTE(gdh1995): Content scripts may access this only after `registerFrameId`
   firefoxVersion: (function() {
     // NOTE(mrmr1993): This only works in the background page.
     let ffVersion = undefined;
     if (browserInfo) {
-      browserInfo.then(browserInfo => ffVersion = browserInfo != null ? browserInfo.version : undefined);
+      browserInfo.then(info => {
+        ffVersion = info != null ? info.version : undefined
+        browserInfo = undefined
+      });
     }
-    return () => ffVersion;
+    return () => ffVersion || browserInfo;
   })(),
 
   getCurrentVersion() {


### PR DESCRIPTION
As said in https://github.com/philc/vimium/issues/3989#issuecomment-1019377405, Firefox will report a version of "91.0" in `navigator.userAgent`, if only `privacy.resistFingerprinting` on `about:config` is enabled.

This bug is reported in https://github.com/philc/vimium/issues/3989#issuecomment-1019370376 and https://github.com/philc/vimium/issues/3964#issuecomment-1024960014.

And https://github.com/philc/vimium/pull/3985#issuecomment-1043402172 reported Firefox 91.6.0 ESR has updated its blocking policy and then Vimium opens 2 tabs on it again. The latest commit adds support for this special case.

This also fixes #4021 and fixes #4032.
