### PR TITLE
Fix Deno Format and simple TODOs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: File a bug
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 **Describe the bug**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,8 @@
 
 2.0.1 (2023-10-04)
 
-- Fix exception when migrating some pre-v2.0 settings. ([#4323](https://github.com/philc/vimium/issues/4323))
+- Fix exception when migrating some pre-v2.0 settings.
+  ([#4323](https://github.com/philc/vimium/issues/4323))
 
 2.0.0 (2023-09-28 -- partially rolled out to users on the Chrome store)
 
@@ -62,14 +63,15 @@
 - Allow find mode to work when using only private windows.
   ([#3614](https://github.com/philc/vimium/issues/3614))
 - Add a count option to closeTabsOnLeft and closeTabsOnRight commands, to allow binding a key to
-  "close just 1 tab on the left/right" rather than closing all tabs, as is the default. E.g. `map cl
+  "close just 1 tab on the left/right" rather than closing all tabs, as is the default. E.g.
+  `map cl
   closeTabsOnLeft count=1`. ([#4296](https://github.com/philc/vimium/pull/4296))
 - Add search completions for Brave Search. ([#3851](https://github.com/philc/vimium/pull/3851))
 - Make regular expressions in find mode work again; other find mode improvements.
   ([#4261](https://github.com/philc/vimium/issues/4261))
 - Bug fixes. ([#3944](https://github.com/philc/vimium/pull/3944),
-[#3752](https://github.com/philc/vimium/pull/3752),
-[#3675](https://github.com/philc/vimium/pull/3675))
+  [#3752](https://github.com/philc/vimium/pull/3752),
+  [#3675](https://github.com/philc/vimium/pull/3675))
 
 1.67.7 (2023-07-12)
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ spirit of the Vim editor.
 
 **Installation instructions:**
 
-* Chrome: [Chrome web store](https://chrome.google.com/extensions/detail/dbepggeogbaibhgnhhndojpepiihcmeb)
-* Edge: [Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/vimium/djmieaghokpkpjfbpelnlkfgfjapaopa)
-* Firefox: [Firefox Add-ons](https://addons.mozilla.org/en-GB/firefox/addon/vimium-ff/)
+- Chrome:
+  [Chrome web store](https://chrome.google.com/extensions/detail/dbepggeogbaibhgnhhndojpepiihcmeb)
+- Edge:
+  [Edge Add-ons](https://microsoftedge.microsoft.com/addons/detail/vimium/djmieaghokpkpjfbpelnlkfgfjapaopa)
+- Firefox: [Firefox Add-ons](https://addons.mozilla.org/en-GB/firefox/addon/vimium-ff/)
 
 To install from source, see [here](CONTRIBUTING.md#installing-from-source).
 

--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -172,13 +172,12 @@ function moveTab({ count, tab, registryEntry }) {
   });
 }
 
-// TODO(philc): Rename to createRepeatCommand.
-const mkRepeatCommand = (command) => (function (request) {
+const createRepeatCommand = (command) => (function (request) {
   request.count--;
   if (request.count >= 0) {
     // TODO(philc): I think we can remove this return statement, and all returns
-    // from commands built using mkRepeatCommand.
-    return command(request, (request) => (mkRepeatCommand(command))(request));
+    // from commands built using createRepeatCommand.
+    return command(request, (request) => (createRepeatCommand(command))(request));
   }
 });
 
@@ -216,7 +215,7 @@ const BackgroundCommands = {
   // Create a new tab. Also, with:
   //     map X createTab http://www.bbc.com/news
   // create a new tab with the given URL.
-  createTab: mkRepeatCommand(async function (request, callback) {
+  createTab: createRepeatCommand(async function (request, callback) {
     if (request.urls == null) {
       if (request.url) {
         // If the request contains a URL, then use it.
@@ -273,7 +272,7 @@ const BackgroundCommands = {
     }
   }),
 
-  duplicateTab: mkRepeatCommand((request, callback) => {
+  duplicateTab: createRepeatCommand((request, callback) => {
     return chrome.tabs.duplicate(
       request.tabId,
       (tab) => callback(Object.assign(request, { tab, tabId: tab.id })),
@@ -311,7 +310,7 @@ const BackgroundCommands = {
       chrome.tabs.remove(tab.id);
     });
   },
-  restoreTab: mkRepeatCommand((request, callback) =>
+  restoreTab: createRepeatCommand((request, callback) =>
     chrome.sessions.restore(null, callback(request))
   ),
   async togglePinTab({ count, tab }) {
@@ -593,7 +592,7 @@ const sendRequestHandlers = {
   getCurrentTabUrl({ tab }) {
     return tab.url;
   },
-  openUrlInNewTab: mkRepeatCommand((request, callback) =>
+  openUrlInNewTab: createRepeatCommand((request, callback) =>
     TabOperations.openUrlInNewTab(request, callback)
   ),
   openUrlInNewWindow(request) {

--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -659,13 +659,13 @@ class LinkHintsMode {
       }
     }
 
-    const newMarkers = []
+    const newMarkers = [];
     for (let stack of stacks) {
       if (stack.length > 1) {
         // Push the last element to the beginning.
-        stack = stack.splice(-1, 1).concat(stack)
+        stack = stack.splice(-1, 1).concat(stack);
       }
-      newMarkers.push(...stack)
+      newMarkers.push(...stack);
     }
     this.hintMarkers = newMarkers;
     this.renderHints();

--- a/pages/vomnibar.js
+++ b/pages/vomnibar.js
@@ -467,7 +467,6 @@ document.addEventListener("DOMContentLoaded", async () => {
   DomUtils.injectUserCss(); // Manually inject custom user styles.
 });
 
-
 if (!window.location.search.includes("dom_tests=true")) {
   init();
 }

--- a/tests/unit_tests/completion_test.js
+++ b/tests/unit_tests/completion_test.js
@@ -322,7 +322,7 @@ context("domain completer (removing entries)", () => {
 });
 
 context("multi completer", () => {
-  const tabs = [{ url: "tab1.com", title: "tab1", id: 1 },];
+  const tabs = [{ url: "tab1.com", title: "tab1", id: 1 }];
   const tabCompleter = new TabCompleter();
   let multiCompleter;
 
@@ -335,7 +335,7 @@ context("multi completer", () => {
     // Even though a TabCompleter returns results when the query is empty, a MultiCompleter which
     // wraps a TabCompleter should not.
     assert.equal(1, (await filterCompleter(tabCompleter, [])).length);
-    assert.equal([], (await filterCompleter(multiCompleter, [])));
+    assert.equal([], await filterCompleter(multiCompleter, []));
   });
 });
 

--- a/tests/unit_tests/tab_recency_test.js
+++ b/tests/unit_tests/tab_recency_test.js
@@ -10,12 +10,12 @@ context("TabRecency", () => {
     setup(async () => {
       stub(chrome.tabs, "query", () => Promise.resolve([]));
       await tabRecency.init();
-      tabRecency.queueAction("register", (1));
-      tabRecency.queueAction("register", (2));
-      tabRecency.queueAction("register", (3));
-      tabRecency.queueAction("register", (4));
-      tabRecency.queueAction("deregister", (4));
-      tabRecency.queueAction("register", (2));
+      tabRecency.queueAction("register", 1);
+      tabRecency.queueAction("register", 2);
+      tabRecency.queueAction("register", 3);
+      tabRecency.queueAction("register", 4);
+      tabRecency.queueAction("deregister", 4);
+      tabRecency.queueAction("register", 2);
     });
 
     should("have the correct entries in the correct order", () => {
@@ -73,8 +73,8 @@ context("TabRecency", () => {
 
     assert.equal([2, 1], tabRecency.getTabsByRecency());
 
-    tabRecency.queueAction("register", (3));
-    tabRecency.queueAction("register", (1));
+    tabRecency.queueAction("register", 3);
+    tabRecency.queueAction("register", 1);
 
     assert.equal([1, 3, 2], tabRecency.getTabsByRecency());
   });


### PR DESCRIPTION
## Description

This PR pushes the `deno fmt` changes to all files to clean up the formatting, and will also cover fixing/removing small TODOs that have been hanging around the project. The changes are the same as from [this](https://github.com/philc/vimium/pull/4518) previous PR but do not include the hard reload DRY changes, as requested.