### PR TITLE
Allow count prefix for close tabs commands

### DIFF
--- a/background_scripts/commands.js
+++ b/background_scripts/commands.js
@@ -498,8 +498,8 @@ const commandDescriptions = {
   togglePinTab: ["Pin or unpin current tab", { background: true }],
   toggleMuteTab: ["Mute or unmute current tab", { background: true, noRepeat: true }],
 
-  closeTabsOnLeft: ["Close tabs on the left", { background: true, noRepeat: true }],
-  closeTabsOnRight: ["Close tabs on the right", { background: true, noRepeat: true }],
+  closeTabsOnLeft: ["Close tabs on the left", { background: true }],
+  closeTabsOnRight: ["Close tabs on the right", { background: true }],
   closeOtherTabs: ["Close all other tabs", { background: true, noRepeat: true }],
 
   moveTabLeft: ["Move tab to the left", { background: true }],

--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -337,16 +337,24 @@ var forCountTabs = (count, currentTab, callback) =>
 
 // Remove tabs before, after, or either side of the currently active tab
 const removeTabsRelative = async (direction, { count, tab }) => {
+  // count is null if the user didn't type a count prefix before issuing this command and didn't
+  // specify a count=n option in their keymapping settings. Interpret this as closing all tabs on
+  // either side.
+  if (count == null) count = 99999;
   const activeTab = tab;
   const tabs = await chrome.tabs.query({ currentWindow: true });
   const toRemove = tabs.filter((tab) => {
-    if (tab.pinned || tab.id == activeTab.id) return false;
+    if (tab.pinned || tab.id == activeTab.id) {
+      return false;
+    }
     switch (direction) {
       case "before":
-        return tab.index < activeTab.index;
+        return tab.index < activeTab.index &&
+          tab.index >= activeTab.index - count;
         break;
       case "after":
-        return tab.index > activeTab.index;
+        return tab.index > activeTab.index &&
+          tab.index <= activeTab.index + count;
         break;
       case "both":
         return true;

--- a/content_scripts/mode_key_handler.js
+++ b/content_scripts/mode_key_handler.js
@@ -132,7 +132,7 @@ class KeyHandlerMode extends Mode {
 
     if (this.keyState[0].command != null) {
       const command = this.keyState[0];
-      const count = this.countPrefix > 0 ? this.countPrefix : 1;
+      const count = this.countPrefix > 0 ? this.countPrefix : null;
       this.reset();
       this.commandHandler({ command, count });
       if ((this.options.count != null) && (--this.options.count <= 0)) {

--- a/content_scripts/mode_normal.js
+++ b/content_scripts/mode_normal.js
@@ -25,9 +25,18 @@ class NormalMode extends KeyHandlerMode {
   }
 
   commandHandler({ command: registryEntry, count }) {
-    count *= registryEntry.options.count != null ? registryEntry.options.count : 1;
+    if (registryEntry.options.count) {
+      count = (count ?? 1) * registryEntry.options.count;
+    }
 
-    if (registryEntry.noRepeat) {
+    // closeTabsOnLeft and closeTabsOnRight interpret a null count as "close all tabs in
+    // {direction}", so don't default the count to 1 for those commands. See #2971.
+    const allowNullCount = ["closeTabsOnLeft", "closeTabsOnRight"].includes(registryEntry.command);
+    if (!allowNullCount && count == null) {
+      count = 1;
+    }
+
+    if (registryEntry.noRepeat && count) {
       count = 1;
     }
 

--- a/content_scripts/mode_visual.js
+++ b/content_scripts/mode_visual.js
@@ -349,6 +349,7 @@ class VisualMode extends KeyHandlerMode {
   }
 
   commandHandler({ command: { command }, count }) {
+    if (count == null) count = 1;
     switch (typeof command) {
       case "string":
         for (let i = 0, end = count; i < end; i++) {
@@ -488,6 +489,7 @@ class VisualLineMode extends VisualMode {
   }
 
   commandHandler({ command: { command }, count }) {
+    if (count == null) count = 1;
     switch (typeof command) {
       case "string":
         for (let i = 0, end = count; i < end; i++) {

--- a/tests/dom_tests/dom_tests.js
+++ b/tests/dom_tests/dom_tests.js
@@ -722,7 +722,8 @@ context("Key mapping", () => {
     sendKeyboardEvent("2");
     sendKeyboardEvent("z");
     sendKeyboardEvent("m");
-    assert.equal(1, this.handlerCalledCount);
+    assert.equal(true, this.handlerCalled);
+    assert.equal(null, this.handlerCalledCount);
   });
 
   should("accept a count prefix for multi-key command mappings", () => {
@@ -734,15 +735,16 @@ context("Key mapping", () => {
 
   should("cancel a key prefix", () => {
     sendKeyboardEvent("z");
+    assert.equal(false, this.handlerCalled);
     sendKeyboardEvent("m");
-    assert.equal(1, this.handlerCalledCount);
+    assert.equal(true, this.handlerCalled);
   });
 
   should("cancel a count prefix after a prefix key", () => {
     sendKeyboardEvent("2");
     sendKeyboardEvent("z");
     sendKeyboardEvent("m");
-    assert.equal(1, this.handlerCalledCount);
+    assert.equal(null, this.handlerCalledCount);
   });
 
   should("cancel a prefix key on escape", () => {
@@ -796,11 +798,6 @@ context("Normal mode", () => {
     assert.equal("zp", commandName);
   });
 
-  should("default to a count of 1", () => {
-    sendKeyboardEvent("m");
-    assert.equal(1, commandCount);
-  });
-
   should("accept count prefixes of length 1", () => {
     sendKeyboardEvent("2");
     sendKeyboardEvent("m");
@@ -817,7 +814,7 @@ context("Normal mode", () => {
     sendKeyboardEvent("2");
     sendKeyboardEvent("z");
     sendKeyboardEvent("m");
-    assert.equal(1, commandCount);
+    assert.equal(null, commandCount);
   });
 
   should("get the correct count for mixed inputs (multi key)", () => {
@@ -832,7 +829,7 @@ context("Normal mode", () => {
     sendKeyboardEvent("z");
     sendKeyboardEvent("z");
     sendKeyboardEvent("p");
-    assert.equal(1, commandCount);
+    assert.equal(null, commandCount);
   });
 
   should("get the correct count for mixed inputs (with leading mapped keys)", () => {
@@ -853,7 +850,7 @@ context("Normal mode", () => {
     sendKeyboardEvent("2");
     sendKeyboardEvent("a");
     sendKeyboardEvent("m");
-    assert.equal(1, commandCount);
+    assert.equal(null, commandCount);
   });
 
   should("get the correct count after unmapped keys", () => {
@@ -883,10 +880,10 @@ context("Insert mode", () => {
   });
 
   should("resume normal mode after leaving insert mode", () => {
-    assert.equal(null, commandCount);
+    assert.equal(null, commandName);
     this.insertMode.exit();
     sendKeyboardEvent("m");
-    assert.equal(1, commandCount);
+    assert.equal("m", commandName);
   });
 });
 


### PR DESCRIPTION
This allows the user to close "just one tab on the right" by adding a prefix to their closeTabsOnRight command.

This has been requested in #2970, #3518, #3345 and probably others.

```
map cl closeTabsOnRight

# Close all tabs on right
cl

# Close just two tabs on the right.
2cl

# Always close one tab on the right
map cl closeTabsOnRight count=1
```

This PR is a continuation of #2971 and replaces #3853.

Note that it's a bit strange that the default count of closeTabsOnRight is infinity, rather than 1. This was done to preserve existing behavior, and so that users don't have to append count=9999 to their config to implement probably the most common desired behavior which is "close all tabs on right".