### PR TITLE
Remove unused `tabId` variable in `openUrlInCurrentTab`

### DIFF
--- a/background_scripts/tab_operations.js
+++ b/background_scripts/tab_operations.js
@@ -12,7 +12,6 @@ async function openUrlInCurrentTab(request) {
   // (like github.com, developer.mozilla.org) will raise an error when we try to run this code. See
   // https://github.com/philc/vimium/issues/4331.
   if (UrlUtils.hasJavascriptPrefix(request.url)) {
-    const tabId = request.tabId;
     const scriptingArgs = {
       target: { tabId: request.tabId },
       func: (text) => {


### PR DESCRIPTION
This variable became unused in 10524a0c1f0fc732e1f9df3497b026e17edf3728 so we can remove it.