### PR TITLE
change the default `actionName` to something that won't be ignored.

### DIFF
--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -1136,8 +1136,8 @@ const LocalHints = {
         const ruleSplit = jsactionRule.trim().split(":");
         if ((ruleSplit.length >= 1) && (ruleSplit.length <= 2)) {
           const [eventType, namespace, actionName] = ruleSplit.length === 1
-            ? ["click", ...ruleSplit[0].trim().split("."), "_"]
-            : [ruleSplit[0], ...ruleSplit[1].trim().split("."), "_"];
+            ? ["click", ...ruleSplit[0].trim().split("."), ""]
+            : [ruleSplit[0], ...ruleSplit[1].trim().split("."), ""];
           if (!isClickable) {
             isClickable = (eventType === "click") && (namespace !== "none") && (actionName !== "_");
           }


### PR DESCRIPTION
In https://github.com/philc/vimium/commit/afeb65f5af849f04df8380212dbf50a6bf186bc4, a change was made to exclude elements with a jsaction with an actionName of "_". However, as written, this also excludes any jsaction that doesn't specify an action name. I'm not sure if this is a desired behavior.

As an example, on https://calendar.google.com/calendar/, each date in the mini calendar has a `jsaction="click:nngp;"` and each is clickable, but because no actionName is specified, Vimium does not place hints there.
