### PR TITLE
Fix: vomnibar does not use UserSearchEngine when it is given

### DIFF
--- a/pages/vomnibar.js
+++ b/pages/vomnibar.js
@@ -30,6 +30,7 @@ const Vomnibar = {
     this.vomnibarUI.setInitialSelectionValue(options.selectFirst ? 0 : -1);
     this.vomnibarUI.setForceNewTab(options.newTab);
     this.vomnibarUI.setQuery(options.query);
+    this.vomnibarUI.setActiveUserSearchEngine(UserSearchEngines.keywordToEngine[options.keyword]);
     this.vomnibarUI.update();
   },
 
@@ -62,6 +63,9 @@ class VomnibarUI {
 
   setQuery(query) {
     this.input.value = query;
+  }
+  setActiveUserSearchEngine(userSearchEngine) {
+    this.activeUserSearchEngine = userSearchEngine;
   }
 
   setInitialSelectionValue(initialSelectionValue) {


### PR DESCRIPTION
## Description
fix #4337
fix #4340 
VomnibarUI comes to lack a method that reads a UserSearchEngine if it is given, through the upgrading for v2.0.