### PR TITLE
FIX Visual/Caret Mode initialization

### DIFF
--- a/content_scripts/mode_visual.js
+++ b/content_scripts/mode_visual.js
@@ -386,8 +386,8 @@ VisualMode.prototype.movements = {
   "Y"(count) { this.movement.selectLine(count); return this.yank(); },
   "p"() { return chrome.runtime.sendMessage({handler: "openUrlInCurrentTab", url: this.yank()}); },
   "P"() { return chrome.runtime.sendMessage({handler: "openUrlInNewTab", url: this.yank()}); },
-  "v"() { return new VisualMode; },
-  "V"() { return new VisualLineMode; },
+  "v"() { return new VisualMode().init(); },
+  "V"() { return new VisualLineMode.init(); },
   "c"() {
     // If we're already in caret mode, or if the selection looks the same as it would in caret mode, then
     // callapse to anchor (so that the caret-mode selection will seem unchanged).  Otherwise, we're in visual
@@ -396,7 +396,7 @@ VisualMode.prototype.movements = {
       this.movement.collapseSelectionToAnchor();
     else
       this.movement.collapseSelectionToFocus();
-    return new CaretMode;
+    return new CaretMode().init();
   },
   "o"() { return this.movement.reverseSelection(); }
 };


### PR DESCRIPTION
## Description
I am using an spanish layout keyboard and stumbled upon https://github.com/philc/vimium/pull/3877 opened almost over a year ago and contains code unrelated to the PR. So I removed the unrelated code (about the scrolling) and fixed the initializations of the Visual and Caret Mode to get it merged faster into [philc:master](https://github.com/philc/vimium). In case this one gets merged https://github.com/philc/vimium/pull/3877 could be closed and vice-versa.