### PR TITLE
new hint style

### DIFF
--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -84,28 +84,32 @@ div.internalVimiumHintMarker {
   white-space: nowrap;
   overflow: hidden;
   font-size: 11px;
-  padding: 1px 3px 0px 3px;
-  background: linear-gradient(to bottom, #FFF785 0%,#FFC542 100%);
-  border: solid 1px #C38A22;
+  padding: 1px 1px 1px 1px;
+  background: rgb(255, 255, 255); /* Change to your desired transparent color */
+  /* background: linear-gradient(to bottom, #FFF785 0%,#FFC542 100%); */
+  /* border: solid 1px #C38A22; */
   border-radius: 3px;
   box-shadow: 0px 3px 7px 0px rgba(0, 0, 0, 0.3);
   z-index: 2147483647;
 }
 
 div.internalVimiumHintMarker span {
-  color: #302505;
+  color: #000000;
+  /* color: #302505; */
   font-family: Helvetica, Arial, sans-serif;
   font-weight: bold;
   font-size: 11px;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6);
+  /* text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6); */
 }
 
 div.internalVimiumHintMarker > .matchingCharacter {
-  color: #D4AC3A;
+  color: #f6f6f5;
+  /* color: #D4AC3A; */
 }
 
 div > .vimiumActiveHintMarker span {
-  color: #A07555 !important;
+  color: #ffffff !important;
+  /* color: #A07555 !important; */
 }
 
 /* Input hints CSS */


### PR DESCRIPTION
## Description

I find bright yellow hint buttons to be too large, and a bit too colorful. I've changed the padding and background color to white. Check out the demo of how it looks like: 
https://www.linkedin.com/posts/matthew-diakonov-a84a1911_browsing-through-the-web-with-keyboard-shortcuts-activity-7210104293620686848-EeyU?utm_source=share&utm_medium=member_desktop 



Please review the "Which pull requests get merged?" section in `CONTRIBUTING.md`.
