### PR TITLE
Optional chaining for `link.innerText...` in prev/next link logic (fixes GitHub)

### DIFF
--- a/content_scripts/mode_normal.js
+++ b/content_scripts/mode_normal.js
@@ -417,7 +417,7 @@ const findAndFollowLink = function (linkStrings) {
 
     let linkMatches = false;
     for (const linkString of linkStrings) {
-      const matches = link.innerText.toLowerCase().includes(linkString) ||
+      const matches = link.innerText?.toLowerCase()?.includes(linkString) ||
         link.value?.includes?.(linkString) ||
         link.getAttribute("title")?.toLowerCase().includes(linkString) ||
         link.getAttribute("aria-label")?.toLowerCase().includes(linkString);


### PR DESCRIPTION
## Description

**On GitHub, prev/next logic does not work.**

```
const links = DomUtils.evaluateXPath(linksXPath, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE);
```

matches also svgs with `button` in class

![image](https://github.com/philc/vimium/assets/697301/da88b6c3-6373-45b6-856d-346d867b905a)

and svgs have `undefined` innerText #TIL, which throws in the matching logic 

![Screen 2023-11-06 at 20 54 55](https://github.com/philc/vimium/assets/697301/5c4d64dc-b631-4e62-ad55-be19bc0e946a)

---

Added optional chaining which fixes the issue.

(thx for amazing work btw, I'm unable to control browser without vimium)