### PR TITLE
Store tab recency information in session storage

### DIFF
--- a/background_scripts/bg_utils.js
+++ b/background_scripts/bg_utils.js
@@ -19,6 +19,8 @@ const BgUtils = {
   },
 };
 
+BgUtils.tabRecency.init();
+
 Object.assign(globalThis, {
   BgUtils,
 });

--- a/background_scripts/tab_recency.js
+++ b/background_scripts/tab_recency.js
@@ -1,10 +1,22 @@
 // TabRecency associates an integer with each tab id representing how recently it has been accessed.
-// These are used to provide an initial recency-based ordering in the tabs vomnibar.
+// The order of tabs as tracked by TabRecency is used to provide a recency-based ordering in the
+// tabs vomnibar.
+//
+// The values are persisted to chrome.storage.session so that they're not lost when the extension's
+// background page is unloaded.
+//
+// In theory, the browser's tab.lastAccessed timestamp field should allow us to sort tabs by
+// recency, but in practice it does not work across several edge cases. See the comments on #4368.
 class TabRecency {
   constructor() {
     this.counter = 1;
     this.tabIdToCounter = {};
+  }
 
+  // Add listeners to chrome.tabs, and load the index from session storage.
+  // If tabs are accessed before we finish loading chrome.storage.session, the in-memory stage and
+  // the session state is merged.
+  init() {
     chrome.tabs.onActivated.addListener((activeInfo) => this.register(activeInfo.tabId));
     chrome.tabs.onRemoved.addListener((tabId) => this.deregister(tabId));
 
@@ -18,15 +30,54 @@ class TabRecency {
       const tabs = await chrome.tabs.query({ windowId, active: true });
       if (tabs[0]) this.register(tabs[0].id);
     });
+
+    this.loadFromStorage();
+  }
+
+  // Loads the index from session storage.
+  async loadFromStorage() {
+    const tabsPromise = chrome.tabs.query({});
+    const storagePromise = chrome.storage.session.get("tabRecency");
+    const [tabs, storage] = await Promise.all([tabsPromise, storagePromise]);
+    if (storage.tabRecency == null) return;
+
+    let maxCounter = 0;
+    for (const counter of Object.values(storage.tabRecency)) {
+      if (maxCounter < counter) maxCounter = counter;
+    }
+    // Tabs loaded from storage should be considered accessed less recently than any tab tracked in
+    // memory, so increase all of the in-memory tabs's counters by maxCounter.
+    for (const [id, counter] of Object.entries(this.tabIdToCounter)) {
+      const newCounter = counter + maxCounter;
+      this.tabIdToCounter[id] = newCounter;
+      if (this.counter < newCounter) this.counter = newCounter;
+    }
+
+    const combined = Object.assign({}, storage.tabRecency, this.tabIdToCounter);
+
+    // Remove any tab IDs which may be no longer present.
+    const tabIds = new Set(tabs.map((t) => t.id));
+    for (const id in combined) {
+      if (!tabIds.has(parseInt(id))) {
+        delete combined[id];
+      }
+    }
+    this.tabIdToCounter = combined;
+  }
+
+  async saveToStorage() {
+    await chrome.storage.session.set({ tabRecency: this.tabIdToCounter });
   }
 
   register(tabId) {
     this.counter++;
     this.tabIdToCounter[tabId] = this.counter;
+    this.saveToStorage();
   }
 
   deregister(tabId) {
     delete this.tabIdToCounter[tabId];
+    this.saveToStorage();
   }
 
   // Recently-visited tabs get a higher score (except the current tab, which gets a low score).

--- a/tests/unit_tests/tab_recency_test.js
+++ b/tests/unit_tests/tab_recency_test.js
@@ -4,27 +4,67 @@ import "../../background_scripts/tab_recency.js";
 context("TabRecency", () => {
   let tabRecency;
 
-  setup(() => {
-    tabRecency = new TabRecency();
-    tabRecency.register(1);
-    tabRecency.register(2);
+  setup(() => tabRecency = new TabRecency());
+
+  context("order", () => {
+    setup(() => {
+      tabRecency.register(1);
+      tabRecency.register(2);
+      tabRecency.register(3);
+      tabRecency.register(4);
+      tabRecency.deregister(4);
+      tabRecency.register(2);
+    });
+
+    should("have the correct entries in the correct order", () => {
+      const expected = [2, 3, 1];
+      assert.equal(expected, tabRecency.getTabsByRecency());
+    });
+
+    should("score tabs by recency; current tab should be last", () => {
+      const score = (id) => tabRecency.recencyScore(id);
+      assert.equal(0, score(2));
+      assert.isTrue(score(2) < score(1));
+      assert.isTrue(score(1) < score(3));
+    });
+  });
+
+  should("loadFromStorage handles empty values", async () => {
+    stub(chrome.tabs, "query", () => Promise.resolve([{ id: 1 }]));
+
+    stub(chrome.storage.session, "get", () => Promise.resolve({}));
+    await tabRecency.loadFromStorage();
+    assert.equal([], tabRecency.getTabsByRecency());
+
+    stub(chrome.storage.session, "get", () => Promise.resolve({ tabRecency: {} }));
+    await tabRecency.loadFromStorage();
+    assert.equal([], tabRecency.getTabsByRecency());
+  });
+
+  should("loadFromStorage merges in-memory tabs with in-storage tabs", async () => {
+    const tabs = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+    stub(chrome.tabs, "query", () => Promise.resolve(tabs));
+
     tabRecency.register(3);
     tabRecency.register(4);
-    tabRecency.deregister(4);
-    tabRecency.register(2);
+
+    const storage = { tabRecency: { 1: 5, 2: 6 } };
+    stub(chrome.storage.session, "get", () => Promise.resolve(storage));
+
+    // Even though the in-storage tab counters are higher than the in-memory tabs, during
+    // loading, the in-memory tab counters are adjusted to be the most recent.
+    await tabRecency.loadFromStorage();
+
+    assert.equal([4, 3, 2, 1], tabRecency.getTabsByRecency());
   });
 
+  should("loadFromStorage prunes out tabs which are no longer active", async () => {
+    const tabs = [{ id: 1 }];
+    stub(chrome.tabs, "query", () => Promise.resolve(tabs));
 
-  should("have the correct entries in the correct order", () => {
-    const expected = [2, 3, 1];
-    assert.equal(expected, tabRecency.getTabsByRecency());
-  });
-
-
-  should("score tabs by recency; current tab should be last", () => {
-    const score = (id) => tabRecency.recencyScore(id);
-    assert.equal(0, score(2));
-    assert.isTrue(score(2) < score(1));
-    assert.isTrue(score(1) < score(3));
+    const storage = { tabRecency: { 1: 5, 2: 6 } };
+    stub(chrome.storage.session, "get", () => Promise.resolve(storage));
+    await tabRecency.loadFromStorage();
+    assert.equal([1], tabRecency.getTabsByRecency());
   });
 });


### PR DESCRIPTION
Currently, the tab order shown by the `Vomnibar.activateTabSelection` command gets lost if the extension's background page is unloaded by the browser.

Here, we save the order into session storage so it persists.

This should fix #4368.

#4431 was another approach at this, but turned out to be non-viable.