### PR TITLE
Correctly handle Firefox hidden tabs.

### DIFF
--- a/background_scripts/bg_utils.js
+++ b/background_scripts/bg_utils.js
@@ -17,7 +17,7 @@ const BgUtils = {
   // Get a query dictionary for `chrome.tabs.query` that will only return the visible tabs.
   visibleTabs() {
     const visibleTabsQuery = {
-      currentWindow: true
+      currentWindow: true,
     };
     // Only Firefox supports hidden tabs
     if (this.isFirefox()) {
@@ -36,11 +36,11 @@ const BgUtils = {
       // Since we know that all indices are in order, we can do a binary search.
       let l = 0;
       let r = tabs.length - 1;
-      while(l <= r) {
+      while (l <= r) {
         let m = (l + r) >> 1;
         if (tabs[m].index < tab.index) {
           l = m + 1;
-        } else if(tabs[m].index > tab.index) {
+        } else if (tabs[m].index > tab.index) {
           r = m - 1;
         } else {
           return m;

--- a/background_scripts/bg_utils.js
+++ b/background_scripts/bg_utils.js
@@ -14,38 +14,16 @@ const BgUtils = {
       : false;
   },
 
-  // Get a query dictionary for `chrome.tabs.query` that will only return the visible tabs.
-  visibleTabs() {
-    const visibleTabsQuery = {
-      currentWindow: true,
-    };
-    // Only Firefox supports hidden tabs
-    if (this.isFirefox()) {
-      visibleTabsQuery.hidden = false;
-    }
-    return visibleTabsQuery;
-  },
-
   // Find the real tab index in a given tab array.
+  // In Firefox there may be hidden tabs,
+  // so `tab.index` may not be the index in the visible tabs array.
   tabIndex(tab, tabs) {
     // First check if the tab is where we expect it (to save processing).
     if (tabs.length > tab.index && tabs[tab.index].index === tab.index) {
       return tab.index;
     } else {
       // If it's not where we expect, find its real position.
-      // Since we know that all indices are in order, we can do a binary search.
-      let l = 0;
-      let r = tabs.length - 1;
-      while (l <= r) {
-        let m = (l + r) >> 1;
-        if (tabs[m].index < tab.index) {
-          l = m + 1;
-        } else if (tabs[m].index > tab.index) {
-          r = m - 1;
-        } else {
-          return m;
-        }
-      }
+      return tabs.findIndex((t) => t.index === tab.index);
     }
   },
 

--- a/background_scripts/bg_utils.js
+++ b/background_scripts/bg_utils.js
@@ -14,6 +14,29 @@ const BgUtils = {
       : false;
   },
 
+  // Get a query dictionary for `chrome.tabs.query` that will only return the visible tabs.
+  visibleTabs() {
+    const visibleTabsQuery = {
+      currentWindow: true
+    };
+    // Only Firefox supports hidden tabs
+    if (this.isFirefox()) {
+      visibleTabsQuery.hidden = false;
+    }
+    return visibleTabsQuery;
+  },
+
+  // Find the real tab index in a given tab array.
+  tabIndex(tab, tabs) {
+    // First check if the tab is where we expect it (to save processing).
+    if (tabs.length > tab.index && tabs[tab.index].index === tab.index) {
+      return tab.index;
+    } else {
+      // If it's not where we expect, find its real position.
+      return tabs.findIndex(t => t.index === tab.index);
+    }
+  },
+
   async getFirefoxVersion() {
     return globalThis.browser ? (await browser.runtime.getBrowserInfo()).version : null;
   },

--- a/background_scripts/bg_utils.js
+++ b/background_scripts/bg_utils.js
@@ -33,7 +33,19 @@ const BgUtils = {
       return tab.index;
     } else {
       // If it's not where we expect, find its real position.
-      return tabs.findIndex(t => t.index === tab.index);
+      // Since we know that all indices are in order, we can do a binary search.
+      let l = 0;
+      let r = tabs.length - 1;
+      while(l <= r) {
+        let m = (l + r) >> 1;
+        if (tabs[m].index < tab.index) {
+          l = m + 1;
+        } else if(tabs[m].index > tab.index) {
+          r = m - 1;
+        } else {
+          return m;
+        }
+      }
     }
   },
 


### PR DESCRIPTION
## Description

This PR solves issues  #2998, #3180, and #3593 by correctly handling Firefox hidden tabs. In Firefox there may be many hidden tabs between visible tabs in the main interface. The expected behavior for these tabs is that they would not be considered while performing operations. This PR makes Vimium behave the same as Firefox's default functionality for switching tabs (ctrl+tab) so that it will *feel more native* for Firefox users. Without these fixes, hidden tabs make Vimium almost unusable in Firefox.

For example, many add-ons hide tabs to allow for quick context switching. This is the result of console logging my current visible tabs:

```
0: Object { id: 3, index: 0, windowId: 1, … }
1: Object { id: 4, index: 1, windowId: 1, … }
2: Object { id: 5, index: 2, windowId: 1, … }
3: Object { id: 6, index: 3, windowId: 1, … }
4: Object { id: 7, index: 4, windowId: 1, … }
5: Object { id: 459, index: 5, windowId: 1, … }
6: Object { id: 458, index: 6, windowId: 1, … }
7: Object { id: 453, index: 7, windowId: 1, … }
8: Object { id: 455, index: 8, windowId: 1, … }
9: Object { id: 457, index: 9, windowId: 1, … }
10: Object { id: 468, index: 10, windowId: 1, … }
11: Object { id: 462, index: 11, windowId: 1, … }
12: Object { id: 464, index: 12, windowId: 1, … }
13: Object { id: 465, index: 13, windowId: 1, … }
14: Object { id: 466, index: 14, windowId: 1, … }
15: Object { id: 463, index: 15, windowId: 1, … }
16: Object { id: 2, index: 430, windowId: 1, … }
17: Object { id: 422, index: 431, windowId: 1, … }
18: Object { id: 423, index: 432, windowId: 1, … }
19: Object { id: 478, index: 433, windowId: 1, … }
20: Object { id: 451, index: 457, windowId: 1, … }
21: Object { id: 452, index: 458, windowId: 1, … }
22: Object { id: 490, index: 459, windowId: 1, … }
23: Object { id: 492, index: 460, windowId: 1, … }
```

Neither the id nor the index is directly related to the tab's "real" position. If I am in tab id 463 and send a command to select `nextTab`, I would expect the tab with id 2 to become selected.

## Implementation

I tried to implement these changes to:

1. Have the least impact on Chrome users.
2. Use sensible, easy code.
3. Cover all Firefox use cases.
4. Impact performance as little as possible.

I did this by adding two utility functions to the existing `bg_utils.js` file which can be used in all existing and future functions. These two functions are both implemented so that on Chrome and in basic cases (if the users has no hidden tabs), the functionality of Vimium will not change. These two functions are then used in all the necessary places.

In the case that we must find the index of a tab within the visible tab array, we must perform a search over the visible tabs. Since the indices are always ordered, I implemented a binary search to improve performance when many tabs are open. This makes the performance **significantly** better than using `findIndex` when the user has many tabs open. Even if the user has 100,000 tabs, the search will take at most 17 iterations, so it should not significantly impact performance.

The operations that I implemented were:

* remove tabs
* select tabs
* move tabs

I have also tried to update all relevant functions so that all operations will work in the future.


## Testing

I have manually tested all of this functionality with hidden tabs and it appears to work correctly. This includes moving tabs to new windows and removing tabs relatively. All manual tests were also done with counts, such as "5 >>" across hidden tab gaps.

I ran the Chrome unit tests and they still pass.

## Conclusion

If you see anything that is wrong or have any improvements to my code or method of implementation, please make a suggestion or fix the issue. I have been using my own fork with a few of these changes for a few years, but since some more people have been asking for this feature I wanted to clean up a good implementation and help other Firefox users be able to use Vimium with other tab-hiding extensions.
