### PR TITLE
Remove unused icons from build

### DIFF
--- a/make.js
+++ b/make.js
@@ -125,7 +125,7 @@ async function buildStorePackage() {
 
   const firefoxManifest = createFirefoxManifest(chromeManifest);
   await writeDistManifest(firefoxManifest);
-  await shell("bash", ["-c", `${zipCommand} ../firefox/vimium-firefox-${version}.zip .`]);
+  await shell("bash", ["-c", `${zipCommand} ../firefox/vimium-firefox-${version}.zip . -x icons/*.png`]);
 
   // Build the Chrome Store package.
   await writeDistManifest(chromeManifest);


### PR DESCRIPTION
Now that the Firefox version uses SVGs directly, the PNGs can be excluded for that build (saves ~17K)