### PR TITLE
Duplicate clicks in Firefox

### DIFF
--- a/lib/dom_utils.js
+++ b/lib/dom_utils.js
@@ -337,7 +337,8 @@ var DomUtils = {
       if (mayBeBlocked && defaultActionShouldTrigger) {
         // Firefox doesn't (currently) trigger the default action for modified keys.
         if ((0 < Object.keys(modifiers).length) || (element.target === "_blank")) {
-          DomUtils.simulateClickDefaultAction(element, modifiers);
+          if(!Utils.isFirefox())
+            DomUtils.simulateClickDefaultAction(element, modifiers);
         }
       }
       result.push(defaultActionShouldTrigger);


### PR DESCRIPTION
Calling simulateClickDefaultAction function causes duplicate tabs in "Open link in new tab." and "Open link in new tab and switch to it." modes in Firefox.

Tested version: Firefox 91.6.0esr (64 bit)