### PR TITLE
Exclusions: exclude keys based on the top frame's URL, not subframe URLs

### DIFF
--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -560,8 +560,9 @@ const sendRequestHandlers = {
   },
 
   async initializeFrame(request, sender) {
-    const tabId = sender.tab.id;
-    const enabledState = Exclusions.isEnabledForUrl(request.topFrameUrl);
+    // Check whether the extension is enabled for the top frame's URL, rather than the URL of the
+    // specific frame that sent this request.
+    const enabledState = Exclusions.isEnabledForUrl(sender.tab.url);
 
     const isTopFrame = sender.frameId == 0;
     if (isTopFrame) {
@@ -588,7 +589,7 @@ const sendRequestHandlers = {
           "32": "../icons/action_disabled_32.png",
         },
       };
-      chrome.action.setIcon({ path: iconSet[whichIcon], tabId: tabId });
+      chrome.action.setIcon({ path: iconSet[whichIcon], tabId: sender.tab.id });
     }
 
     const response = Object.assign({

--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -561,9 +561,10 @@ const sendRequestHandlers = {
 
   async initializeFrame(request, sender) {
     const tabId = sender.tab.id;
-    const enabledState = Exclusions.isEnabledForUrl(request.url);
+    const enabledState = Exclusions.isEnabledForUrl(request.topFrameUrl);
 
-    if (request.frameIsFocused) {
+    const isTopFrame = sender.frameId == 0;
+    if (isTopFrame) {
       let whichIcon;
       if (!enabledState.isEnabledForUrl) {
         whichIcon = "disabled";

--- a/content_scripts/vimium_frontend.js
+++ b/content_scripts/vimium_frontend.js
@@ -409,10 +409,7 @@ globalThis.lastFocusedInput = (function () {
 
 // Checks if Vimium should be enabled or not based on the top frame's URL.
 const checkIfEnabledForUrl = async () => {
-  const response = await chrome.runtime.sendMessage({
-    handler: "initializeFrame",
-    topFrameUrl: window.top.location.toString(),
-  });
+  const response = await chrome.runtime.sendMessage({ handler: "initializeFrame" });
 
   isEnabledForUrl = response.isEnabledForUrl;
 

--- a/content_scripts/vimium_frontend.js
+++ b/content_scripts/vimium_frontend.js
@@ -199,7 +199,7 @@ const initializePreDomReady = async function () {
   // NOTE(philc): I'm blocking further Vimium initialization on this, for simplicity. If necessary
   // we could allow other tasks to run concurrently.
   await Settings.onLoaded();
-  checkIfEnabledForUrl(document.hasFocus());
+  checkIfEnabledForUrl();
 
   const requestHandlers = {
     getFocusStatus(_request, _sender) {
@@ -308,7 +308,7 @@ const installListeners = Utils.makeIdempotent(function () {
 // Whenever we get the focus, check if we should be enabled.
 const onFocus = forTrusted(function (event) {
   if (event.target === window) {
-    checkIfEnabledForUrl(true);
+    checkIfEnabledForUrl();
   }
 });
 
@@ -407,17 +407,11 @@ globalThis.lastFocusedInput = (function () {
   return () => recentlyFocusedElement;
 })();
 
-// Checks if Vimium should be enabled or not in this frame. As a side effect, it also informs the
-// background page whether this frame has the focus, allowing the background page to change the
-// Vimium Action icon to indicate whether the curent page is excluded in Vimium.
-const checkIfEnabledForUrl = async (frameIsFocused) => {
-  if (frameIsFocused == null) {
-    frameIsFocused = windowIsFocused();
-  }
+// Checks if Vimium should be enabled or not based on the top frame's URL.
+const checkIfEnabledForUrl = async () => {
   const response = await chrome.runtime.sendMessage({
     handler: "initializeFrame",
-    frameIsFocused,
-    url: window.location.toString(),
+    topFrameUrl: window.top.location.toString(),
   });
 
   isEnabledForUrl = response.isEnabledForUrl;

--- a/test_harnesses/cross_origin_iframe.html
+++ b/test_harnesses/cross_origin_iframe.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+  <title>Cross origin iFrame</title>
+  <style type="text/css" media="screen">
+    body {
+      background-color: black;
+      color: #999;
+      height: 4000px;
+    }
+
+    iframe {
+      width: 800px;
+      height: 400px;
+      border: 2px solid green;
+    }
+  </style>
+</head>
+
+<body>
+  Iframe from a different origin as its parent:<br />
+  <iframe src="https://example.com" />
+
+</body>
+
+</html>


### PR DESCRIPTION
The exclusion keys in Vimium apply on a per-frame basis. So, if you're visiting a site `example.com`, and it has an iframe showing content from `sub.example.com`, your exclusion keys won't work if the iframe has the focus. This is very surprising, and I think hard for people to debug and grok. It appears that Vimium's exclusion keys are simply not working. It's also hard to workaround -- how does one know what the domain of the iframe is, so that they can set exclusion rules for that domain? You have to open the browser's developer tools and poke around.

I'm not sure where this per-frame exclusion behavior originally came from, and whether there was a specific reason for it. It was discussed early on in #1453.

This PR changes it so that the exclusion rules and passkeys from the top frame's URL are applied to all subframes on that page. I think this is a better UX.

This fixes #3254, #3960, #4375, and possibly other open issues.