### PR TITLE
Fix shebang line error during build

### DIFF
--- a/make.js
+++ b/make.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env deno run --allow-read --allow-write --allow-env --allow-net --allow-run --unstable
+#!/usr/bin/env -S deno run --allow-read --allow-write --allow-env --allow-net --allow-run --unstable
 // --unstable is required for Puppeteer.
 // Usage: ./make.js command. Use -l to list commands.
 // This is a set of tasks for building and testing Vimium in development.


### PR DESCRIPTION
Fix error running `./make.js`.
## Description
Fix error `/usr/bin/env: ‘deno run --allow-read --allow-write --allow-env --allow-net --allow-run --unstable’: No such file or directory` when building via `./make.js package`.

