### PR TITLE
avoid triggering popup blocker on some old versions of firefox 

### DIFF
--- a/lib/dom_utils.js
+++ b/lib/dom_utils.js
@@ -320,16 +320,25 @@ var DomUtils = {
     const eventSequence = ["mouseover", "mousedown", "mouseup", "click"];
     const result = [];
     for (let event of eventSequence) {
-      // In firefox prior to 96, simulating a click on an element would be blocked. In 96+,
-      // extensions can trigger native click listeners on elements. See #3985.
-      const mayBeBlocked = event === "click" && Utils.isFirefox() && parseInt(Utils.firefoxVersion()) < 96
-          && /^91\.[0-5](\.|$)/.test(Utils.firefoxVersion())
+      // In firefox prior to 96, simulating a click on an element would be blocked under some conditions (#2602, #2960).
+      // In 96+, extensions can trigger native click listeners on elements (#3985).
+      // While 91.6.0esr also merged the patch, so it's necessary to check the minor version (#4000).
+      // The root difference is a logic change imported in https://bugzilla.mozilla.org/show_bug.cgi?id=1739929 .
+      let mayBeBlocked = false
+      if (event === "click" && Utils.isFirefox()) {
+        const [major, minor] = (Utils.firefoxVersion() + "").split(".").map(i => parseInt(i) || 0)
+        if (major > 0 && major < 96) {
+          if (major !== 91) {
+            mayBeBlocked = true
+          } else if (element.target === "_blank" && Object.keys(modifiers).length === 0 || minor != null && minor < 6) {
+            mayBeBlocked = true // see https://github.com/philc/vimium/pull/3985#issue-1101757110
+          }
+        }
+      }
       const defaultActionShouldTrigger =
         mayBeBlocked && (Object.keys(modifiers).length === 0) &&
             (element.target === "_blank") && element.href &&
             !element.hasAttribute("onclick") && !element.hasAttribute("_vimium-has-onclick-listener") ?
-          // Simulating a click on a target "_blank" element triggers the Firefox popup blocker.
-          // Note(smblott) This will be incorrect if there is a click listener on the element.
           true
         :
           this.simulateMouseEvent(event, element, modifiers);


### PR DESCRIPTION
The old code in #4000 ignores Firefox versions which are older than 96 while don't belong to 91. So this PR adds it.

Should fix #4165 .
