### PR TITLE
Fix z-index of Vimium elements

### DIFF
--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -620,8 +620,6 @@ class LinkHintsMode {
     const newMarkers = []
     for (let stack of stacks) {
       if (stack.length > 1) {
-        // Push the first element to the end.
-        // stack = stack.concat(stack.splice(0, 1))
         // Push the last element to the beginning.
         stack = stack.splice(-1, 1).concat(stack)
       }

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -3,10 +3,9 @@
  * don't use the same CSS class names that the page is using, so the page's CSS doesn't mess with
  * the style of our Vimium dialogs.
  *
- * The z-indexes of Vimium elements are very large, because we always want them to show on top. We
- * know that Chrome supports z-index values up to about 2^31. The values we use are large numbers
- * approaching that bound. However, we must leave headroom for link hints. Hint marker z-indexes
- * start at 2140000001.
+ * We use the maximum z-index value for all Vimium elements to guarantee that they always appear on
+ * top. Chrome supports z-index values up to 2,147,483,647 (= 2^31 - 1). We utilize the maximum
+ * z-index value allowable to ensure Vimium elements have precedence over all other page elements.
  */
 
 /*
@@ -60,7 +59,7 @@ tr.vimiumReset {
   vertical-align: baseline;
   white-space: normal;
   width: auto;
-  z-index: 2140000000; /* Vimium's reference z-index value. */
+  z-index: 2147483647;
 }
 
 thead.vimiumReset, tbody.vimiumReset {
@@ -86,6 +85,7 @@ div.internalVimiumHintMarker {
   border: solid 1px #C38A22;
   border-radius: 3px;
   box-shadow: 0px 3px 7px 0px rgba(0, 0, 0, 0.3);
+  z-index: 2147483647;
 }
 
 div.internalVimiumHintMarker span {
@@ -149,7 +149,7 @@ iframe.vimiumHelpDialogFrame {
   display: block;
   position: fixed;
   border: none;
-  z-index: 2139999997; /* Three less than the reference value. */
+  z-index: 2147483647;
 }
 
 div#vimiumHelpDialogContainer {
@@ -316,7 +316,7 @@ div.vimiumHUD {
   border-radius: 4px;
   box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.8);
   border: 1px solid #aaa;
-  z-index: 2139999999;
+  z-index: 2147483647;
 }
 
 iframe.vimiumHUDFrame {
@@ -332,7 +332,7 @@ iframe.vimiumHUDFrame {
   right: 20px;
   margin: 0 0 0 -40%;
   border: none;
-  z-index: 2139999998; /* Two less than the reference value. */
+  z-index: 2147483647;
   opacity: 0;
 }
 
@@ -409,7 +409,7 @@ iframe.vomnibarFrame {
   margin: 0 0 0 -40%;
   border: none;
   font-family: sans-serif;
-  z-index: 2139999998; /* Two less than the reference value. */
+  z-index: 2147483647;
 }
 
 div.vimiumFlash {
@@ -417,7 +417,7 @@ div.vimiumFlash {
   padding: 1px;
   background-color: transparent;
   position: absolute;
-  z-index: 2140000000;
+  z-index: 2147483647;
 }
 
 /* UIComponent CSS */

--- a/lib/dom_utils.js
+++ b/lib/dom_utils.js
@@ -86,7 +86,8 @@ const DomUtils = {
   // Note that adding these nodes all at once (via a parent div) is significantly faster than
   // one-by-one.
   addElementsToPage(elements, containerOptions) {
-    const parent = this.createElement("div");
+    // Don't create a new container if we already have one.
+    const parent = document.getElementById(containerOptions.id) || this.createElement("div");
     if (containerOptions.id != null) parent.id = containerOptions.id;
     if (containerOptions.className != null) parent.className = containerOptions.className;
     for (const el of elements) parent.appendChild(el);


### PR DESCRIPTION
Fixes #4068

## Description

This pull request addresses the issue where cookie banners or other DOM elements have a higher `z-index` than Vimium's hint markers, causing them to be obscured. 

The code changes introduced in this PR puts all Vimium elements to the `z-index`'s max value (2^31 - 1). 

Link hint rotation is now done by reordering the DOM elements instead of the `z-index`. The order is the same as before (1.67).

This is an alternative implementation to #4310 as stated in [this comment](https://github.com/philc/vimium/issues/4068#issuecomment-1732490163) (thanks again, @raindUwU)

You can take a look at it on https://www.onetrust.com/cookie-banner-gallery/. There is 7-fold overlap in the top right corner to test rotation and a high z-index button in the left bottom corner that was obscured before.