### PR TITLE
Filter suggestions if certain symbols are in the query terms.

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -247,7 +247,8 @@ w: https://www.wikipedia.org/w/index.php?title=Special:Search&search=%s Wikipedi
     helpDialog_showAdvancedCommands: false,
     optionsPage_showAdvancedOptions: false,
     passNextKeyKeys: [],
-    ignoreKeyboardLayout: false
+    ignoreKeyboardLayout: false,
+    filterOmnibarSuggestions: false
   }
 };
 

--- a/pages/options.html
+++ b/pages/options.html
@@ -223,6 +223,20 @@ b: http://b.com/?q=%s description
             </td>
           </tr>
           <tr>
+            <td class="caption"></td>
+            <td verticalAlign="top" class="booleanOption">
+              <div class="help">
+                <div class="example">
+                  Based on <a target="_blank" href="https://support.mozilla.org/en-US/kb/address-bar-autocomplete-firefox#w_changing-results-on-the-fly">this Firefox feature</a>, filter your omnibar suggestions based on a token in the input.
+                </div>
+              </div>
+              <label>
+                <input id="filterOmnibarSuggestions" type="checkbox"/>
+                Filter omnibar suggestions
+              </label>
+            </td>
+          </tr>
+          <tr>
             <td class="caption">Previous patterns</td>
             <td verticalAlign="top">
                 <div class="help">

--- a/pages/options.js
+++ b/pages/options.js
@@ -255,7 +255,8 @@ const Options = {
   grabBackFocus: CheckBoxOption,
   searchEngines: TextOption,
   searchUrl: NonEmptyTextOption,
-  userDefinedLinkHintCss: NonEmptyTextOption
+  userDefinedLinkHintCss: NonEmptyTextOption,
+  filterOmnibarSuggestions: CheckBoxOption
 };
 
 const initOptionsPage = function() {


### PR DESCRIPTION
This implements a few filters based on the article here:
https://support.mozilla.org/en-US/kb/address-bar-autocomplete-firefox#w_changing-results-on-the-fly

The article mentions filtering based on bookmark tags, and that's not
possible due to them not being exposed via the API at this time.

## Description
Provide a rationale for this PR, and a reference to the corresponding issue, if there is one.

Please review the "Which pull requests get merged?" section in `CONTRIBUTING.md`.
