### PR TITLE
Correct rawQueryList initialization

### DIFF
--- a/lib/find_mode_history.js
+++ b/lib/find_mode_history.js
@@ -13,14 +13,14 @@ const FindModeHistory = {
       if (this.isIncognitoMode) this.key = "findModeRawQueryListIncognito";
 
       let result = await this.storage.get(this.key);
-      if (result[this.key]) {
-        this.rawQueryList = result[this.key] || [];
-      } else if (this.isIncognitoMode) {
+      if (this.isIncognitoMode) {
         // This is the first incognito tab, so we need to initialize the incognito-mode query
         // history.
         result = await this.storage.get("findModeRawQueryList");
         this.rawQueryList = result.findModeRawQueryList || [];
         this.storage.set({ findModeRawQueryListIncognito: this.rawQueryList });
+      } else {
+        this.rawQueryList = result[this.key] || [];
       }
     }
 


### PR DESCRIPTION
## Description

This pull request proposes a modification to the code logic to fix a problem I encountered while using the find-mode.

### Problem
The original code didn't cover all conditions when initializing the rawQueryList variable, resulting in an error when saving the query and finding the next match.

### Solution
In this pull request, I've restructured the logic to offer a clearer and more reliable initialization process for the rawQueryList variable.

Please review and provide feedback. Thank you!
