### PR TITLE
Fix: Using `Clipboard API` instead of `execCommand`

### DIFF
--- a/content_scripts/hud.js
+++ b/content_scripts/hud.js
@@ -37,8 +37,8 @@ const HUD = {
       // Force the re-computation of styles, so Chrome sends a visibility change message to the child frame.
       // See https://github.com/philc/vimium/pull/3277#issuecomment-487363284
 
-      // Allow to access the clipboard through iframes.
-      this.hudUI.iframeElement.allow = "clipboard-read";
+      // Allow to access to the clipboard through iframes.
+      this.hudUI.iframeElement.allow = "clipboard-read; clipboard-write";
       getComputedStyle(this.hudUI.iframeElement).display;
     } else {
       this.hudUI.toggleIframeElementClasses("vimiumClickable", "vimiumNonClickable");

--- a/content_scripts/hud.js
+++ b/content_scripts/hud.js
@@ -36,6 +36,9 @@ const HUD = {
       this.hudUI.toggleIframeElementClasses("vimiumUIComponentHidden", "vimiumUIComponentVisible");
       // Force the re-computation of styles, so Chrome sends a visibility change message to the child frame.
       // See https://github.com/philc/vimium/pull/3277#issuecomment-487363284
+
+      // Allow to access the clipboard through iframes.
+      this.hudUI.iframeElement.allow = "clipboard-read";
       getComputedStyle(this.hudUI.iframeElement).display;
     } else {
       this.hudUI.toggleIframeElementClasses("vimiumClickable", "vimiumNonClickable");

--- a/lib/clipboard.js
+++ b/lib/clipboard.js
@@ -9,13 +9,13 @@ const Clipboard = {
   },
 
   // http://groups.google.com/group/chromium-extensions/browse_thread/thread/49027e7f3b04f68/f6ab2457dee5bf55
-  copy({data}) {
+  async copy({data}) {
     const textArea = this._createTextArea();
     textArea.value = data.replace(/\xa0/g, " ");
 
     document.body.appendChild(textArea);
     textArea.select();
-    document.execCommand("Copy");
+    await navigator.clipboard.writeText(textArea.value);
     document.body.removeChild(textArea);
   },
 

--- a/lib/clipboard.js
+++ b/lib/clipboard.js
@@ -20,12 +20,11 @@ const Clipboard = {
   },
 
   // Returns a string representing the clipboard contents. Supports rich text clipboard values.
-  paste() {
+  async paste() {
     const textArea = this._createTextArea("div"); // Use a <div> so Firefox pastes rich text.
     document.body.appendChild(textArea);
     textArea.focus();
-    document.execCommand("Paste");
-    const value = textArea.innerText;
+    const value = await navigator.clipboard.readText();
     document.body.removeChild(textArea);
     // When copying &nbsp; characters, they get converted to \xa0. Convert to space instead. See #2217.
     return value.replace(/\xa0/g, " ");

--- a/pages/hud.js
+++ b/pages/hud.js
@@ -153,9 +153,9 @@ const handlers = {
   },
 
   pasteFromClipboard() {
-    Utils.setTimeout(TIME_TO_WAIT_FOR_IPC_MESSAGES, function() {
+    Utils.setTimeout(TIME_TO_WAIT_FOR_IPC_MESSAGES, async function() {
       const focusedElement = document.activeElement;
-      const data = Clipboard.paste();
+      const data = await Clipboard.paste();
       if (focusedElement != null)
         focusedElement.focus();
       window.parent.focus();

--- a/pages/hud.js
+++ b/pages/hud.js
@@ -142,9 +142,9 @@ const handlers = {
   },
 
   copyToClipboard(data) {
-    Utils.setTimeout(TIME_TO_WAIT_FOR_IPC_MESSAGES, function() {
+    Utils.setTimeout(TIME_TO_WAIT_FOR_IPC_MESSAGES, async function() {
       const focusedElement = document.activeElement;
-      Clipboard.copy(data);
+      await Clipboard.copy(data);
       if (focusedElement != null)
         focusedElement.focus();
       window.parent.focus();


### PR DESCRIPTION
On Chrome version 105.0.5195.102 (64-bit), `execCommand("Paste")` no longer seems to work.
https://github.com/philc/vimium/issues/4120

What is worse, execCommand is said completely not to work by January 2023, since Manifest 
 V2 is supposed to stop working.
https://www.bleepingcomputer.com/news/google/google-manifest-v2-chrome-extensions-to-stop-working-in-2023/

Instead of execCommand, I use [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API), which is designed to supersede accessing the clipboard using [document.execCommand()](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand).

Thanks.