### PR TITLE
Fix DRY and Styling Issues (hardReload)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,8 @@
 
 2.0.1 (2023-10-04)
 
-- Fix exception when migrating some pre-v2.0 settings. ([#4323](https://github.com/philc/vimium/issues/4323))
+- Fix exception when migrating some pre-v2.0 settings.
+  ([#4323](https://github.com/philc/vimium/issues/4323))
 
 2.0.0 (2023-09-28 -- partially rolled out to users on the Chrome store)
 
@@ -62,14 +63,14 @@
 - Allow find mode to work when using only private windows.
   ([#3614](https://github.com/philc/vimium/issues/3614))
 - Add a count option to closeTabsOnLeft and closeTabsOnRight commands, to allow binding a key to
-  "close just 1 tab on the left/right" rather than closing all tabs, as is the default. E.g. `map cl
-  closeTabsOnLeft count=1`. ([#4296](https://github.com/philc/vimium/pull/4296))
+  "close just 1 tab on the left/right" rather than closing all tabs, as is the default. E.g.
+  `map cl closeTabsOnLeft count=1`. ([#4296](https://github.com/philc/vimium/pull/4296))
 - Add search completions for Brave Search. ([#3851](https://github.com/philc/vimium/pull/3851))
 - Make regular expressions in find mode work again; other find mode improvements.
   ([#4261](https://github.com/philc/vimium/issues/4261))
 - Bug fixes. ([#3944](https://github.com/philc/vimium/pull/3944),
-[#3752](https://github.com/philc/vimium/pull/3752),
-[#3675](https://github.com/philc/vimium/pull/3675))
+  [#3752](https://github.com/philc/vimium/pull/3752),
+  [#3675](https://github.com/philc/vimium/pull/3675))
 
 1.67.7 (2023-07-12)
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ spirit of the Vim editor.
 
 **Installation instructions:**
 
-* Chrome: [Chrome web store](https://chrome.google.com/extensions/detail/dbepggeogbaibhgnhhndojpepiihcmeb)
-* Edge: [Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/vimium/djmieaghokpkpjfbpelnlkfgfjapaopa)
-* Firefox: [Firefox Add-ons](https://addons.mozilla.org/en-GB/firefox/addon/vimium-ff/)
+- Chrome:
+  [Chrome web store](https://chrome.google.com/extensions/detail/dbepggeogbaibhgnhhndojpepiihcmeb)
+- Edge:
+  [Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/vimium/djmieaghokpkpjfbpelnlkfgfjapaopa)
+- Firefox: [Firefox Add-ons](https://addons.mozilla.org/en-GB/firefox/addon/vimium-ff/)
 
 To install from source, see [here](CONTRIBUTING.md#installing-from-source).
 

--- a/background_scripts/commands.js
+++ b/background_scripts/commands.js
@@ -297,7 +297,6 @@ const Commands = {
       "scrollToLeft",
       "scrollToRight",
       "reload",
-      "hardReload",
       "copyCurrentUrl",
       "openCopiedUrlInCurrentTab",
       "openCopiedUrlInNewTab",
@@ -382,7 +381,6 @@ const Commands = {
     "enterVisualLineMode",
     "toggleViewSource",
     "passNextKey",
-    "hardReload",
   ],
 };
 
@@ -401,7 +399,7 @@ const defaultKeyMappings = {
   "d": "scrollPageDown",
   "u": "scrollPageUp",
   "r": "reload",
-  "R": "hardReload",
+  "R": "reload hard",
   "yy": "copyCurrentUrl",
   "p": "openCopiedUrlInCurrentTab",
   "P": "openCopiedUrlInNewTab",
@@ -488,7 +486,6 @@ const commandDescriptions = {
   scrollFullPageUp: ["Scroll a full page up"],
 
   reload: ["Reload the page", { background: true }],
-  hardReload: ["Hard reload the page", { background: true }],
   toggleViewSource: ["View page source", { noRepeat: true }],
 
   copyCurrentUrl: ["Copy the current URL to the clipboard", { noRepeat: true }],

--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -172,13 +172,12 @@ function moveTab({ count, tab, registryEntry }) {
   });
 }
 
-// TODO(philc): Rename to createRepeatCommand.
-const mkRepeatCommand = (command) => (function (request) {
+const createRepeatCommand = (command) => (function (request) {
   request.count--;
   if (request.count >= 0) {
     // TODO(philc): I think we can remove this return statement, and all returns
-    // from commands built using mkRepeatCommand.
-    return command(request, (request) => (mkRepeatCommand(command))(request));
+    // from commands built using createRepeatCommand.
+    return command(request, (request) => (createRepeatCommand(command))(request));
   }
 });
 
@@ -188,7 +187,7 @@ const BackgroundCommands = {
   // Create a new tab. Also, with:
   //     map X createTab http://www.bbc.com/news
   // create a new tab with the given URL.
-  createTab: mkRepeatCommand(async function (request, callback) {
+  createTab: createRepeatCommand(async function (request, callback) {
     if (request.urls == null) {
       if (request.url) {
         // If the request contains a URL, then use it.
@@ -245,7 +244,7 @@ const BackgroundCommands = {
     }
   }),
 
-  duplicateTab: mkRepeatCommand((request, callback) => {
+  duplicateTab: createRepeatCommand((request, callback) => {
     return chrome.tabs.duplicate(
       request.tabId,
       (tab) => callback(Object.assign(request, { tab, tabId: tab.id })),
@@ -283,7 +282,7 @@ const BackgroundCommands = {
       chrome.tabs.remove(tab.id);
     });
   },
-  restoreTab: mkRepeatCommand((request, callback) =>
+  restoreTab: createRepeatCommand((request, callback) =>
     chrome.sessions.restore(null, callback(request))
   ),
   async togglePinTab({ count, tab }) {
@@ -538,7 +537,7 @@ const sendRequestHandlers = {
   getCurrentTabUrl({ tab }) {
     return tab.url;
   },
-  openUrlInNewTab: mkRepeatCommand((request, callback) =>
+  openUrlInNewTab: createRepeatCommand((request, callback) =>
     TabOperations.openUrlInNewTab(request, callback)
   ),
   openUrlInNewWindow(request) {

--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -356,12 +356,6 @@ const BackgroundCommands = {
       chrome.tabs.reload(tab.id, { bypassCache });
     });
   },
-
-  async hardReload({ count, tab }) {
-    await forCountTabs(count, tab, (tab) => {
-      chrome.tabs.reload(tab.id, { bypassCache: true });
-    });
-  },
 };
 
 async function forCountTabs(count, currentTab, callback) {

--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -659,13 +659,13 @@ class LinkHintsMode {
       }
     }
 
-    const newMarkers = []
+    const newMarkers = [];
     for (let stack of stacks) {
       if (stack.length > 1) {
         // Push the last element to the beginning.
-        stack = stack.splice(-1, 1).concat(stack)
+        stack = stack.splice(-1, 1).concat(stack);
       }
-      newMarkers.push(...stack)
+      newMarkers.push(...stack);
     }
     this.hintMarkers = newMarkers;
     this.renderHints();

--- a/tests/unit_tests/completion_test.js
+++ b/tests/unit_tests/completion_test.js
@@ -320,7 +320,7 @@ context("domain completer (removing entries)", () => {
 });
 
 context("multi completer", () => {
-  const tabs = [{ url: "tab1.com", title: "tab1", id: 1 },];
+  const tabs = [{ url: "tab1.com", title: "tab1", id: 1 }];
   const tabCompleter = new TabCompleter();
   let multiCompleter;
 
@@ -333,7 +333,7 @@ context("multi completer", () => {
     // Even though a TabCompleter returns results when the query is empty, a MultiCompleter which
     // wraps a TabCompleter should not.
     assert.equal(1, (await filterCompleter(tabCompleter, [])).length);
-    assert.equal([], (await filterCompleter(multiCompleter, [])));
+    assert.equal([], await filterCompleter(multiCompleter, []));
   });
 });
 

--- a/tests/unit_tests/tab_recency_test.js
+++ b/tests/unit_tests/tab_recency_test.js
@@ -10,12 +10,12 @@ context("TabRecency", () => {
     setup(async () => {
       stub(chrome.tabs, "query", () => Promise.resolve([]));
       await tabRecency.init();
-      tabRecency.queueAction("register", (1));
-      tabRecency.queueAction("register", (2));
-      tabRecency.queueAction("register", (3));
-      tabRecency.queueAction("register", (4));
-      tabRecency.queueAction("deregister", (4));
-      tabRecency.queueAction("register", (2));
+      tabRecency.queueAction("register", 1);
+      tabRecency.queueAction("register", 2);
+      tabRecency.queueAction("register", 3);
+      tabRecency.queueAction("register", 4);
+      tabRecency.queueAction("deregister", 4);
+      tabRecency.queueAction("register", 2);
     });
 
     should("have the correct entries in the correct order", () => {
@@ -73,8 +73,8 @@ context("TabRecency", () => {
 
     assert.equal([2, 1], tabRecency.getTabsByRecency());
 
-    tabRecency.queueAction("register", (3));
-    tabRecency.queueAction("register", (1));
+    tabRecency.queueAction("register", 3);
+    tabRecency.queueAction("register", 1);
 
     assert.equal([1, 3, 2], tabRecency.getTabsByRecency());
   });


### PR DESCRIPTION
## Description

Removes duplicate `hardReload` functionality. I decided to go with removing the `hardReload` function entirely and mapping `R` to `reload hard`. The other obvious option would be to keep the `hardReload` function and have it call `reload({count: count, tabId: tabId, registryEntry: {options: {hard: true}}})`. This fixes the one main downside of my chosen implementation: it means the key mapping appears like this: "`R`, `r`  Reload the page" which is not intuitive and does not make it clear that `R` is hard reload and `r` is regular reload.

Perhaps this calls for a change to how the commands are rendered in the help menu. If you would like, I can do that in this PR.

Since this is a refactor pull request, I used it to make two other changes that have been outstanding:

1. Rename `mkRepeateCommands` to `createRepeatCommands`.
2. Resolve the other `deno fmt` corrections.

I looked through the rest of the `background_scripts/main.js` file and there didn't seem to be any more obvious DRY violations or other easy refactors that should be done. If you have any more reactors you have been wanting done, let me know and I can add them to this PR.

The tests pass and with quick testing, the addon seems to still work correctly in Chromium and Firefox.