### PR TITLE
fix(#4447): Fix Key Exlusion Bug

### DIFF
--- a/pages/action.html
+++ b/pages/action.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" type="text/css" href="action.css">
   <link rel="stylesheet" type="text/css" href="../content_scripts/vimium.css">
 
+  <script src="../background_scripts/tab_recency.js"></script>
   <script src="../background_scripts/bg_utils.js"></script>
   <script src="../lib/utils.js"></script>
   <script src="../lib/dom_utils.js"></script>


### PR DESCRIPTION
Load tab_recency module before loading bg_utils
in action page.

## Description
bg_utils depends on tab_recency, since tab_recenty wasn't being loaded, bg_utils was throwing error
which caused the bug #4447 
So loading tab_recency fixes the issue.
