### PR TITLE
feat(completion): adds man page search, completion

### DIFF
--- a/background_scripts/completion_engines.js
+++ b/background_scripts/completion_engines.js
@@ -73,10 +73,10 @@ class GoogleMaps extends GoogleXMLBaseEngine {
         keyword: "m",
         explanation:
         `\
-        This uses regular Google completion, but prepends the text "<tt>map of</tt>" to the query.  It works
-        well for places, countries, states, geographical regions and the like, but will not perform address
-        search.\
-        `
+This uses regular Google completion, but prepends the text "<tt>map of</tt>" to the query.  It works
+well for places, countries, states, geographical regions and the like, but will not perform address
+search.\
+`
       }
     });
   }

--- a/background_scripts/completion_engines.js
+++ b/background_scripts/completion_engines.js
@@ -39,10 +39,12 @@ class BaseEngine {
 
 // Several Google completion engines package responses as XML. This parses such XML.
 class GoogleXMLBaseEngine extends BaseEngine {
-  parse(xhr) {
-    return Array.from(xhr.responseXML.getElementsByTagName("suggestion"))
-    .map(suggestion => suggestion.getAttribute("data"))
-    .filter(suggestion => suggestion);
+  parse(body) {
+    const parser = new DOMParser();
+    const xml = parser.parseFromString(body, 'application/xml');
+    return Array.from(xml.getElementsByTagName("suggestion"))
+      .map(suggestion => suggestion.getAttribute("data"))
+      .filter(suggestion => suggestion);
   }
 }
 
@@ -70,17 +72,17 @@ class GoogleMaps extends GoogleXMLBaseEngine {
         searchUrl: "https://www.google.com/maps?q=%s",
         keyword: "m",
         explanation:
-          `\
-This uses regular Google completion, but prepends the text "<tt>map of</tt>" to the query.  It works
-well for places, countries, states, geographical regions and the like, but will not perform address
-search.\
-`
+        `\
+        This uses regular Google completion, but prepends the text "<tt>map of</tt>" to the query.  It works
+        well for places, countries, states, geographical regions and the like, but will not perform address
+        search.\
+        `
       }
     });
   }
 
-  parse(xhr) {
-    return Array.from(super.parse(xhr))
+  parse(body) {
+    return Array.from(super.parse(body))
     .filter(suggestion => suggestion.startsWith(GoogleMaps.prefix))
     .map(suggestion => suggestion.slice(GoogleMaps.prefix.length));
   }
@@ -100,6 +102,22 @@ class Youtube extends GoogleXMLBaseEngine {
     });
   }
 }
+class ManKier extends BaseEngine {
+  constructor() {
+    super({
+      engineUrl: "https://www.mankier.com/api/v2/mans/?q=%s",
+      regexps: ["^https?://www\\.mankier\\.com"],
+      example: {
+        searchUrl: "https://www.mankier.com/?q=%s",
+        keyword: "ma"
+      }
+    });
+  }
+
+  parse(body) {
+    return JSON.parse(body).results.map((res) => res.name);
+  }
+}
 
 class Wikipedia extends BaseEngine {
   constructor() {
@@ -113,7 +131,7 @@ class Wikipedia extends BaseEngine {
     });
   }
 
-  parse(xhr) { return JSON.parse(xhr.responseText)[1]; }
+  parse(body) { return JSON.parse(body)[1]; }
 }
 
 class Bing extends BaseEngine {
@@ -128,7 +146,7 @@ class Bing extends BaseEngine {
     });
   }
 
-  parse(xhr) { return JSON.parse(xhr.responseText)[1]; }
+  parse(body) { return JSON.parse(body)[1]; }
 }
 
 class Amazon extends BaseEngine {
@@ -143,7 +161,7 @@ class Amazon extends BaseEngine {
     });
   }
 
-  parse(xhr) { return JSON.parse(xhr.responseText)[1]; }
+  parse(body) { return JSON.parse(body)[1]; }
 }
 
 class AmazonJapan extends BaseEngine {
@@ -158,7 +176,7 @@ class AmazonJapan extends BaseEngine {
     });
   }
 
-  parse(xhr) { return JSON.parse(xhr.responseText)[1]; }
+  parse(body) { return JSON.parse(body)[1]; }
 }
 
 class DuckDuckGo extends BaseEngine {
@@ -173,8 +191,8 @@ class DuckDuckGo extends BaseEngine {
     });
   }
 
-  parse(xhr) {
-    return Array.from(JSON.parse(xhr.responseText)).map((suggestion) => suggestion.phrase);
+  parse(body) {
+    return Array.from(JSON.parse(body)).map((suggestion) => suggestion.phrase);
   }
 }
 
@@ -191,8 +209,8 @@ class Webster extends BaseEngine {
     });
   }
 
-  parse(xhr) {
-    return Array.from(JSON.parse(xhr.responseText).docs).map((suggestion) => suggestion.word);
+  parse(body) {
+    return Array.from(JSON.parse(body).docs).map((suggestion) => suggestion.word);
   }
 }
 
@@ -208,8 +226,8 @@ class Qwant extends BaseEngine {
     });
   }
 
-  parse(xhr) {
-    return Array.from(JSON.parse(xhr.responseText).data.items).map((suggestion) => suggestion.value);
+  parse(body) {
+    return Array.from(JSON.parse(body).data.items).map((suggestion) => suggestion.value);
   }
 }
 
@@ -225,7 +243,7 @@ class UpToDate extends BaseEngine {
     });
   }
 
-  parse(xhr) { return JSON.parse(xhr.responseText).data.searchTerms; }
+  parse(body) { return JSON.parse(body).data.searchTerms; }
 }
 
 // A dummy search engine which is guaranteed to match any search URL, but never produces completions.  This
@@ -252,6 +270,7 @@ const CompletionEngines = [
   Webster,
   Qwant,
   UpToDate,
+  ManKier,
   DummyCompletionEngine
 ];
 

--- a/background_scripts/completion_search.js
+++ b/background_scripts/completion_search.js
@@ -186,14 +186,14 @@ const CompletionSearch = {
         });
       }
 
-          // ... then use the suggestions.
-          this.inTransit[completionCacheKey].use(suggestions => {
-            this.mostRecentSearchUrl = searchUrl;
-            this.mostRecentQuery = query;
-            this.mostRecentSuggestions = suggestions;
-            // TODO(philc): Is this return necessary?
-            return callback(this.completionCache.set(completionCacheKey, suggestions));
-          });
+      // ... then use the suggestions.
+      this.inTransit[completionCacheKey].use(suggestions => {
+        this.mostRecentSearchUrl = searchUrl;
+        this.mostRecentQuery = query;
+        this.mostRecentSuggestions = suggestions;
+        // TODO(philc): Is this return necessary?
+        return callback(this.completionCache.set(completionCacheKey, suggestions));
+      });
     })));
   },
 

--- a/background_scripts/completion_search.js
+++ b/background_scripts/completion_search.js
@@ -33,8 +33,8 @@ class EnginePrefixWrapper {
     return this.engine.getUrl(queryTerms);
   }
 
-  parse(xhr) {
-    return this.postprocessSuggestions(this.engine.parse(xhr));
+  parse(body) {
+    return this.postprocessSuggestions(this.engine.parse(body));
   }
 
   postprocessSuggestions(suggestions) { return suggestions; }
@@ -46,22 +46,17 @@ const CompletionSearch = {
   completionCache: new SimpleCache(2 * 60 * 60 * 1000, 5000), // Two hours, 5000 entries.
   engineCache:new SimpleCache(1000 * 60 * 60 * 1000), // 1000 hours.
 
+
   // The amount of time to wait for new requests before launching the current request (for example, if the user
   // is still typing).
   delay: 100,
 
   get(searchUrl, url, callback) {
-    const xhr = new XMLHttpRequest();
-    xhr.open("GET", url, true);
-    xhr.timeout = 2500;
-    // According to https://xhr.spec.whatwg.org/#request-error-steps,
-    // readystatechange always gets called whether a request succeeds or not,
-    // and the `readyState == 4` means an associated `state` is "done", which is true even if any error happens
-    xhr.onreadystatechange = function() {
-      if (xhr.readyState === 4)
-        return callback(xhr.status === 200 ? xhr : null);
-    };
-    return xhr.send();
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), 2500);
+    return fetch(url, { method: 'GET', mode: 'cors', signal: controller.signal })
+    .then((response) => clearTimeout(id) && response.status !== 200 ? callback(null) : response.text())
+    .then((body) => callback(body));
   },
 
   // Look up the completion engine for this searchUrl.  Because of DummyCompletionEngine, we know there will
@@ -163,13 +158,13 @@ const CompletionSearch = {
           const url = engine.getUrl(queryTerms);
 
           // TODO(philc): Do we need to return the result of this.get here, or can we remove this return statement?
-          return this.get(searchUrl, url, (xhr = null) => {
+          return this.get(searchUrl, url, (body = null) => {
             // Parsing the response may fail if we receive an unexpected or an unexpectedly-formatted response.
             // In all cases, we fall back to the catch clause, below.  Therefore, we "fail safe" in the case of
             // incorrect or out-of-date completion engines.
             let suggestions;
             try {
-              suggestions = engine.parse(xhr)
+              suggestions = engine.parse(body)
                 // Make all suggestions lower case. It looks odd when suggestions from one completion engine are
                 // upper case, and those from another are lower case.
                 .map(s => s.toLowerCase())
@@ -191,14 +186,14 @@ const CompletionSearch = {
         });
       }
 
-      // ... then use the suggestions.
-      this.inTransit[completionCacheKey].use(suggestions => {
-        this.mostRecentSearchUrl = searchUrl;
-        this.mostRecentQuery = query;
-        this.mostRecentSuggestions = suggestions;
-        // TODO(philc): Is this return necessary?
-        return callback(this.completionCache.set(completionCacheKey, suggestions));
-      });
+          // ... then use the suggestions.
+          this.inTransit[completionCacheKey].use(suggestions => {
+            this.mostRecentSearchUrl = searchUrl;
+            this.mostRecentQuery = query;
+            this.mostRecentSuggestions = suggestions;
+            // TODO(philc): Is this return necessary?
+            return callback(this.completionCache.set(completionCacheKey, suggestions));
+          });
     })));
   },
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -239,6 +239,7 @@ w: https://www.wikipedia.org/w/index.php?title=Special:Search&search=%s Wikipedi
 # b: https://www.bing.com/search?q=%s Bing
 # d: https://duckduckgo.com/?q=%s DuckDuckGo
 # az: https://www.amazon.com/s/?field-keywords=%s Amazon
+# ma: https://www.mankier.com/?q=%s ManKier
 # qw: https://www.qwant.com/?q=%s Qwant\
 `,
     newTabUrl: "about:newtab",


### PR DESCRIPTION
## Description
I am a big fan of this project and humbly request this PR for consideration. 

It adds support for man page completion by way of [mankier](https://www.mankier.com/). This site is very useful for reading command documentation in the browser. Here is an [example](https://www.mankier.com/1/fd) of such a man page.
- This was relatively straightforward to accomplish by way of extending the completion `BaseEngine`.

Small refactor to use [Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) instead of `XMLHttpRequest`. I did this for two reasons:
- The [MV3](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-overview/) spec [requires](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#background-service-workers) that the background script use `Fetch`, as SW has no access to `XMLHttpRequest`. 
- `XMLHttpRequest` has no equivalent of [mode](https://javascript.info/fetch-api#mode) - without which API calls to the ManKier endpoint will fail, due to a CSP violation.

Thank you!

Please review the "Which pull requests get merged?" section in `CONTRIBUTING.md`.
:white_check_mark:
