### PR TITLE
Command options (in help message)

### DIFF
--- a/background_scripts/commands.js
+++ b/background_scripts/commands.js
@@ -304,7 +304,6 @@ const Commands = {
       "scrollToLeft",
       "scrollToRight",
       "reload",
-      "hardReload",
       "copyCurrentUrl",
       "openCopiedUrlInCurrentTab",
       "openCopiedUrlInNewTab",
@@ -393,7 +392,6 @@ const Commands = {
     "enterVisualLineMode",
     "toggleViewSource",
     "passNextKey",
-    "hardReload",
     "setZoom",
     "zoomIn",
     "zoomOut",
@@ -416,7 +414,7 @@ const defaultKeyMappings = {
   "d": "scrollPageDown",
   "u": "scrollPageUp",
   "r": "reload",
-  "R": "hardReload",
+  "R": "reload hard",
   "yy": "copyCurrentUrl",
   "p": "openCopiedUrlInCurrentTab",
   "P": "openCopiedUrlInNewTab",
@@ -506,7 +504,6 @@ const commandDescriptions = {
   scrollFullPageUp: ["Scroll a full page up"],
 
   reload: ["Reload the page", { background: true }],
-  hardReload: ["Hard reload the page", { background: true }],
   toggleViewSource: ["View page source", { noRepeat: true }],
 
   copyCurrentUrl: ["Copy the current URL to the clipboard", { noRepeat: true }],

--- a/background_scripts/commands.js
+++ b/background_scripts/commands.js
@@ -280,7 +280,7 @@ const Commands = {
             command,
             description: this.availableCommands[command].description,
             keys: keys,
-            advanced: this.advancedCommands.includes(command),
+            advanced: this.advancedCommands.includes(command) || this.advancedCommands.includes(`${command} ${options}`),
             options: options,
           });
         }
@@ -398,6 +398,7 @@ const Commands = {
     "zoomIn",
     "zoomOut",
     "zoomReset",
+    "reload hard"
   ],
 };
 

--- a/background_scripts/commands.js
+++ b/background_scripts/commands.js
@@ -280,7 +280,8 @@ const Commands = {
             command,
             description: this.availableCommands[command].description,
             keys: keys,
-            advanced: this.advancedCommands.includes(command) || this.advancedCommands.includes(`${command} ${options}`),
+            advanced: this.advancedCommands.includes(command) ||
+              this.advancedCommands.includes(`${command} ${options}`),
             options: options,
           });
         }
@@ -398,7 +399,7 @@ const Commands = {
     "zoomIn",
     "zoomOut",
     "zoomReset",
-    "reload hard"
+    "reload hard",
   ],
 };
 

