### PR TITLE
Add clipboardWrite back to manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -34,6 +34,7 @@
     "sessions",
     "notifications",
     "webNavigation",
+    "clipboardWrite",
     "<all_urls>"
   ],
   "content_scripts": [


### PR DESCRIPTION
## Description
On Chrome and FireFox, `yy` and `yf` do not work. Adding `clipboardWrite` back to the `manifest.json` solves this. The current version doesn’t work for me on either Chrome or FireFox dev edition, after updating the manifest and installing on Chrome/FireFox, `yy` and `yf` work. Solves #4170 and #4173.