### PR TITLE
✨ feat(completions): add tab favicon for better image quality

### DIFF
--- a/background_scripts/completion.js
+++ b/background_scripts/completion.js
@@ -47,6 +47,7 @@ class Suggestion {
   // The generated HTML string for showing this suggestion in the Vomnibar.
   html;
   searchUrl;
+  favIconUrl;
 
   constructor(options) {
     Object.seal(this);
@@ -77,8 +78,9 @@ class Suggestion {
     if (this.description === "tab" && !BgUtils.isFirefox()) {
       const faviconUrl = new URL(chrome.runtime.getURL("/_favicon/"));
       faviconUrl.searchParams.set("pageUrl", this.url);
-      faviconUrl.searchParams.set("size", "16");
-      faviconHtml = `<img class="vomnibarIcon" src="${faviconUrl.toString()}" />`;
+      faviconUrl.searchParams.set("size", "64");
+      const src = this.favIconUrl.startsWith("http") ? this.favIconUrl : faviconUrl.toString();
+      faviconHtml = `<img class="vomnibarIcon" src="${src}" />`;
     }
     if (this.isCustomSearch) {
       this.html = `\
@@ -489,6 +491,7 @@ class TabCompleter {
           queryTerms,
           description: "tab",
           url: tab.url,
+          favIconUrl: tab.favIconUrl,
           title: tab.title,
           tabId: tab.id,
           deDuplicate: false,

--- a/pages/vomnibar.css
+++ b/pages/vomnibar.css
@@ -86,6 +86,7 @@
 #vomnibar li .vomnibarIcon {
   padding: 0 13px 0 6px;
   vertical-align: bottom;
+  width: 16px;
 }
 
 #vomnibar li .vomnibarSource {


### PR DESCRIPTION
## Description

<img width="398" alt="image" src="https://github.com/user-attachments/assets/e24be030-0302-4efc-a040-6a0fdc547c15">

As many of you know, a significant number of users apply custom CSS to enhance their Vimium experience. While creating my own custom styling, I encountered a limitation with the Vomnibar: the favicon is always fetched at a 16px size. This fixed size makes resizing the icon challenging, as it can result in a blurry appearance.


![image](https://github.com/user-attachments/assets/ad505e35-bcc5-4e57-98b1-dcd6a034e951) 

This PR addresses this issue by fetching the tab's favicon URL directly when available, allowing for a higher-quality icon. If the favicon isn't available, the PR provides a fallback with an improved size, ensuring the icon looks sharp and visually appealing even when resized.


