### PR TITLE
Add missing 110% Firefox zoom level.

### DIFF
--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -186,7 +186,7 @@ function nextZoomLevel(currentZoom, steps) {
   // Chrome's default zoom levels.
   const chromeLevels = [0.25, 0.33, 0.5, 0.75, 0.8, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 5];
   // Firefox's default zoom levels.
-  const firefoxLevels = [0.3, 0.5, 0.67, 0.8, 0.9, 1, 1.2, 1.33, 1.5, 1.7, 2, 2.4, 3, 4, 5];
+  const firefoxLevels = [0.3, 0.5, 0.67, 0.8, 0.9, 1, 1.1, 1.2, 1.33, 1.5, 1.7, 2, 2.4, 3, 4, 5];
 
   let zoomLevels = chromeLevels; // Chrome by default
   if (BgUtils.isFirefox()) {


### PR DESCRIPTION
## Description

While using the new zoom updates, I noticed that somehow 110% got left out of the updated Firefox zoom levels list. 110% is one of the levels Firefox uses by default, so I have added it here.