### PR TITLE
Fix find mode not searching inside elements with `display` property set to `contents`

### DIFF
--- a/content_scripts/mode_find.js
+++ b/content_scripts/mode_find.js
@@ -483,7 +483,10 @@ const getAllTextNodes = () => {
   function getAllTextNodes(node) {
     if (node.nodeType === Node.TEXT_NODE) {
       textNodes.push(node);
-    } else if (node.nodeType === Node.ELEMENT_NODE && node.checkVisibility()) {
+    } else if (
+      node.nodeType === Node.ELEMENT_NODE &&
+      (node.checkVisibility() || node.style.display === "contents")
+    ) {
       const children = node.childNodes;
       for (const child of children) {
         getAllTextNodes(child, textNodes);


### PR DESCRIPTION
## Description

Resolves #4492.

The [`checkVisibility` method](https://developer.mozilla.org/en-US/docs/Web/API/Element/checkVisibility) considers elements with `display` set to `contents` as not visible in the page and it is true that the element is not visible, but its children are completely visible. So I simply made the node traversal algorithm also visit the children of elements with `node.style.display === 'contents'` and it worked.
