### PR TITLE
Fixes for Orion Browser #3610

### DIFF
--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -4,7 +4,7 @@
  * the style of our Vimium dialogs.
  *
  * The z-indexes of Vimium elements are very large, because we always want them to show on top. We
- * know that Chrome supports z-index values up to about 2^31. The values we use are large numbers
+ * know that Chrome supports z-index values up to about 2,147,483,648. The values we use are large numbers
  * approaching that bound. However, we must leave headroom for link hints. Hint marker z-indexes
  * start at 2140000001.
  */
@@ -33,7 +33,7 @@ tr.vimiumReset {
   cursor: auto;
   display: inline;
   float: none;
-  font-family : "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+  font-family: "Helvetica Neue", "Helvetica", "Arial", sans-serif;
   font-size: inherit;
   font-style: normal;
   font-variant: normal;

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -156,12 +156,23 @@ const Settings = {
     const shouldMigrate = settings["settingsVersion"] == null;
     if (!shouldMigrate) return settings;
 
+    // Safari struggles to parse anything that isn't a stringified JSON object when using JSON.parse().
+    // This ensures that only stringified JSON objects get passed into the parser.
+    const isValidJSON = (str) => {
+      try {
+        JSON.parse(str);
+        return true;
+      } catch (e) {
+        return false;
+      }
+    };
+
     // Migration for v2.0.0: decode all values so that they're not JSON string encoded.
     const newSettings = {};
     for (const [k, v] of Object.entries(settings)) {
       // Most pre-2.0 settings were strings, but the global marks were stored as native values. See
       // #4323. So check the setting value's type before migrating.
-      if (typeof v === "string") {
+      if (typeof v === "string" && isValidJSON(v)) {
         newSettings[k] = JSON.parse(v);
       } else {
         newSettings[k] = v;


### PR DESCRIPTION
## Description

This pull request has some reference to issue #3610. But mainly this pull request is so we can run Vimium in [Orion](https://kagi.com/orion/). For those that don't know, Orion is a WebKit based browser that is attempting to support both Chrome and Firefox extensions alike.

I believe Vimium was working previously for the most part but then something to do with settings parsing broke it I believe. The issue I found was that WebKit's support for `JSON.parse()` seems to have a few issues.

1. There was a `^` symbol in `vimium.css` that WebKit's `JSON.parse()` didn't know how to handle when iterating and parsing through the settings keys in `settings.js: migrateSettingsIfNecessary(settings)`.

2. WebKit's `JSON.parse()` struggled again in the same iterator when given an item that was not a stringified JSON object. So a simple validation was added in so only stringified JSON objects would be parsed.

After these fixes were made I tested it with [Orion Version 0.99.126.4.1-beta (WebKit 618.1.2)](https://orionfeedback.org/d/6797-orion-macos-0991264).

_A small formatting fix was also made._