### PR TITLE
Fix z-index of link hints

### DIFF
--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -38,7 +38,7 @@ class LocalHint {
   element; // The clickable element.
   image; // When element is an <area> (image map), `image` is its associated image.
   rect; // The rectangle where the hint should shown, to avoid overlapping with other hints.
-  zIndex; // Tracking z-Index of parent
+  parentZIndex; // Tracking z-Index of parent.
   linkText; // Used in FilterHints.
   showLinkText; // Used in FilterHints.
   // The reason that an element has a link hint when the reason isn't obvious, e.g. the body of a
@@ -448,7 +448,7 @@ class LinkHintsMode {
       // If a clickable element has zIndex > nextZIndex, we use this z-index + 1.
       // Rotation may not work for these hints in some cases but they are not obscured anymore.
       // This was a long time issue especially with cookie banners.
-      zIndex = Math.max(this.getNextZIndex(), localHint.zIndex + 1)
+      zIndex = Math.max(this.getNextZIndex(), localHint.parentZIndex + 1);
       el.style.zIndex = zIndex;
       el.className = "vimiumReset internalVimiumHintMarker vimiumHintMarker";
       Object.assign(marker, {
@@ -1219,8 +1219,8 @@ const LocalHints = {
     }
 
     if (isClickable) {
-      // Track z-Index to prevent obscuring of link hints
-      zIndex = Utils.findNonAutoZIndex(element)
+      // Track z-Index to prevent obscuring of link hints.
+      zIndex = DomUtils.findNonAutoZIndex(element);
       // An image map has multiple clickable areas, and so can represent multiple LocalHints.
       if (imageMapAreas.length > 0) {
         const mapHints = imageMapAreas.map((areaAndRect) => {
@@ -1229,7 +1229,7 @@ const LocalHints = {
             image: element,
             // element,
             rect: areaAndRect.rect,
-            zIndex: zIndex,
+            parentZIndex: zIndex,
             secondClassCitizen: onlyHasTabIndex,
             possibleFalsePositive,
             reason,
@@ -1242,7 +1242,7 @@ const LocalHints = {
           const hint = new LocalHint({
             element,
             rect: clientRect,
-            zIndex: zIndex,
+            parentZIndex: zIndex,
             secondClassCitizen: onlyHasTabIndex,
             possibleFalsePositive,
             reason,

--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -448,7 +448,7 @@ class LinkHintsMode {
       // If a clickable element has zIndex > nextZIndex, we use this z-index + 1.
       // Rotation may not work for these hints in some cases but they are not obscured anymore.
       // This was a long time issue especially with cookie banners.
-      zIndex = Math.max(this.getNextZIndex(), localHint.parentZIndex + 1);
+      const zIndex = Math.max(this.getNextZIndex(), localHint.parentZIndex + 1);
       el.style.zIndex = zIndex;
       el.className = "vimiumReset internalVimiumHintMarker vimiumHintMarker";
       Object.assign(marker, {
@@ -1220,7 +1220,7 @@ const LocalHints = {
 
     if (isClickable) {
       // Track z-Index to prevent obscuring of link hints.
-      zIndex = DomUtils.findNonAutoZIndex(element);
+      const parentZIndex = DomUtils.findNonAutoZIndex(element);
       // An image map has multiple clickable areas, and so can represent multiple LocalHints.
       if (imageMapAreas.length > 0) {
         const mapHints = imageMapAreas.map((areaAndRect) => {
@@ -1229,7 +1229,7 @@ const LocalHints = {
             image: element,
             // element,
             rect: areaAndRect.rect,
-            parentZIndex: zIndex,
+            parentZIndex: parentZIndex,
             secondClassCitizen: onlyHasTabIndex,
             possibleFalsePositive,
             reason,
@@ -1242,7 +1242,7 @@ const LocalHints = {
           const hint = new LocalHint({
             element,
             rect: clientRect,
-            parentZIndex: zIndex,
+            parentZIndex: parentZIndex,
             secondClassCitizen: onlyHasTabIndex,
             possibleFalsePositive,
             reason,

--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -1220,7 +1220,7 @@ const LocalHints = {
 
     if (isClickable) {
       // Track z-Index to prevent obscuring of link hints.
-      const parentZIndex = DomUtils.findNonAutoZIndex(element);
+      const parentZIndex = DomUtils.findZIndex(element);
       // An image map has multiple clickable areas, and so can represent multiple LocalHints.
       if (imageMapAreas.length > 0) {
         const mapHints = imageMapAreas.map((areaAndRect) => {

--- a/lib/dom_utils.js
+++ b/lib/dom_utils.js
@@ -654,7 +654,7 @@ const DomUtils = {
     return document.head.appendChild(script);
   },
 
-  // Check all parent nodes for a numerical z-index
+  // Check all parent nodes for a numerical z-index.
   findZIndex(element) {
     while (element && element.parentElement) {
       const computedStyle = window.getComputedStyle(element);

--- a/lib/dom_utils.js
+++ b/lib/dom_utils.js
@@ -654,17 +654,18 @@ const DomUtils = {
     return document.head.appendChild(script);
   },
 
-  // If the current element has "auto" z-index, check its parent recursively
+  // Check all parent nodes for a numerical z-index
   findNonAutoZIndex(element) {
-    if (!element) {
-      return 0;
+    while (element && element.parentElement) {
+      const computedStyle = window.getComputedStyle(element);
+      const zIndex = computedStyle.getPropertyValue("z-index");
+      const parsedZIndex = parseInt(zIndex);
+      if (zIndex == parsedZIndex) {
+        return parsedZIndex;
+      }
+      element = element.parentElement;
     }
-    const computedStyle = window.getComputedStyle(element);
-    const zIndex = computedStyle.getPropertyValue("z-index");
-    if (zIndex !== "auto") {
-      return parseInt(zIndex) || 0;
-    }
-    return this.findNonAutoZIndex(element.parentElement);
+    return 0;
   },
 };
 

--- a/lib/dom_utils.js
+++ b/lib/dom_utils.js
@@ -655,7 +655,7 @@ const DomUtils = {
   },
 
   // Check all parent nodes for a numerical z-index
-  findNonAutoZIndex(element) {
+  findZIndex(element) {
     while (element && element.parentElement) {
       const computedStyle = window.getComputedStyle(element);
       const zIndex = computedStyle.getPropertyValue("z-index");

--- a/lib/dom_utils.js
+++ b/lib/dom_utils.js
@@ -653,6 +653,19 @@ const DomUtils = {
     // TODO(philc): Can we remove this return?
     return document.head.appendChild(script);
   },
+
+  // If the current element has "auto" z-index, check its parent recursively
+  findNonAutoZIndex(element) {
+    if (!element) {
+      return 0;
+    }
+    const computedStyle = window.getComputedStyle(element);
+    const zIndex = computedStyle.getPropertyValue("z-index");
+    if (zIndex !== "auto") {
+      return parseInt(zIndex) || 0;
+    }
+    return this.findNonAutoZIndex(element.parentElement);
+  },
 };
 
 window.DomUtils = DomUtils;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -390,6 +390,20 @@ const Utils = {
       .map((line) => line.trim())
       .filter((line) => (line.length > 0) && !(Array.from('#"').includes(line[0])));
   },
+
+  // If the current element has "auto" z-index, check its parent recursively
+  findNonAutoZIndex(element) {
+    if (!element) {
+      return 0;
+    }
+    const computedStyle = window.getComputedStyle(element);
+    const zIndex = computedStyle.getPropertyValue('z-index');
+
+    if (zIndex !== 'auto') {
+      return parseInt(zIndex) || 0;
+    }
+    return this.findNonAutoZIndex(element.parentElement);
+  },
 };
 
 Array.copy = (array) => Array.prototype.slice.call(array, 0);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -390,20 +390,6 @@ const Utils = {
       .map((line) => line.trim())
       .filter((line) => (line.length > 0) && !(Array.from('#"').includes(line[0])));
   },
-
-  // If the current element has "auto" z-index, check its parent recursively
-  findNonAutoZIndex(element) {
-    if (!element) {
-      return 0;
-    }
-    const computedStyle = window.getComputedStyle(element);
-    const zIndex = computedStyle.getPropertyValue('z-index');
-
-    if (zIndex !== 'auto') {
-      return parseInt(zIndex) || 0;
-    }
-    return this.findNonAutoZIndex(element.parentElement);
-  },
 };
 
 Array.copy = (array) => Array.prototype.slice.call(array, 0);


### PR DESCRIPTION
Fixes #4068

## Description

This pull request addresses the issue where cookie banners or other DOM elements have a higher z-index than Vimium's link hints, causing them to be obscured. The code changes introduced in this PR focus on resolving the z-index conflict when these elements are obscured by their parent element.

## Discussion

An alternative to patching the z-index as done in this implementation would be reordering the link hints in the DOM as mentioned in [this comment](https://github.com/philc/vimium/issues/4068#issuecomment-1732490163) and set Vimium's elements z-index to the max value.