### PR TITLE
Fix clickable elements with class 'btn'

### DIFF
--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -1,3 +1,18 @@
+//
+// This implements link hinting. Typing "F" will enter link-hinting mode, where all clickable items
+// on the page have a hint marker displayed containing a sequence of letters. Typing those letters
+// will select a link.
+//
+// In our 'default' mode, the characters we use to show link hints are a user-configurable option.
+// By default they're the home row. The CSS which is used on the link hints is also a configurable
+// option.
+//
+// In 'filter' mode, our link hints are numbers, and the user can narrow down the range of
+// possibilities by typing the text of the link itself.
+//
+
+// A DOM element that sits on top of a link, showing the key the user should type to select the
+// link.
 class HintMarker {
   hintDescriptor;
   localHint;

--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -1,18 +1,3 @@
-//
-// This implements link hinting. Typing "F" will enter link-hinting mode, where all clickable items
-// on the page have a hint marker displayed containing a sequence of letters. Typing those letters
-// will select a link.
-//
-// In our 'default' mode, the characters we use to show link hints are a user-configurable option.
-// By default they're the home row. The CSS which is used on the link hints is also a configurable
-// option.
-//
-// In 'filter' mode, our link hints are numbers, and the user can narrow down the range of
-// possibilities by typing the text of the link itself.
-//
-
-// A DOM element that sits on top of a link, showing the key the user should type to select the
-// link.
 class HintMarker {
   hintDescriptor;
   localHint;
@@ -1220,6 +1205,12 @@ const LocalHints = {
     if (!isClickable && !(tabIndex < 0) && !isNaN(tabIndex)) {
       isClickable = true;
       onlyHasTabIndex = true;
+    }
+
+    // Check for elements with class 'btn'
+    if (!isClickable && className?.toLowerCase().includes("btn")) {
+      isClickable = true;
+      possibleFalsePositive = true;
     }
 
     if (isClickable) {

--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -1,3 +1,18 @@
+//
+// This implements link hinting. Typing "F" will enter link-hinting mode, where all clickable items
+// on the page have a hint marker displayed containing a sequence of letters. Typing those letters
+// will select a link.
+//
+// In our 'default' mode, the characters we use to show link hints are a user-configurable option.
+// By default they're the home row. The CSS which is used on the link hints is also a configurable
+// option.
+//
+// In 'filter' mode, our link hints are numbers, and the user can narrow down the range of
+// possibilities by typing the text of the link itself.
+//
+
+// A DOM element that sits on top of a link, showing the key the user should type to select the
+// link.
 class HintMarker {
   hintDescriptor;
   localHint;
@@ -1189,11 +1204,16 @@ const LocalHints = {
     // # Detect elements with "click" listeners installed with `addEventListener()`.
     // isClickable ||= element.hasAttribute "_vimium-has-onclick-listener"
 
-    // An element with a class name containing the text "button" might be clickable. However, real
+    // An element with a class name containing the text "button" or "btn" might be clickable. However, real
     // clickables are often wrapped in elements with such class names. So, when we find clickables
     // based only on their class name, we mark them as unreliable.
     const className = element.getAttribute("class");
     if (!isClickable && className?.toLowerCase().includes("button")) {
+      isClickable = true;
+      possibleFalsePositive = true;
+    }
+
+    if (!isClickable && className?.toLowerCase().includes("btn")) {
       isClickable = true;
       possibleFalsePositive = true;
     }
@@ -1205,12 +1225,6 @@ const LocalHints = {
     if (!isClickable && !(tabIndex < 0) && !isNaN(tabIndex)) {
       isClickable = true;
       onlyHasTabIndex = true;
-    }
-
-    // Check for elements with class 'btn'
-    if (!isClickable && className?.toLowerCase().includes("btn")) {
-      isClickable = true;
-      possibleFalsePositive = true;
     }
 
     if (isClickable) {

--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -1,18 +1,3 @@
-//
-// This implements link hinting. Typing "F" will enter link-hinting mode, where all clickable items
-// on the page have a hint marker displayed containing a sequence of letters. Typing those letters
-// will select a link.
-//
-// In our 'default' mode, the characters we use to show link hints are a user-configurable option.
-// By default they're the home row. The CSS which is used on the link hints is also a configurable
-// option.
-//
-// In 'filter' mode, our link hints are numbers, and the user can narrow down the range of
-// possibilities by typing the text of the link itself.
-//
-
-// A DOM element that sits on top of a link, showing the key the user should type to select the
-// link.
 class HintMarker {
   hintDescriptor;
   localHint;
@@ -1208,12 +1193,7 @@ const LocalHints = {
     // clickables are often wrapped in elements with such class names. So, when we find clickables
     // based only on their class name, we mark them as unreliable.
     const className = element.getAttribute("class");
-    if (!isClickable && className?.toLowerCase().includes("button")) {
-      isClickable = true;
-      possibleFalsePositive = true;
-    }
-
-    if (!isClickable && className?.toLowerCase().includes("btn")) {
+    if (!isClickable && (className?.toLowerCase().includes("button") || className?.toLowerCase().includes("btn"))) {
       isClickable = true;
       possibleFalsePositive = true;
     }

--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -1207,8 +1207,8 @@ const LocalHints = {
     // An element with a class name containing the text "button" or "btn" might be clickable. However, real
     // clickables are often wrapped in elements with such class names. So, when we find clickables
     // based only on their class name, we mark them as unreliable.
-    const className = element.getAttribute("class");
-    if (!isClickable && (className?.toLowerCase().includes("button") || className?.toLowerCase().includes("btn"))) {
+    const className = element.getAttribute("class")?.toLowerCase()
+    if (!isClickable && (className?.includes("button") || className?.includes("btn"))) {
       isClickable = true;
       possibleFalsePositive = true;
     }


### PR DESCRIPTION
Fixes #3550

Update `content_scripts/link_hints.js` to make elements with class 'btn' clickable.

* Add logic to `getLocalHintsForElement` to check for class 'btn' and mark elements as clickable.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/philc/vimium/issues/3550?shareId=c288d7af-145c-4168-b305-1f3dbc8f7f3b).