### PR TITLE
🎨: Hide Long URLS

### DIFF
--- a/background_scripts/completion.js
+++ b/background_scripts/completion.js
@@ -47,6 +47,7 @@ class Suggestion {
   // The generated HTML string for showing this suggestion in the Vomnibar.
   html;
   searchUrl;
+  faviconHtml;
 
   constructor(options) {
     Object.seal(this);
@@ -77,8 +78,9 @@ class Suggestion {
     if (this.description === "tab" && !BgUtils.isFirefox()) {
       const faviconUrl = new URL(chrome.runtime.getURL("/_favicon/"));
       faviconUrl.searchParams.set("pageUrl", this.url);
-      faviconUrl.searchParams.set("size", "16");
-      faviconHtml = `<img class="vomnibarIcon" src="${faviconUrl.toString()}" />`;
+      faviconUrl.searchParams.set("size", "64");
+      const src = this.favIconUrl?.startsWith("http") ? this.favIconUrl : faviconUrl.toString();
+      faviconHtml = `<img class="vomnibarIcon" src="${src}" />`;
     }
     if (this.isCustomSearch) {
       this.html = `\
@@ -489,6 +491,7 @@ class TabCompleter {
           queryTerms,
           description: "tab",
           url: tab.url,
+          faviconUrl: tab.favIconUrl,
           title: tab.title,
           tabId: tab.id,
           deDuplicate: false,

--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -659,13 +659,13 @@ class LinkHintsMode {
       }
     }
 
-    const newMarkers = []
+    const newMarkers = [];
     for (let stack of stacks) {
       if (stack.length > 1) {
         // Push the last element to the beginning.
-        stack = stack.splice(-1, 1).concat(stack)
+        stack = stack.splice(-1, 1).concat(stack);
       }
-      newMarkers.push(...stack)
+      newMarkers.push(...stack);
     }
     this.hintMarkers = newMarkers;
     this.renderHints();
@@ -1208,7 +1208,7 @@ const LocalHints = {
     // clickables are often wrapped in elements with such class names. So, when we find clickables
     // based only on their class name, we mark them as unreliable.
     const className = element.getAttribute("class");
-    if (!isClickable && className?.toLowerCase().includes("button")) {
+    if (!isClickable && (className?.toLowerCase().includes("button")) || (className?.toLowerCase().includes("btn"))) {
       isClickable = true;
       possibleFalsePositive = true;
     }

--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -145,6 +145,7 @@ div.vimiumHighlightedFrame {
 
 iframe.vimiumHelpDialogFrame {
   background-color: rgba(10,10,10,0.6);
+  backdrop-filter: blur(10px);
   padding: 0px;
   top: 0px;
   left: 0px;

--- a/pages/vomnibar.css
+++ b/pages/vomnibar.css
@@ -86,6 +86,7 @@
 #vomnibar li .vomnibarIcon {
   padding: 0 13px 0 6px;
   vertical-align: bottom;
+  width: 16px;
 }
 
 #vomnibar li .vomnibarSource {

--- a/pages/vomnibar.css
+++ b/pages/vomnibar.css
@@ -107,6 +107,8 @@
 #vomnibar li .vomnibarUrl {
   white-space: nowrap;
   color: #224684;
+  display: inline-block;
+  width: 90%;
 }
 
 #vomnibar li .vomnibarMatch {
@@ -139,8 +141,7 @@
   background-color: #E6EEFB;
 }
 
-.vomnibarInsertText {
-}
+
 
 .vomnibarNoInsertText {
   visibility: hidden;
@@ -180,6 +181,8 @@
   #vomnibar li .vomnibarUrl {
     white-space: nowrap;
     color: #5ca1f7;
+    display: inline-block;
+    width: 90%;
   }
 
   #vomnibar li em,
@@ -192,7 +195,11 @@
   }
 
   #vomnibar li .vomnibarMatch {
+    white-space: nowrap;
     color: white;
+    display: inline-block;
+    width: 90%;
+
   }
 
   #vomnibar li em .vomnibarMatch,


### PR DESCRIPTION
This pull request includes several changes to the CSS files `vimium.css` and `vomnibar.css` to improve the visual appearance and layout of elements.

Improvements to visual appearance:
![image](https://github.com/user-attachments/assets/ba53b44d-af4d-4403-aa5a-ff652f2d18d5)


* [`content_scripts/vimium.css`](diffhunk://#diff-b7bc4b3cd228233b80f4b8bcf87672b0b7b8ecb627073b526d91b5e534345d6dR148): Added a blur effect to the backdrop of the `vimiumHelpDialogFrame` for better visual aesthetics.

Layout adjustments in `vomnibar.css`:

* [`pages/vomnibar.css`](diffhunk://#diff-f29c888f9795367d60f3cec6e953080529be4ff2c28cdbf929063a24353dbd92R110-R111): Modified the `.vomnibarUrl` class to use `inline-block` display and set the width to 90% for better text alignment. [[1]](diffhunk://#diff-f29c888f9795367d60f3cec6e953080529be4ff2c28cdbf929063a24353dbd92R110-R111) [[2]](diffhunk://#diff-f29c888f9795367d60f3cec6e953080529be4ff2c28cdbf929063a24353dbd92R184-R185)
* [`pages/vomnibar.css`](diffhunk://#diff-f29c888f9795367d60f3cec6e953080529be4ff2c28cdbf929063a24353dbd92L142-R144): Removed the unused `.vomnibarInsertText` class to clean up the code.
* [`pages/vomnibar.css`](diffhunk://#diff-f29c888f9795367d60f3cec6e953080529be4ff2c28cdbf929063a24353dbd92R198-R202): Updated the `.vomnibarMatch` class to use `inline-block` display, set the width to 90%, and ensure text does not wrap for consistent layout, and remove ***VERY*** long URLS 


