### PR TITLE
Fix: find mode does not seek to display the match

### DIFF
--- a/content_scripts/mode_find.js
+++ b/content_scripts/mode_find.js
@@ -465,9 +465,13 @@ const highlight = (textNode, startIndex, length) => {
   selection.addRange(range);
 
   // Ensure the highlighted element is visible within the viewport.
-  const rect = textNode.parentElement.getBoundingClientRect();
+  const rect = range.getBoundingClientRect();
   if (rect.top < 0 || rect.bottom > window.innerHeight) {
-    textNode.parentElement.scrollIntoView({ block: "center" });
+    const screenHeight = window.innerHeight;
+    window.scrollTo({
+      top: window.scrollY + rect.top + rect.height / 2 - screenHeight / 2,
+      behavior: "smooth",
+    });
   }
 
   return true;


### PR DESCRIPTION
## Description

This pull request addresses an issue where the selected text range was not being centered on the screen when the containing element was larger than the viewport. To solve this problem, I modified the code to calculate and scroll to the center of the selected range.

fix #4341