### PR TITLE
Don't trigger "InstallTrigger is deprecated and will be removed in the future" warning

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,8 +19,14 @@ if (window.browser && browser.runtime && browser.runtime.getBrowserInfo)
 
 var Utils = {
   isFirefox: (function() {
+    let isFirefox = false;
+
     // We want this browser check to also cover Firefox variants, like LibreWolf. See #3773.
-    const isFirefox = typeof InstallTrigger !== 'undefined';
+    isFirefox = 'InstallTrigger' in window;
+
+    if (!isFirefox && browserInfo) {
+      browserInfo.then(browserInfo => isFirefox = browserInfo.name === "Firefox");
+    }
     return () => isFirefox;
   })(),
 


### PR DESCRIPTION
By checking for presence in window it doesn't trigger the warning, which
is a bit annoying since it's in my console all the time and makes it
harder to see "did the script I'm working on throw a warning/error?" at
a glance.

Furthermore, it also puts back the old check that was removed in #3773;
InstallTrigger will be removed eventually, and it will then break for
everyone. This conditional should probably be updated, but I don't know
what to (and any updated version may have the same issue).

Fixes #4033