### PR TITLE
fix omnibar crash when encountering tabs without title

### DIFF
--- a/background_scripts/completion.js
+++ b/background_scripts/completion.js
@@ -487,8 +487,8 @@ class TabCompleter {
         const suggestion = new Suggestion({
           queryTerms,
           description: "tab",
-          url: tab.url,
-          title: tab.title,
+          url: tab.url || "",
+          title: tab.title || "",
           tabId: tab.id,
           deDuplicate: false,
         });
@@ -693,7 +693,7 @@ const RankingUtils = {
       let matchedTerm = false;
       for (const thing of things) {
         if (!matchedTerm) {
-          matchedTerm = thing.match(regexp);
+          matchedTerm = thing?.match(regexp);
         }
       }
       if (!matchedTerm) return false;


### PR DESCRIPTION
The "url" and "title" properties of tab objects are optional an can be null sometimes. When a tab with either of these properties being null is encountered the interactive search just breaks without updating the completion suggestions.

I'm using Firefox 121.0 on macOS 13.6.1 (Apple Silicon). I have too many tabs open and apparently sometimes tabs can end up with an url of `about:blank` and and no title. Both the
`url` and the `title` property are documented as "optional" in [Firefox] and [Chrome] which I
assume means they can both be `null`.

[Firefox]: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/Tab
[Chrome]: https://developer.chrome.com/docs/extensions/reference/api/tabs#type-Tab

I've adapted the code accordingly. This fixes the issue for me and should not introduce any new
bugs.