### PR TITLE
Add Option Do not close the last tab

### DIFF
--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -254,7 +254,16 @@ const BackgroundCommands = {
       // In Firefox, Ctrl-W will not close a pinned tab, but on Chrome, it will. We try to be
       // consistent with each browser's UX for pinned tabs.
       if (tab.pinned && BgUtils.isFirefox()) return;
-      chrome.tabs.remove(tab.id);
+      if(Settings.get("keepLastTabOpen")){
+        chrome.tabs.query({ currentWindow: true }, function (tabs) {
+          if(tabs.length == 1){
+            chrome.tabs.create({ url: Settings.get("newTabUrl") });
+            chrome.tabs.remove(tabs[0].id);
+          }
+        });
+      } else {
+        chrome.tabs.remove(tab.id);
+      }
     });
   },
   restoreTab: mkRepeatCommand((request, callback) =>

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -69,6 +69,7 @@ w: https://www.wikipedia.org/w/index.php?title=Special:Search&search=%s Wikipedi
   waitForEnterForFilteredHints: true,
   helpDialog_showAdvancedCommands: false,
   ignoreKeyboardLayout: false,
+  keepLastTabOpen: false,
 };
 
 /*

--- a/pages/options.html
+++ b/pages/options.html
@@ -233,6 +233,20 @@ b: http://b.com/?q=%s description
           </td>
         </tr>
         <tr>
+          <td class="caption"></td>
+          <td verticalAlign="top" class="booleanOption">
+            <div class="help">
+              <div class="example">
+                Do not close the last tab
+              </div>
+            </div>
+            <label>
+              <input id="keepLastTabOpen" type="checkbox" />
+              Do not close the last tab 
+            </label>
+          </td>
+        </tr>
+        <tr>
           <td class="caption">Default search<br />engine</td>
           <td verticalAlign="top">
             <div class="help">

--- a/pages/options.js
+++ b/pages/options.js
@@ -17,6 +17,7 @@ const options = {
   searchUrl: "string",
   settingsVersion: "string", // This is a hidden field.
   userDefinedLinkHintCss: "string",
+  keepLastTabOpen: "boolean",
 };
 
 const OptionsPage = {


### PR DESCRIPTION
## Description

Enable this option so that when there is only one tab left in the window, using `x` will create a new window with the `New Tab URL` before closing the page.
