### PR TITLE
Move cursor at end of text on focused one-line textareas

### DIFF
--- a/lib/dom_utils.js
+++ b/lib/dom_utils.js
@@ -299,11 +299,15 @@ var DomUtils = {
       return handlerStack.bubbleEvent("click", {target: element});
     } else {
       element.focus();
-      if (element.tagName.toLowerCase() !== "textarea") {
-        // If the cursor is at the start of the (non-textarea) element's contents, send it to the end. Motivation:
+      if ((element.tagName.toLowerCase() !== "textarea") || (element.value.indexOf("\n") < 0)) {
+        // If the cursor is at the start of the (non-multiline-textarea) element's contents, send it to the end.
+        // Motivation:
         // * the end is a more useful place to focus than the start,
         // * this way preserves the last used position (except when it's at the beginning), so the user can
         //   'resume where they left off'.
+        // This works well for single-line inputs, however, the UX is *bad* for multiline inputs (such as
+        // text areas), and doubly so if the end of the input happens to be out of the viewport, that's
+        // why multiline-textareas are excluded.
         // NOTE(mrmr1993): Some elements throw an error when we try to access their selection properties, so
         // wrap this with a try.
         try {


### PR DESCRIPTION
When we `simulateSelect` an input and the cursor is at the start of the text, we move it to the end of text for all `isSelectable` elements *except* `textarea`s to avoid bad UX for multiline inputs (e.g. the end of input could happen to be out of the viewport). However some sites may use `<textarea>` for what really is a single-line input for 99% times of the usage (e.g. Google search bar which recently has become a `<textarea>`) and the cursor won't go to the end of text in such cases.

This commit changes `simulateSelect` to skip `textarea` cursor reposition only if the `textarea` has *more than one* line of text treating single-line `textarea`s as regular `isSelectable` elements.

fixes #4247
fixes #4251
