### PR TITLE
Add zoom commands

### DIFF
--- a/background_scripts/commands.js
+++ b/background_scripts/commands.js
@@ -350,6 +350,9 @@ const Commands = {
       "closeOtherTabs",
       "moveTabLeft",
       "moveTabRight",
+      "zoomIn",
+      "zoomOut",
+      "zoomReset",
     ],
     misc: ["showHelp", "toggleViewSource"],
   },
@@ -381,6 +384,9 @@ const Commands = {
     "enterVisualLineMode",
     "toggleViewSource",
     "passNextKey",
+    "zoomIn",
+    "zoomOut",
+    "zoomReset",
   ],
 };
 
@@ -454,6 +460,9 @@ const defaultKeyMappings = {
   "X": "restoreTab",
   "<a-p>": "togglePinTab",
   "<a-m>": "toggleMuteTab",
+  "zi": "zoomIn",
+  "zo": "zoomOut",
+  "z0": "zoomReset",
 
   // Marks
   "m": "Marks.activateCreateMode",
@@ -546,6 +555,10 @@ const commandDescriptions = {
 
   moveTabLeft: ["Move tab to the left", { background: true }],
   moveTabRight: ["Move tab to the right", { background: true }],
+
+  zoomIn: ["Increase zoom on current tab", { background: true }],
+  zoomOut: ["Decrease zoom on current tab", { background: true }],
+  zoomReset: ["Reset zoom on current tab", { background: true }],
 
   "Vomnibar.activate": ["Open URL, bookmark or history entry", { topFrame: true }],
   "Vomnibar.activateInNewTab": ["Open URL, bookmark or history entry in a new tab", {

--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -159,6 +159,14 @@ const mkRepeatCommand = (command) => (function (request) {
   }
 });
 
+const setZoom = (tabId, callback) => {
+  chrome.tabs.getZoom(tabId, (factor) => {
+    chrome.tabs.setZoomSettings(tabId, { scope: "per-tab" }, () => {
+      chrome.tabs.setZoom(tabId, callback(factor));
+    });
+  });
+};
+
 // These are commands which are bound to keystrokes which must be handled by the background page.
 // They are mapped in commands.coffee.
 const BackgroundCommands = {
@@ -260,6 +268,17 @@ const BackgroundCommands = {
   toggleMuteTab,
   moveTabLeft: moveTab,
   moveTabRight: moveTab,
+  zoomIn({ tabId, count }) {
+    const step = Settings.get("zoomStep");
+    setZoom(tabId, (factor) => factor + step * count);
+  },
+  zoomOut({ tabId, count }) {
+    const step = Settings.get("zoomStep");
+    setZoom(tabId, (factor) => factor - step * count);
+  },
+  zoomReset({ tabId }) {
+    setZoom(tabId, () => 1.0);
+  },
 
   async nextFrame({ count, tabId }) {
     // We're assuming that these frames are returned in the order that they appear on the page. This

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -1,6 +1,7 @@
 // WIP rewrite of settings.js
 const defaultOptions = {
   scrollStepSize: 60,
+  zoomStep: 0.10,
   smoothScroll: true,
   keyMappings: "# Insert your preferred key mappings here.",
   linkHintCharacters: "sadfjklewcmpgh",

--- a/pages/options.css
+++ b/pages/options.css
@@ -123,6 +123,11 @@ input#scrollStepSize {
   margin-right: 3px;
   padding-left: 3px;
 }
+input#zoomStep {
+  width: 70px;
+  margin-right: 3px;
+  padding-left: 3px;
+}
 textarea#userDefinedLinkHintCss, textarea#keyMappings, textarea#searchEngines {
   width: 100%;;
   min-height: 140px;

--- a/pages/options.html
+++ b/pages/options.html
@@ -113,6 +113,17 @@ b: http://b.com/?q=%s description
             <input id="scrollStepSize" type="number" />px
           </td>
         </tr>
+        <tr>
+          <td class="caption">Zoom step</td>
+          <td>
+            <div class="help">
+              <div class="example">
+                Factor to increment by when zooming in or out.
+              </div>
+            </div>
+            <input id="zoomStep" type="number" min="0.01" max="1.00" step="0.01" />
+          </td>
+        </tr>
         <tr id="linkHintCharactersContainer">
           <td class="caption">Characters used<br /> for link hints</td>
           <td verticalAlign="top">

--- a/pages/options.js
+++ b/pages/options.js
@@ -11,6 +11,7 @@ const options = {
   regexFindMode: "boolean",
   ignoreKeyboardLayout: "boolean",
   scrollStepSize: "number",
+  zoomStep: "number",
   smoothScroll: "boolean",
   grabBackFocus: "boolean",
   searchEngines: "string",


### PR DESCRIPTION
Implements zoom commands in a manner similar to cVim (which I recently migrated away from as it seems unmaintained).

The three new commands are `zoomIn`, `zoomOut`, and `zoomReset`. These are combined with a configurable `zoomStep` option which defaults to `0.10` (10%).

The default key mappings for the above commands are `zi`, `zo`, and `z0` (cVim defaults) -- may be worth bikeshedding over.

Fixes #1866 and #4161 (also see #2978).