### PR TITLE
Add debounce to `HUD.search()` method

### DIFF
--- a/content_scripts/hud.js
+++ b/content_scripts/hud.js
@@ -6,6 +6,7 @@ const HUD = {
   tween: null,
   hudUI: null,
   findMode: null,
+  searchTimeout: null,
   abandon() {
     if (this.hudUI) {
       this.hudUI.hide(false);
@@ -86,16 +87,22 @@ const HUD = {
   },
 
   search(data) {
-    // NOTE(mrmr1993): On Firefox, window.find moves the window focus away from the HUD. We use
-    // postFindFocus to put it back, so the user can continue typing.
-    this.findMode.findInPlace(data.query, {
-      "postFindFocus": this.hudUI.iframeElement.contentWindow,
-    });
+    if (this.searchTimeout) {
+      clearTimeout(this.searchTimeout);
+    }
 
-    // Show the number of matches in the HUD UI.
-    const matchCount = FindMode.query.parsedQuery.length > 0 ? FindMode.query.matchCount : 0;
-    const showMatchText = FindMode.query.rawQuery.length > 0;
-    this.hudUI.postMessage({ name: "updateMatchesCount", matchCount, showMatchText });
+    this.searchTimeout = Utils.setTimeout(300, () => {
+      // NOTE(mrmr1993): On Firefox, window.find moves the window focus away from the HUD. We use
+      // postFindFocus to put it back, so the user can continue typing.
+      this.findMode.findInPlace(data.query, {
+        "postFindFocus": this.hudUI.iframeElement.contentWindow,
+      });
+
+      // Show the number of matches in the HUD UI.
+      const matchCount = FindMode.query.parsedQuery.length > 0 ? FindMode.query.matchCount : 0;
+      const showMatchText = FindMode.query.rawQuery.length > 0;
+      this.hudUI.postMessage({ name: "updateMatchesCount", matchCount, showMatchText });
+    });
   },
 
   // Hide the HUD.


### PR DESCRIPTION
## Description

This PR adds a debounce mechanism to the `HUD.search()` method in the `content_scripts/hud.js` file. The purpose of this change is to improve performance and reduce unnecessary searches when users are typing quickly in the HUD search field.

The implementation uses a `setTimeout` to delay the search execution by 300ms, clearing any previous timeout if a new search is initiated before the delay expires. This approach helps to minimize the number of searches performed while the user is still typing, potentially reducing strain on system resources and improving the overall user experience.

Related to issue: https://github.com/philc/vimium/issues/4546

### Changes made:

1. Added a `searchTimeout` property to the `HUD` object to store the timeout ID.
2. Implemented a debounce mechanism in the `search` method using `Utils.setTimeout`.
3. Moved the existing search logic inside the debounce callback.

### Rationale:

This change aligns with Vimium's design principles, particularly:

1. **Reliable**: By reducing the frequency of searches, we ensure smoother performance on various websites.
2. **Feels native**: The debounce mechanism is a common pattern in web applications, making Vimium feel more like a native part of the browser.
3. **Simple**: The implementation is straightforward and doesn't add significant complexity to the codebase.

### Additional context:

The PR introduces a small change (less than 50 LOC) that should be beneficial for many Vimium users, especially those who frequently use the HUD search feature on content-heavy pages.

### Testing:

I've run the test suite, and all tests have passed:
```bash
❯ ./make.js test
run: started
test-unit: started
Pass (192/192)
test-unit: finished (149ms)
test-dom: started
Listening on http://localhost:35500/
Running dom_tests.html
Pass (109/109)
Running vomnibar_test.html
Pass (3/3)
Unstable API 'Deno.Server.shutdown'. The --unstable flag must be provided.
```
Additionally, I've manually tested the changes by installing from source on Firefox Browser. The debounce functionality works as expected, reducing the number of searches performed during rapid typing.
Here's a screenshot of the Developer Tools, showing the Debugger Tab and Console (I didn't keep the `console.debug()`):
![debug](https://github.com/user-attachments/assets/671738ca-d881-4271-870e-0fd8fe445fc5)

### Follow-up / Open questions
- Upgrading Deno
- Add debounce test(s) using [FakeTime](https://jsr.io/@std/testing/doc/time/~/FakeTime)
  - I took a stab at it, but failed to integrate with `shoulda`, some documentation on how to add tests would be helpful.