### PR TITLE
Chrome: fix state icon

### DIFF
--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -493,7 +493,7 @@ var Frames = {
         const enabledStateIcon =
           !enabledState.isEnabledForUrl ?
             DISABLED_ICON
-          : enabledState.passKeys.length >= 0 ?
+          : enabledState.passKeys.length > 0 ?
             PARTIAL_ICON
           :
             ENABLED_ICON;


### PR DESCRIPTION
## Description
This PR fixes extension icon on Google Chrome to use **ENABLED_ICON** if there is no partial rule for the current page.