### PR TITLE
allow extension to run on chrome://pages

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
     "browser_style": false,
     "open_in_tab": true
   },
-  "host_permissions": ["<all_urls>"],
+  "host_permissions": ["chrome://*/*","<all_urls>"],
   "permissions": [
     "tabs",
     "bookmarks",
@@ -35,7 +35,7 @@
   ],
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": ["chrome://*/*","<all_urls>"],
       "js": [
         "lib/utils.js",
         "lib/keyboard_utils.js",


### PR DESCRIPTION
## Description
its very annoying when I am on a home tab and cannot user vim binding so this pr adds permission to allow chrome to run extension on chrome:// pages https://github.com/philc/vimium/issues/3333

you will need to enable extension chrome://flags/#extensions-on-chrome-urls 