### PR TITLE
add action=hover-and-scroll to LinkHints

### DIFF
--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -78,8 +78,9 @@ const COPY_LINK_TEXT = {
 const HOVER_LINK = {
   name: "hover",
   indicator: "Hover link",
+  doesScroll: false,
   linkActivator(link) {
-    new HoverMode(link);
+    new HoverMode(link, HOVER_LINK.doesScroll);
   }
 };
 const FOCUS_LINK = {
@@ -222,7 +223,10 @@ var LinkHints = {
     const action = registryEntry ? registryEntry.options.action : null;
     switch (action) {
       case "copy-text": mode = COPY_LINK_TEXT; break;
-      case "hover": mode = HOVER_LINK; break;
+      case "hover": case "hover-and-scroll":
+        HOVER_LINK.doesScroll = action !== "hover";
+        mode = HOVER_LINK;
+        break;
       case "focus": mode = FOCUS_LINK; break;
     }
 
@@ -1257,10 +1261,13 @@ class WaitForEnter extends Mode {
 }
 
 class HoverMode extends Mode {
-  constructor(link) {
+  constructor(link, doesScroll) {
     super();
     super.init({name: "hover-mode", singleton: "hover-mode", exitOnEscape: true});
     this.link = link;
+    if (doesScroll) {
+      Scroller.selectElement(link);
+    }
     DomUtils.simulateHover(this.link);
     this.onExit(() => DomUtils.simulateUnhover(this.link));
   }

--- a/content_scripts/scroller.js
+++ b/content_scripts/scroller.js
@@ -369,6 +369,11 @@ const Scroller = {
     return (element !== activatedElement) && isScrollableElement(element);
   },
 
+  // check
+  selectElement(element) {
+    activatedElement = element;
+  },
+
   // Scroll the top, bottom, left and right of element into view.  The is used by visual mode to ensure the
   // focus remains visible.
   scrollIntoView(element) {


### PR DESCRIPTION
This implements the idea said in https://github.com/philc/vimium/issues/3134#issuecomment-1049531404 ,
so that users may select a scrollable area by selecting one of its child elements, without worrying about side effects of clicking.
