### PR TITLE
Support query keyword in activateBookmark.

### DIFF
--- a/content_scripts/vomnibar.js
+++ b/content_scripts/vomnibar.js
@@ -24,19 +24,23 @@ const Vomnibar = {
     });
   },
 
-  activateBookmarks(sourceFrameId) {
-    this.open(sourceFrameId, {
-      completer: "bookmarks",
-      selectFirst: true,
-    });
+  activateBookmarks(sourceFrameId, registryEntry) {
+    let options = Object.assign({}, registryEntry.options,
+      {
+        completer: "bookmarks",
+        selectFirst: true,
+      });
+    this.open(sourceFrameId, options);
   },
 
-  activateBookmarksInNewTab(sourceFrameId) {
-    this.open(sourceFrameId, {
-      completer: "bookmarks",
-      selectFirst: true,
-      newTab: true,
-    });
+  activateBookmarksInNewTab(sourceFrameId, registryEntry) {
+    let options = Object.assign({}, registryEntry.options,
+      {
+        completer: "bookmarks",
+        selectFirst: true,
+        newTab: true,
+      });
+    this.open(sourceFrameId, options);
   },
 
   activateEditUrl(sourceFrameId) {


### PR DESCRIPTION
## Description

I would like to create a shortcut that lets me browse a specific folder in my bookmarks. To do this I would like to prefill a query into the `Vomnibar.activateBookmark` command.

What I want is to have:
```
map wtf Vomnibar.activateBookmarks query=/links
```
To allow me to browse the links folder of my bookmarks.

It turns out that those options already get parsed into the keyregistry, and the activate command already accepts these options, so the only thing to needed would be to add this extra argument to the content script (similarly to the `Vomnibar.activate` above) as is done in the PR.
