### PR TITLE
[niche] Add Host Search to vim

### DIFF
--- a/background_scripts/commands.js
+++ b/background_scripts/commands.js
@@ -226,7 +226,8 @@ const Commands = {
       "Vomnibar.activateBookmarksInNewTab",
       "Vomnibar.activateTabSelection",
       "Vomnibar.activateEditUrl",
-      "Vomnibar.activateEditUrlInNewTab"],
+      "Vomnibar.activateEditUrlInNewTab",
+      "Vomnibar.searchCurrentHost"],
     findCommands: ["enterFindMode", "performFind", "performBackwardsFind"],
     historyNavigation:
       ["goBack", "goForward"],
@@ -265,6 +266,7 @@ const Commands = {
     "LinkHints.activateModeToDownloadLink",
     "Vomnibar.activateEditUrl",
     "Vomnibar.activateEditUrlInNewTab",
+    "Vomnibar.searchCurrentHost",
     "LinkHints.activateModeToOpenIncognito",
     "LinkHints.activateModeToCopyLinkUrl",
     "goNext",
@@ -450,6 +452,7 @@ const commandDescriptions = {
   "Vomnibar.activateBookmarksInNewTab": ["Open a bookmark in a new tab", { topFrame: true }],
   "Vomnibar.activateEditUrl": ["Edit the current URL", { topFrame: true }],
   "Vomnibar.activateEditUrlInNewTab": ["Edit the current URL and open in a new tab", { topFrame: true }],
+  "Vomnibar.searchCurrentHost": ["Search Current Host", { topFrame: true }],
 
   nextFrame: ["Select the next frame on the page", { background: true }],
   mainFrame: ["Select the page's main/top frame", { topFrame: true, noRepeat: true }],

--- a/content_scripts/mode_normal.js
+++ b/content_scripts/mode_normal.js
@@ -277,7 +277,8 @@ if (typeof Vomnibar !== 'undefined') {
     "Vomnibar.activateBookmarks": Vomnibar.activateBookmarks.bind(Vomnibar),
     "Vomnibar.activateBookmarksInNewTab": Vomnibar.activateBookmarksInNewTab.bind(Vomnibar),
     "Vomnibar.activateEditUrl": Vomnibar.activateEditUrl.bind(Vomnibar),
-    "Vomnibar.activateEditUrlInNewTab": Vomnibar.activateEditUrlInNewTab.bind(Vomnibar)
+    "Vomnibar.activateEditUrlInNewTab": Vomnibar.activateEditUrlInNewTab.bind(Vomnibar),
+    "Vomnibar.searchCurrentHost": Vomnibar.searchCurrentHost.bind(Vomnibar)
   });
 }
 

--- a/content_scripts/vomnibar.js
+++ b/content_scripts/vomnibar.js
@@ -63,6 +63,15 @@ const Vomnibar = {
     });
   },
 
+  searchCurrentHost(sourceFrameId) {
+    return this.open(sourceFrameId, {
+      completer: "omni",
+      selectFirst: false,
+      query: `site:${window.location.host} `,
+      newTab: true
+    });
+  },
+
   init() {
     if (!this.vomnibarUI)
       this.vomnibarUI = new UIComponent("pages/vomnibar.html", "vomnibarFrame", function() {})


### PR DESCRIPTION
Implements the ability to search the current host via google. Basically the same as: https://chrome.google.com/webstore/detail/search-the-current-site/jliolpcnkmolaaecncdfeofombdekjcp

