### PR TITLE
Mouse out of last clicked element when ESC is typed

### DIFF
--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -164,6 +164,10 @@ const HintCoordinator = {
   localHints: null,
   cacheAllKeydownEvents: null,
 
+  // A WeakRef to the last clicked element. We track this so that we can mouse of it if the user
+  // types ESC after clicking on it. See #3073.
+  lastClickedElementRef: null,
+
   // Returns if the HintCoordinator will handle a given LinkHintsMessage.
   // Some messages will not be handled in the case where the help dialog is shown, and is then
   // hidden, but is still receiving link hints messages via broadcastLinkHintsMessage.
@@ -289,6 +293,15 @@ const HintCoordinator = {
       this.onExit.pop()(isSuccess);
     }
     this.linkHintsMode = this.localHints = null;
+  },
+
+  mouseOutOfLastClickedElement() {
+    if (this.lastClickedElementRef == null) return;
+    const el = this.lastClickedElementRef.deref();
+    if (el) {
+      DomUtils.simulateMouseEvent("mouseout", el, null);
+    }
+    this.lastClickedElementRef = null;
   },
 };
 
@@ -680,6 +693,7 @@ class LinkHintsMode {
             if (["input", "select", "object", "embed"].includes(clickEl.nodeName.toLowerCase())) {
               clickEl.focus();
             }
+            HintCoordinator.lastClickedElementRef = new WeakRef(clickEl);
             return linkActivator(clickEl);
           }
         }

--- a/content_scripts/mode_key_handler.js
+++ b/content_scripts/mode_key_handler.js
@@ -67,6 +67,9 @@ class KeyHandlerMode extends Mode {
       HelpDialog.toggle();
       return this.suppressEvent;
     } else if (isEscape) {
+      // Some links stay "open" after clicking, until you mouse off of them, like Wikipedia's link
+      // preview popups. If the user types escape, issue a mouseout event here. See #3073.
+      HintCoordinator.mouseOutOfLastClickedElement();
       return this.continueBubbling;
     } else if (this.isMappedKey(keyChar)) {
       this.handleKeyChar(keyChar);

--- a/content_scripts/mode_key_handler.js
+++ b/content_scripts/mode_key_handler.js
@@ -62,8 +62,8 @@ class KeyHandlerMode extends Mode {
     const isEscape = KeyboardUtils.isEscape(event);
     if (isEscape && ((this.countPrefix !== 0) || (this.keyState.length !== 1))) {
       return DomUtils.consumeKeyup(event, () => this.reset());
-      // If the help dialog loses the focus, then Escape should hide it; see point 2 in #2045.
     } else if (isEscape && HelpDialog && HelpDialog.isShowing()) {
+      // If the help dialog loses the focus, then Escape should hide it; see point 2 in #2045.
       HelpDialog.toggle();
       return this.suppressEvent;
     } else if (isEscape) {

--- a/content_scripts/mode_visual.js
+++ b/content_scripts/mode_visual.js
@@ -271,7 +271,6 @@ class VisualMode extends KeyHandlerMode {
     this.onExit((event = null) => {
       // Retain any selection, regardless of how we exit.
       if (this.shouldRetainSelectionOnExit) {
-        null;
         // This mimics vim: when leaving visual mode via Escape, collapse to focus, otherwise
         // collapse to anchor.
       } else if (

--- a/lib/handler_stack.js
+++ b/lib/handler_stack.js
@@ -48,9 +48,7 @@ class HandlerStack {
   // @passEventToPage.
   bubbleEvent(type, event) {
     this.eventNumber += 1;
-    const {
-      eventNumber,
-    } = this;
+    const eventNumber = this.eventNumber;
     for (const handler of this.stack.slice().reverse()) {
       // A handler might have been removed (handler.id == null), so check; or there might just be no
       // handler for this type of event.


### PR DESCRIPTION
Some pages, like Wikipedia, open a popup when a link is clicked, and it won't get dismissed unless there is a mouseout event on the link.

Vimium does not issue a mouseout event on links, in case the menu is a hover menu and the user wants to click on an item in that hover menu.

In this PR we allow ESC in normal mode to mouseout of the last clicked element, which dismisses the popup on Wikipedia pages.

Fixes #3073 