### PR TITLE
Contributing: Update puppeteer version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ Our tests use [shoulda.js](https://github.com/philc/shoulda.js) and
 [Puppeteer](https://github.com/puppeteer/puppeteer). To run the tests:
 
  1. Install [Deno](https://deno.land/) if you don't have it already.
- 1. `PUPPETEER_PRODUCT=chrome deno run -A --unstable https://deno.land/x/puppeteer@9.0.2/install.ts` to
+ 1. `PUPPETEER_PRODUCT=chrome deno run -A --unstable https://deno.land/x/puppeteer@16.2.0/install.ts` to
     install [Puppeteer](https://github.com/lucacasonato/deno-puppeteer)
  1. `./make.js test` to build the code and run the tests.
 


### PR DESCRIPTION
The currently-listed puppeteer version did not work for me (hung indefinitely).
You may also need to update the deno lock, until I ran `deno cache --lock=deno.lock --lock-write make.js` I got:
```
$ ./make.js test
error: The source code is invalid, as it does not match the expected hash in the lock file.
  Specifier: https://esm.sh/jszip@3.5.0
  Lock file: .../vimium/deno.lock
```