### PR TITLE
Add yank (copy) markdown link of current tab

### DIFF
--- a/background_scripts/commands.js
+++ b/background_scripts/commands.js
@@ -197,6 +197,7 @@ const Commands = {
       "scrollToRight",
       "reload",
       "copyCurrentUrl",
+      "copyCurrentMarkdown",
       "openCopiedUrlInCurrentTab",
       "openCopiedUrlInNewTab",
       "goUp",
@@ -297,6 +298,7 @@ const defaultKeyMappings = {
   "u": "scrollPageUp",
   "r": "reload",
   "yy": "copyCurrentUrl",
+  "ym": "copyCurrentMarkdown",
   "p": "openCopiedUrlInCurrentTab",
   "P": "openCopiedUrlInNewTab",
   "gi": "focusInput",
@@ -386,6 +388,7 @@ const commandDescriptions = {
   toggleViewSource: ["View page source", { noRepeat: true }],
 
   copyCurrentUrl: ["Copy the current URL to the clipboard", { noRepeat: true }],
+  copyCurrentMarkdown: ["Copy the current title and URL as markdown link to the clipboard", { noRepeat: true }],
   openCopiedUrlInCurrentTab: ["Open the clipboard's URL in the current tab", { noRepeat: true }],
   openCopiedUrlInNewTab: ["Open the clipboard's URL in a new tab", { repeatLimit: 20 }],
 

--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -633,6 +633,7 @@ var sendRequestHandlers = {
   // getCurrentTabUrl is used by the content scripts to get their full URL, because window.location cannot help
   // with Chrome-specific URLs like "view-source:http:..".
   getCurrentTabUrl({tab}) { return tab.url; },
+  getCurrentTabMarkdown({tab}) { return `[${tab.title}](${tab.url})` },
   openUrlInNewTab: mkRepeatCommand((request, callback) => TabOperations.openUrlInNewTab(request, callback)),
   openUrlInNewWindow(request) { return TabOperations.openUrlInNewWindow(request); },
   openUrlInIncognito(request) { return chrome.windows.create({incognito: true, url: Utils.convertToUrl(request.url)}); },

--- a/content_scripts/mode_normal.js
+++ b/content_scripts/mode_normal.js
@@ -119,6 +119,15 @@ var NormalModeCommands = {
     });
   },
 
+  copyCurrentMarkdown() {
+    chrome.runtime.sendMessage({ handler: "getCurrentTabMarkdown" }, function(url) {
+      HUD.copyToClipboard(url);
+      if (28 < url.length)
+        url = url.slice(0, 26) + "....";
+      HUD.showForDuration(`Yanked ${url}`, 2000);
+    });
+  },
+
   openCopiedUrlInNewTab(count) {
     HUD.pasteFromClipboard(url => chrome.runtime.sendMessage({ handler: "openUrlInNewTab", url, count }));
   },


### PR DESCRIPTION
This adds a new command, copyCurrentMarkdown, with a default keybinding `ym`, to copy a link to the current tab in markdown format, i.e. "[title](url)".

## Description
Firstly, this has been suggested and implemented before, see PR #2054.
However, that pull request was never merged.
Having a way to copy a link in markdown format is implemented in other projects for keyboard-based browsing, for example qutebrowser. It is typically something a user expects to be able to do easily.
It relates to issues #131 #889 #2474 #3611 #4133 