### PR TITLE
Use the tab.lastAccessed timestamp to sort tabs by recency in Vomnibar

### DIFF
--- a/background_scripts/bg_utils.js
+++ b/background_scripts/bg_utils.js
@@ -1,80 +1,4 @@
-const TIME_DELTA = 500; // Milliseconds.
-
-// TabRecency associates a logical timestamp with each tab id. These are used to provide an initial
-// recency-based ordering in the tabs vomnibar (which allows jumping quickly between
-// recently-visited tabs).
-class TabRecency {
-  constructor() {
-    this.timestamp = 1;
-    this.current = -1;
-    this.cache = {};
-    this.lastVisited = null;
-    this.lastVisitedTime = null;
-
-    chrome.tabs.onActivated.addListener((activeInfo) => this.register(activeInfo.tabId));
-    chrome.tabs.onRemoved.addListener((tabId) => this.deregister(tabId));
-
-    chrome.tabs.onReplaced.addListener((addedTabId, removedTabId) => {
-      this.deregister(removedTabId);
-      this.register(addedTabId);
-    });
-
-    if (chrome.windows != null) {
-      chrome.windows.onFocusChanged.addListener((wnd) => {
-        if (wnd !== chrome.windows.WINDOW_ID_NONE) {
-          chrome.tabs.query({ windowId: wnd, active: true }, (tabs) => {
-            if (tabs[0]) {
-              this.register(tabs[0].id);
-            }
-          });
-        }
-      });
-    }
-  }
-
-  register(tabId) {
-    const currentTime = new Date();
-    // Register tabId if it's been visited for at least @timeDelta ms. Tabs which are visited only
-    // for a very-short time (e.g. those passed through with `5J`) aren't registered as visited.
-    if ((this.lastVisitedTime != null) && (TIME_DELTA <= (currentTime - this.lastVisitedTime))) {
-      this.cache[this.lastVisited] = ++this.timestamp;
-    }
-
-    this.current = this.lastVisited = tabId;
-    this.lastVisitedTime = currentTime;
-  }
-
-  deregister(tabId) {
-    if (tabId === this.lastVisited) {
-      // Ensure we don't register this tab, since it's going away.
-      this.lastVisited = this.lastVisitedTime = null;
-    }
-    delete this.cache[tabId];
-  }
-
-  // Recently-visited tabs get a higher score (except the current tab, which gets a low score).
-  recencyScore(tabId) {
-    if (!this.cache[tabId]) {
-      this.cache[tabId] = 1;
-    }
-    if (tabId === this.current) {
-      return 0.0;
-    } else {
-      return this.cache[tabId] / this.timestamp;
-    }
-  }
-
-  // Returns a list of tab Ids sorted by recency, most recent tab first.
-  getTabsByRecency() {
-    const tabIds = Object.keys(this.cache || {});
-    tabIds.sort((a, b) => this.cache[b] - this.cache[a]);
-    return tabIds.map((tId) => parseInt(tId));
-  }
-}
-
 const BgUtils = {
-  tabRecency: new TabRecency(),
-
   // We're using browser.runtime to determine the browser name and version for Firefox. That API is
   // only available on the background page. We're not using window.navigator because it's
   // unreliable. Sometimes browser vendors will provide fake values, like when
@@ -104,8 +28,6 @@ const BgUtils = {
     return string.replace(/["&'<>]/g, (char) => BgUtils.escapedEntities[char]);
   },
 };
-
-BgUtils.TIME_DELTA = TIME_DELTA; // Referenced by our tests.
 
 Object.assign(globalThis, {
   BgUtils,

--- a/background_scripts/completion.js
+++ b/background_scripts/completion.js
@@ -486,8 +486,6 @@ class TabCompleter {
       } else {
         // Recently visited tabs get a higher score (except the current tab, which gets a low score).
         const isCurrent = currentTab.id == tab.id;
-        // tab.lastAccessed might be null; it was introduced in Chrome 121.
-        // TODO(philc): remove this "|| 0" check after increasing Chrome's min version to 121.
         return isCurrent ? 0 : tab.lastAccessed || 0;
       }
     };

--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -316,8 +316,6 @@ const BackgroundCommands = {
   async visitPreviousTab({ count, tab }) {
     const sortedTabs = (await chrome.tabs.query({}))
       .filter((t) => t.id != tab.id)
-      // tab.lastAccessed might be null; it was introduced in Chrome 121.
-      // TODO(philc): remove this "|| 0" check after increasing Chrome's min version to 121.
       .sort((a, b) => (b.lastAccessed || 0) - (a.lastAccessed || 0));
     if (sortedTabs.length == 0) return;
     selectSpecificTab({ id: sortedTabs[(count - 1) % sortedTabs.length].id });

--- a/tests/unit_tests/completion_test.js
+++ b/tests/unit_tests/completion_test.js
@@ -339,8 +339,8 @@ context("multi completer", () => {
 
 context("tab completer", () => {
   const tabs = [
-    { url: "tab1.com", title: "tab1", id: 1 },
-    { url: "tab2.com", title: "tab2", id: 2 },
+    { url: "tab1.com", title: "tab1", id: 1, lastAccessed: 1 },
+    { url: "tab2.com", title: "tab2", id: 2, lastAccessed: 2 },
   ];
   let completer;
 
@@ -351,7 +351,7 @@ context("tab completer", () => {
 
   should("return tabs by recency when query is empty", async () => {
     const results = await filterCompleter(completer, []);
-    assert.equal(["tab1.com", "tab2.com"], results.map((tab) => tab.url));
+    assert.equal(["tab2.com", "tab1.com"], results.map((tab) => tab.url));
   });
 
   should("return matching tabs", async () => {
@@ -646,66 +646,5 @@ context("RegexpCache", () => {
 
   should("search for a string with a prefix/suffix (negative case)", () => {
     assert.isTrue("hound dog".search(RegexpCache.get("do", "\\b", "\\b")) === -1);
-  });
-});
-
-let fakeTimeDeltaElapsing = () => {};
-
-context("TabRecency", () => {
-  const tabRecency = BgUtils.tabRecency;
-
-  setup(() => {
-    fakeTimeDeltaElapsing = () => {
-      if (tabRecency.lastVisitedTime != null) {
-        tabRecency.lastVisitedTime = new Date(tabRecency.lastVisitedTime - BgUtils.TIME_DELTA);
-      }
-    };
-
-    tabRecency.register(3);
-    fakeTimeDeltaElapsing();
-    tabRecency.register(2);
-    fakeTimeDeltaElapsing();
-    tabRecency.register(9);
-    fakeTimeDeltaElapsing();
-    tabRecency.register(1);
-    tabRecency.deregister(9);
-    fakeTimeDeltaElapsing();
-    tabRecency.register(4);
-    fakeTimeDeltaElapsing();
-  });
-
-  should("have entries for recently active tabs", () => {
-    assert.isTrue(tabRecency.cache[1]);
-    assert.isTrue(tabRecency.cache[2]);
-    assert.isTrue(tabRecency.cache[3]);
-  });
-
-  should("not have entries for removed tabs", () => {
-    assert.isFalse(tabRecency.cache[9]);
-  });
-
-  should("give a high score to the most recent tab", () => {
-    assert.isTrue(tabRecency.recencyScore(4) < tabRecency.recencyScore(1));
-    assert.isTrue(tabRecency.recencyScore(3) < tabRecency.recencyScore(1));
-    assert.isTrue(tabRecency.recencyScore(2) < tabRecency.recencyScore(1));
-  });
-
-  should("give a low score to the current tab", () => {
-    assert.isTrue(tabRecency.recencyScore(1) > tabRecency.recencyScore(4));
-    assert.isTrue(tabRecency.recencyScore(2) > tabRecency.recencyScore(4));
-    assert.isTrue(tabRecency.recencyScore(3) > tabRecency.recencyScore(4));
-  });
-
-  should("rank tabs by recency", () => {
-    assert.isTrue(tabRecency.recencyScore(3) < tabRecency.recencyScore(2));
-    assert.isTrue(tabRecency.recencyScore(2) < tabRecency.recencyScore(1));
-    tabRecency.register(3);
-    fakeTimeDeltaElapsing();
-    tabRecency.register(4); // Making 3 the most recent tab which isn't the current tab.
-    assert.isTrue(tabRecency.recencyScore(1) < tabRecency.recencyScore(3));
-    assert.isTrue(tabRecency.recencyScore(2) < tabRecency.recencyScore(3));
-    assert.isTrue(tabRecency.recencyScore(4) < tabRecency.recencyScore(3));
-    assert.isTrue(tabRecency.recencyScore(4) < tabRecency.recencyScore(1));
-    assert.isTrue(tabRecency.recencyScore(4) < tabRecency.recencyScore(2));
   });
 });


### PR DESCRIPTION
tab.lastAccessed has been available in Firefox since Firefox 56, and was just added to Chrome 121.

We were previously tracking this property ourselves. Our implementation was flawed because the tab last accessed timestamps would be garbage collected every time the extension's service worker gets unloaded, as of our migration to manifest V3.

Now we can get rid of our own state tracking in the background service worker, and as a result, this should fix #4368.
