### PR TITLE
use popovers for hint markers

### DIFF
--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -459,6 +459,7 @@ class LinkHintsMode {
       // Each hint marker is assigned a different z-index.
       el.style.zIndex = this.getNextZIndex();
       el.className = "vimiumReset internalVimiumHintMarker vimiumHintMarker";
+      el.popover = "manual";
       Object.assign(marker, {
         element: el,
         localHint,
@@ -731,6 +732,9 @@ class LinkHintsMode {
     if (!linkMarker.isLocalMarker()) return;
 
     linkMarker.element.style.display = "";
+    try { 
+      marker.element.showPopover();
+    } catch {}
     for (let j = 0, end = linkMarker.element.childNodes.length; j < end; j++) {
       if (j < matchingCharCount) {
         linkMarker.element.childNodes[j].classList.add("matchingCharacter");
@@ -743,6 +747,9 @@ class LinkHintsMode {
   hideMarker(marker) {
     if (marker.isLocalMarker()) {
       marker.element.style.display = "none";
+      try { 
+        marker.element.hidePopover();
+      } catch {}
     }
   }
 


### PR DESCRIPTION
## Description

This PR offers a bit of a starting point for fixing https://github.com/philc/vimium/issues/4408. The basic principle is that all of the HintMarkers need to use [`popover`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover) in order to sit on the ["top layer"](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer) so that they appear above all other content. 

I don't have any time to work on this PR further, but I thought it could serve as a bit of a starting point to help with #4408.
