### PR TITLE
Add display style attribute to prevent popover content from being hidden on GitHub Enterprise (and maybe other sites)

### DIFF
--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -419,6 +419,7 @@ class LinkHintsMode {
         top: 0,
         left: 0,
         position: "absolute",
+        display: 'block',
         width: "100%",
         height: "100%",
         overflow: "visible",


### PR DESCRIPTION
## Description

This PR was spun out of [this issue](https://github.com/philc/vimium/issues/4446), where it was reported that hint markers were no longer visible on GitHub Enterprise pages since [this commit](https://github.com/philc/vimium/commit/412cc37621a578ee260925f31e0722539af33f39). 

It looks like GHE pages have some styling rules that prevent popovers that are not technically "open" from being displayed. If we explicitly set our marker container's `display` style attribute that will take priority over those rules. 

## Verification
Testing locally, the issue is resolved on GHE

![ghewin](https://github.com/philc/vimium/assets/7697924/233a876a-050a-4724-b64a-0b8bf577eda7)

I was not able to run the tests locally; it looks like there are some restrictions on my machine that interfere with puppeteer's installation:

>error trying to connect: invalid peer certificate: UnknownIssuer


