### PR TITLE
Clarify that f and F show visible links

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Navigating the current page:
     G       scroll to bottom of the page
     d       scroll down half a page
     u       scroll up half a page
-    f       open a link in the current tab
-    F       open a link in a new tab
+    f       show links and open in the current tab
+    F       show links and open in a new tab
     r       reload
     gs      view source
     i       enter insert mode -- all commands will be ignored until you hit Esc to exit
@@ -46,10 +46,10 @@ Navigating the current page:
 
 Navigating to new pages:
 
-    o       Open URL, bookmark, or history entry
-    O       Open URL, bookmark, history entry in a new tab
-    b       Open bookmark
-    B       Open bookmark in a new tab
+    o       open URL, bookmark, or history entry
+    O       open URL, bookmark, history entry in a new tab
+    b       open bookmark
+    B       open bookmark in a new tab
 
 Using find:
 
@@ -90,7 +90,7 @@ Using marks:
 
 Additional advanced browsing commands:
 
-    ]], [[  Follow the link labeled 'next' or '>' ('previous' or '<')
+    ]], [[  follow the link labeled 'next' or '>' ('previous' or '<')
               - helpful for browsing paginated sites
     <a-f>   open multiple links in a new tab
     gi      focus the first (or n-th) text input box on the page. Use <tab> to cycle through options.


### PR DESCRIPTION
## Description

Great add-on, it will make browsing so much faster, thanks!

After installing the add-on, I was reading the help page (`?`) but could not see how to find links. I normally use "search for links in text" via the `'` character in Firefox.

https://support.mozilla.org/en-US/kb/search-contents-current-page-text-or-links#w_search-links-only

It was only by mistake that I pressed `f` and saw the links on the page highlighted with shortcuts, which is an even better solution for finding links.

So would it make sense to clarify that `f` and `F` show links on the help page?

PS. I also fixed a few instances where a line starts with a capital letter, since it looks like the style is to only start with small letters.