### PR TITLE
Link hints for role="radio"

### DIFF
--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -910,7 +910,7 @@ var LocalHints = {
     if (element.hasAttribute("onclick")) {
       isClickable = true;
     } else if (((role = element.getAttribute("role")) != null) &&
-               ["button" , "tab" , "link", "checkbox", "menuitem", "menuitemcheckbox", "menuitemradio"].includes(role.toLowerCase())) {
+               ["button" , "tab" , "link", "checkbox", "menuitem", "menuitemcheckbox", "menuitemradio", "radio"].includes(role.toLowerCase())) {
       isClickable = true;
     } else if (((contentEditable = element.getAttribute("contentEditable")) != null) &&
                ["", "contenteditable", "true"].includes(contentEditable.toLowerCase())) {


### PR DESCRIPTION
## Description
Add support for the ARIA `radio` role in link hints detection. This provides parity with `<input type="radio" />` radio buttons, which currently receive link hints.
