### PR TITLE
Make `focusInput` focus all the input filelds in the whold page

### DIFF
--- a/content_scripts/mode_normal.js
+++ b/content_scripts/mode_normal.js
@@ -256,7 +256,7 @@ const NormalModeCommands = {
 
     for (let i = 0, end = resultSet.snapshotLength; i < end; i++) {
       element = resultSet.snapshotItem(i);
-      if (!element.getClientRects(element, true)) {
+      if (!element.getClientRects()[0]) {
         continue;
       }
       visibleInputs.push({ element, index: i, rect: Rect.copy(element.getBoundingClientRect()) });

--- a/content_scripts/mode_normal.js
+++ b/content_scripts/mode_normal.js
@@ -256,7 +256,7 @@ const NormalModeCommands = {
 
     for (let i = 0, end = resultSet.snapshotLength; i < end; i++) {
       element = resultSet.snapshotItem(i);
-      if (!DomUtils.getVisibleClientRect(element, true)) {
+      if (!element.getClientRects(element, true)) {
         continue;
       }
       visibleInputs.push({ element, index: i, rect: Rect.copy(element.getBoundingClientRect()) });


### PR DESCRIPTION
## Description

close #4046 

This change makes `focusInput` focus all the input fields in the whold page (including the fields out of view).

## Reasons why applying this feature
1. For most webpages, there is a search bar at the top of the page, which is the most used input field. However, at the time when we want to search something else, we are very likely have been at the bottom of the page, and thus present *foucs input* function can not be used because the search bar is at top.
2. For most webpages, there are not much input fields. So focusing all input fields will not spend much time of user to switch to the aimed input field.