### PR TITLE
Update default dark theme css to include vimiumHUD styling

### DIFF
--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -515,4 +515,24 @@ iframe.vimiumNonClickable {
     box-shadow: none;
     color: white;
   }
+
+  /* Dark Mode CSS for Vimium HUD */
+
+  div.vimiumHUD,
+  div.vimiumHUD .vimiumHUDSearchAreaInner,
+  div.vimiumHUD .vimiumUIComponentVisible {
+    background-color: #1d1d1f;
+    border: none;
+    box-shadow: none;
+    color: white;
+  }
+
+  div.vimiumHUD .vimiumHUDSearchArea {
+    border: 1px solid black;
+    background-color: #35363a;
+  }
+
+  div.vimiumHUD span#hud-find-input {
+    color: white !important;
+  }
 }


### PR DESCRIPTION
## Description

Current default dark theme (applied by `prefers-color-scheme: dark`) doesn't style Vimium HUD, 
which clashes against other elements that utilize the dark theme, namely vomnibar.

This PR adds missing styles.