### PR TITLE
Add Kagi search suggestions

### DIFF
--- a/background_scripts/completion_engines.js
+++ b/background_scripts/completion_engines.js
@@ -228,6 +228,24 @@ class Brave extends BaseEngine {
   }
 }
 
+// Kagi is a paid ad-free search engine
+class Kagi extends BaseEngine {
+  constructor() {
+    super({
+      engineUrl: "https://kagi.com/autosuggest?q=%s",
+      regexps: ["^https?://www\\.kagi\\.com/"],
+      example: {
+        searchUrl: "https://www.kagi.com/search?q=%s",
+        keyword: "k",
+      },
+    });
+  }
+
+  parse(text) {
+    return JSON.parse(text).map((suggestion) => suggestion.t);
+  }
+}
+
 // On the user-facing documentation page pages/completion_engines.html, these completion search
 // engines will be shown to the user in this order.
 const CompletionEngines = [
@@ -241,8 +259,9 @@ const CompletionEngines = [
   Webster,
   Qwant,
   Brave,
+  Kagi,
 ];
 
 globalThis.CompletionEngines = CompletionEngines;
 
-export { Amazon, Brave, DuckDuckGo, Qwant, Webster };
+export { Amazon, Brave, DuckDuckGo, Kagi, Qwant, Webster };

--- a/tests/unit_tests/completion_engines_test.js
+++ b/tests/unit_tests/completion_engines_test.js
@@ -24,6 +24,14 @@ context("Brave completion", () => {
   });
 });
 
+context("Kagi completion", () => {
+  should("parses results", () => {
+    const response = JSON.stringify([{ t: "one" }, { t: "two" }]);
+    const results = new Engines.Kagi().parse(response);
+    assert.equal(["one", "two"], results);
+  });
+});
+
 context("DuckDuckGo completion", () => {
   should("parses results", () => {
     const response = JSON.stringify([


### PR DESCRIPTION
## Description

[Kagi](https://kagi.com/) is a paid ad-free search engine. Since it's paid, I imagine it's less popular in terms of pure user numbers than some of the other search engines included here, but I also imagine there's a decent overlap between Vimium and Kagi users, so I thought I'd put this in.