### PR TITLE
Fix text overflowing button container

### DIFF
--- a/pages/options.css
+++ b/pages/options.css
@@ -137,7 +137,7 @@ input#searchUrl {
 }
 #buttonsPanel { width: 100%; }
 #advancedOptions { display: none; }
-#advancedOptionsButton { width: 170px; }
+#advancedOptionsButton { width: 200px; }
 .help {
   position: absolute;
   right: -320px;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49123398/202931483-3a150af5-867d-4227-9a30-f1ab03c376b7.png)

![image](https://user-images.githubusercontent.com/49123398/202931528-45dd0ecd-9d9e-4b0c-ac53-7952d872e531.png)

I am not set up to test this change, so I don't know if the width increase is sufficient.

Notice in the image above that there is no 's' in "Show Advanced Options". Despite this, [the code in question](https://github.com/philc/vimium/blob/master/pages/options.js#L282-L291) seems correct. 

Although "show" and "hide" are both 4 characters, they are not equally spaced; therefore, I determine width to be the cause of this too. The proposed fix should fix both issues.