--- a/background_scripts/commands.js
+++ b/background_scripts/commands.js
@@ -260,9 +260,11 @@ const Commands = {
     const commandToKey = {};
     for (const key of Object.keys(this.keyToRegistryEntry || {})) {
       const registryEntry = this.keyToRegistryEntry[key];
-      const optionString = registryEntry.optionList?.length > 0 ? registryEntry.optionList?.join(" ") : '';
+      const optionString = registryEntry.optionList?.length > 0
+        ? registryEntry.optionList?.join(" ")
+        : "";
       if (commandToKey[registryEntry.command] == null) {
-        commandToKey[registryEntry.command] = {}
+        commandToKey[registryEntry.command] = {};
       }
       (commandToKey[registryEntry.command][optionString] != null
         ? commandToKey[registryEntry.command][optionString]
@@ -273,7 +275,7 @@ const Commands = {
       const commands = this.commandGroups[group];
       commandGroups[group] = [];
       for (const command of commands) {
-        for (const [options, keys] of Object.entries(commandToKey[command] ?? {'': []})) {
+        for (const [options, keys] of Object.entries(commandToKey[command] ?? { "": [] })) {
           commandGroups[group].push({
             command,
             description: this.availableCommands[command].description,

--- a/background_scripts/commands.js
+++ b/background_scripts/commands.js
@@ -563,8 +563,8 @@ const commandDescriptions = {
   moveTabRight: ["Move tab to the right", { background: true }],
 
   setZoom: ["Set zoom level to a given value. E.g. map zz setZoom 1.5", { background: true }],
-  zoomIn: ["Increase zoom", { background: true }],
-  zoomOut: ["Decrease zoom", { background: true }],
+  zoomIn: ["Zoom in", { background: true }],
+  zoomOut: ["Zoom out", { background: true }],
   zoomReset: ["Reset zoom", { background: true }],
 
   "Vomnibar.activate": ["Open URL, bookmark or history entry", { topFrame: true }],

--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -405,12 +405,6 @@ const BackgroundCommands = {
       chrome.tabs.reload(tab.id, { bypassCache });
     });
   },
-
-  async hardReload({ count, tab }) {
-    await forCountTabs(count, tab, (tab) => {
-      chrome.tabs.reload(tab.id, { bypassCache: true });
-    });
-  },
 };
 
 async function forCountTabs(count, currentTab, callback) {

--- a/pages/help_dialog.js
+++ b/pages/help_dialog.js
@@ -124,7 +124,15 @@ const HelpDialog = {
             });
           }
 
-          $$(descriptionElement, ".vimiumHelpDescription").textContent = command.description;
+          const MAX_OPTION_LENGTH = 30
+          const optionsTruncated = command.options.substring(0, MAX_OPTION_LENGTH);
+          let ellipis = '';
+          if (command.options.length > MAX_OPTION_LENGTH) {
+            ellipis = '...';
+            $$(descriptionElement, ".vimiumHelpDescription").title = command.options;
+          }
+          const optionsString = command.options ? ` (${optionsTruncated}${ellipis})` : '';
+          $$(descriptionElement, ".vimiumHelpDescription").textContent = `${command.description}${optionsString}`;
 
           keysElement = $$(keysElement, ".vimiumKeyBindings");
           let lastElement = null;

--- a/pages/help_dialog.js
+++ b/pages/help_dialog.js
@@ -125,14 +125,16 @@ const HelpDialog = {
           }
 
           const MAX_LENGTH = 50;
+          // - 3 because 3 is the length of the ellipsis string, "..."
           const desiredOptionsLength = Math.max(0, MAX_LENGTH - command.description.length - 3);
-          const optionsTruncated = command.options.substring(0, desiredOptionsLength);
-          let ellipis = "";
+          // If command + options is too long: truncate, add ellipsis, and set hover.
+          let optionsTruncated = command.options.substring(0, desiredOptionsLength);
           if ((command.description.length + command.options.length) > MAX_LENGTH) {
-            ellipis = "...";
+            optionsTruncated += "...";
+            // Full option list (non-ellipsized) will be visible on hover.
             $$(descriptionElement, ".vimiumHelpDescription").title = command.options;
           }
-          const optionsString = command.options ? ` (${optionsTruncated}${ellipis})` : "";
+          const optionsString = command.options ? ` (${optionsTruncated})` : "";
           const fullDescription = `${command.description}${optionsString}`;
           $$(descriptionElement, ".vimiumHelpDescription").textContent = fullDescription;
 

--- a/pages/help_dialog.js
+++ b/pages/help_dialog.js
@@ -124,15 +124,17 @@ const HelpDialog = {
             });
           }
 
-          const MAX_OPTION_LENGTH = 30
-          const optionsTruncated = command.options.substring(0, MAX_OPTION_LENGTH);
-          let ellipis = '';
-          if (command.options.length > MAX_OPTION_LENGTH) {
-            ellipis = '...';
+          const MAX_LENGTH = 50;
+          const desiredOptionsLength = Math.max(0, MAX_LENGTH - command.description.length - 3);
+          const optionsTruncated = command.options.substring(0, desiredOptionsLength);
+          let ellipis = "";
+          if ((command.description.length + command.options.length) > MAX_LENGTH) {
+            ellipis = "...";
             $$(descriptionElement, ".vimiumHelpDescription").title = command.options;
           }
-          const optionsString = command.options ? ` (${optionsTruncated}${ellipis})` : '';
-          $$(descriptionElement, ".vimiumHelpDescription").textContent = `${command.description}${optionsString}`;
+          const optionsString = command.options ? ` (${optionsTruncated}${ellipis})` : "";
+          const fullDescription = `${command.description}${optionsString}`;
+          $$(descriptionElement, ".vimiumHelpDescription").textContent = fullDescription;
 
           keysElement = $$(keysElement, ".vimiumKeyBindings");
           let lastElement = null;


### PR DESCRIPTION
## Description

Show command options in the help message dialogue as specified in [this comment](https://github.com/philc/vimium/pull/4518#issuecomment-2268204745) and the associated PR discussion.

Handles truncating based on the full length of the line, not just the length of the options, and shows the full options on hover.

![image](https://github.com/user-attachments/assets/95116841-2d73-486e-848a-7803fadbd67a)

Always indicates the presence of options even on lines with very long descriptions.

![image](https://github.com/user-attachments/assets/141aa5c5-d03b-47f9-afaf-90d9913ffda8)

Correctly handles flags (without showing them as flag=true)

![image](https://github.com/user-attachments/assets/51821101-6fb3-4592-adc6-63203b7c767a)

Handles commands with multiple options.

![image](https://github.com/user-attachments/assets/80677521-6464-43dd-b501-66ae44cbb151)

This PR also switches the new `hardReload` for the old `reload hard` to avoid repeated code/functionality.

## Implementation

There could be cleaner implementations, so let me know if you have a better idea, but I believe I have found a good method that requires minimal changes and fits very well into the existing mechanism. I will describe the implementation and logic more in comments on the code.

I have formatted all new code (see #4553 for the other changes from `deno fmt`) and all tests pass.