### PR TITLE
Implement user-configurable search completion providers

### DIFF
--- a/background_scripts/completion_engines.js
+++ b/background_scripts/completion_engines.js
@@ -224,6 +224,6 @@ const CompletionEngines = [
   DummyCompletionEngine,
 ];
 
-globalThis.CompletionEngines = CompletionEngines;
+globalThis.CompletionEngines = globalThis.BuiltinCompletionEngines = CompletionEngines;
 
-export { Amazon, DuckDuckGo, Qwant, Webster };
+export { Amazon, BaseEngine, DuckDuckGo, Qwant, Webster };

--- a/background_scripts/completion_engines.js
+++ b/background_scripts/completion_engines.js
@@ -27,7 +27,7 @@
 
 // A base class for common regexp-based matching engines. "options" must define:
 //   options.engineUrl: the URL to use for the completion engine. This must be a string.
-//   options.regexps: one or regular expressions.  This may either a single string or a list of strings.
+//   options.regexps: Regexes matching search URLs this engine handles. List of strings or RegExps.
 //   options.example: an example object containing at least "keyword" and "searchUrl", and optional "description".
 // TODO(philc): This base class is doing very little. We should remove it and use composition.
 class BaseEngine {
@@ -42,6 +42,9 @@ class BaseEngine {
   getUrl(queryTerms) {
     return Utils.createSearchUrl(queryTerms, this.engineUrl);
   }
+  parse(text) {
+    return JSON.parse(text)[1];
+  }
 }
 
 class Google extends BaseEngine {
@@ -54,10 +57,6 @@ class Google extends BaseEngine {
         keyword: "g",
       },
     });
-  }
-
-  parse(text) {
-    return JSON.parse(text)[1];
   }
 }
 
@@ -99,10 +98,6 @@ class Youtube extends BaseEngine {
       },
     });
   }
-
-  parse(text) {
-    return JSON.parse(text)[1];
-  }
 }
 
 class Wikipedia extends BaseEngine {
@@ -116,10 +111,6 @@ class Wikipedia extends BaseEngine {
       },
     });
   }
-
-  parse(text) {
-    return JSON.parse(text)[1];
-  }
 }
 
 class Bing extends BaseEngine {
@@ -132,10 +123,6 @@ class Bing extends BaseEngine {
         keyword: "b",
       },
     });
-  }
-
-  parse(text) {
-    return JSON.parse(text)[1];
   }
 }
 

--- a/background_scripts/completion_search.js
+++ b/background_scripts/completion_search.js
@@ -45,8 +45,13 @@ class EnginePrefixWrapper {
 const CompletionSearch = {
   debug: false,
   inTransit: {},
-  completionCache: new SimpleCache(2 * 60 * 60 * 1000, 5000), // Two hours, 5000 entries.
-  engineCache: new SimpleCache(1000 * 60 * 60 * 1000), // 1000 hours.
+  completionCache: undefined,
+  engineCache: undefined,
+
+  clearCache() {
+    this.completionCache = new SimpleCache(2 * 60 * 60 * 1000, 5000); // Two hours, 5000 entries.
+    this.engineCache = new SimpleCache(1000 * 60 * 60 * 1000); // 1000 hours.
+  },
 
   // The amount of time to wait for new requests before launching the current request (for example,
   // if the user is still typing).
@@ -221,7 +226,8 @@ const CompletionSearch = {
                   () => this.completionCache.set(completionCacheKey, null),
                 );
                 if (this.debug) {
-                  console.log("fail", url);
+                  console.error("completion failed:", url);
+                  console.error(error);
                 }
               }
 
@@ -255,4 +261,5 @@ const CompletionSearch = {
   },
 };
 
+CompletionSearch.clearCache();
 globalThis.CompletionSearch = CompletionSearch;

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -51,7 +51,7 @@ w: https://www.wikipedia.org/w/index.php?title=Special:Search&search=%s Wikipedi
 
 # More examples.
 #
-# (Vimium supports search completion Wikipedia, as
+# (Vimium supports search completion for Wikipedia, as
 # above, and for these.)
 #
 # g: https://www.google.com/search?q=%s Google
@@ -62,6 +62,15 @@ w: https://www.wikipedia.org/w/index.php?title=Special:Search&search=%s Wikipedi
 # d: https://duckduckgo.com/?q=%s DuckDuckGo
 # az: https://www.amazon.com/s/?field-keywords=%s
 # qw: https://www.qwant.com/?q=%s Qwant\
+#
+# You can also configure a custom search completion provider.
+#   shortcut: search-url?search=%s @autocomplete-url?search=%s Description
+# By default data[1] is used, but you can also set a path:
+#   shortcut: search-url?search=%s @autocomplete-url?search=%s@path.2.*.list Description
+# Examples:
+# rs: https://runescape.wiki/?search=%s @https://runescape.wiki/api.php?action=opensearch&format=json&search=%s Runescape Wiki
+# os: https://oldschool.runescape.wiki/?search=%s @https://oldschool.runescape.wiki/api.php?action=opensearch&format=json&search=%s Old School Runescape wiki
+# man: https://www.mankier.com/?q=%s @https://www.mankier.com/api/v2/suggest/?q=%s@results.*.text ManKier Man Pages
 `,
   newTabUrl: "about:newtab", // Equal to the value of Utils.chromeNewTabUrl.
   grabBackFocus: false,


### PR DESCRIPTION
Search completions are clearly useful enough to be a mainline feature, but the maintainer does not want to expand its usefulness by adding more providers. This PR allows users to benefit from the feature with more than the handful of built-in completion providers.

Adds the following tested examples:
```
rs: https://runescape.wiki/?search=%s @https://runescape.wiki/api.php?action=opensearch&format=json&search=%s Runescape Wiki
os: https://oldschool.runescape.wiki/?search=%s @https://oldschool.runescape.wiki/api.php?action=opensearch&format=json&search=%s Old School Runescape wiki
man: https://www.mankier.com/?q=%s @https://www.mankier.com/api/v2/suggest/?q=%s@results.*.text ManKier Man Pages
```

Fixes #4281, opened in case this PR is also rejected.
Mitigates the following closed or ignored PRs/issues to add engines:
#3851 #3981 #4091 #4094 #4189 #4238