### PR TITLE
Fix broken link in contributing document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ Here's the rationale behind this policy:
 - Adding a new feature is only part of the work. Once it's added, a feature must be maintained
   forever.
 - Vimium is a project which suffers from the
-  [stadium model of open source](https://645ventures.com/voices/articles/github-at-scale-and-how-to-help-stadium-model-maintainers):
+  [stadium model of open source](https://645ventures.com/homepage-databases/github-at-scale-and-how-to-help-stadium-model-maintainers):
   there are many users but unfortunately few maintainers. As a result, there is bandwidth to
   maintain only a limited number of features in the main repo.
 


### PR DESCRIPTION
## Description

The [current link](https://645ventures.com/voices/articles/github-at-scale-and-how-to-help-stadium-model-maintainers) doesn't lead to the desired page:
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/f0d7c5ae-f71b-486a-8af8-93fc053686f4">

This PR fixes it.

A more systematic fix might be to use some kind of a broken link finder, perhaps in a cron-triggered GitHub workflow (e.g. [this](https://github.com/lycheeverse/lychee) — note that I haven't tried this one).