### PR TITLE
Fix LocalHints.getElementFromPoint for shadow roots containing only text

### DIFF
--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -1273,7 +1273,8 @@ const LocalHints = {
     stack.push(element);
 
     if (element && element.shadowRoot) {
-      return LocalHints.getElementFromPoint(x, y, element.shadowRoot, stack);
+      // a shadow root can contain a text node with no further elements
+      return LocalHints.getElementFromPoint(x, y, element.shadowRoot, stack) || element;
     }
 
     return element;


### PR DESCRIPTION
## Description

`LocalHints.getElementFromPoint` could return nothing if it's called on a shadow root element which only contains some text (no additional tags), since `elementsFromPoint` can return an empty array if there's no element (e.g. only a text node) to return. This causes a problem where the link-hint for a clickable element containing such a shadow root could be mistakenly hidden.

In this case, we can't produce an element to represent the content of the shadow root (because it contains no elements!), so we should just return the shadow root itself.

Should fix #4620.