### PR TITLE
Fix regression of background colors (dark mode) of Vimium iframes

### DIFF
--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -425,6 +425,7 @@ iframe.vimiumUIComponentHidden {
 
 iframe.vimiumUIComponentVisible {
   display: block;
+  color-scheme: light dark;
 }
 
 iframe.vimiumUIComponentReactivated {
@@ -512,8 +513,4 @@ iframe.vimiumNonClickable {
     box-shadow: none;
     color: white;
   }
-}
-
-.vimiumUIComponentVisible {
-  color-scheme: normal;
 }

--- a/pages/help_dialog.html
+++ b/pages/help_dialog.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>Vimium Help</title>
+    <meta name="color-scheme" content="light dark">
     <script src="../lib/utils.js"></script>
     <script src="../lib/keyboard_utils.js"></script>
     <script src="../lib/dom_utils.js"></script>

--- a/pages/hud.html
+++ b/pages/hud.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>HUD</title>
+    <meta name="color-scheme" content="light dark">
     <link rel="stylesheet" type="text/css" href="../content_scripts/vimium.css" />
     <script type="text/javascript" src="../lib/utils.js"></script>
     <script type="text/javascript" src="../lib/dom_utils.js"></script>

--- a/pages/vomnibar.html
+++ b/pages/vomnibar.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <title>Vomnibar</title>
+    <meta name="color-scheme" content="light dark">
     <script type="text/javascript" src="../lib/utils.js"></script>
     <script type="text/javascript" src="../lib/settings.js"></script>
     <script type="text/javascript" src="../lib/keyboard_utils.js"></script>


### PR DESCRIPTION
**Updated**: `color-scheme: light dark;` works perfectly on Firefox 105/106 and Chrome 88/99/106 during my testes.

1. The changes which breaks `color-scheme: light`, as reported in #4148, is caused by a fix of https://bugzilla.mozilla.org/show_bug.cgi?id=1782596 .
2. And then I searched and found [1789338 - Element picker is light themed when uBlock origin theme is set to auto in Nightly](https://bugzilla.mozilla.org/show_bug.cgi?id=1789338)
3. So I installed uBlock Origin and tested its picker iframe, and noticed `color-scheme: light dark` (https://github.com/gorhill/uBlock/pull/3872)

Then this fixes #4156 and replaces commit fbeee3dd557ffaa0cb82bf783b997ba4cfc74d91.