### PR TITLE
In Firefox, make the removeTab command ignore pinned tabs

### DIFF
--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -249,7 +249,12 @@ const BackgroundCommands = {
     return selectTab("last", request);
   },
   removeTab({ count, tab }) {
-    return forCountTabs(count, tab, (tab) => chrome.tabs.remove(tab.id));
+    return forCountTabs(count, tab, (tab) => {
+      // In Firefox, Ctrl-W will not close a pinned tab, but on Chrome, it will. We try to be
+      // consistent with each browser's UX for pinned tabs.
+      if (tab.pinned && BgUtils.isFirefox()) return;
+      chrome.tabs.remove(tab.id);
+    });
   },
   restoreTab: mkRepeatCommand((request, callback) =>
     chrome.sessions.restore(null, callback(request))


### PR DESCRIPTION
In Chrome, Ctrl-w will close a pinned tab, but in Firefox, it won't (see #4359).

Note also that Vimium's "closeTabsOnLeft" command will not close pinned tabs, but running "removeTab" with a count will close pinned tabs, which is a bit inconsistent.

I propose that we respect the UX that Firefox has, and prevent `removeTab`, with or without a count, from closing pinned tabs on Firefox, but allow `removeTab` to close tabs on Chrome.