### PR TITLE
refactor: remove Selection.type polyfill

### DIFF
--- a/content_scripts/mode_find.js
+++ b/content_scripts/mode_find.js
@@ -396,13 +396,13 @@ FindMode.restoreDefaultSelectionHighlight = forTrusted(() =>
 
 const getCurrentRange = function () {
   const selection = getSelection();
-  if (DomUtils.getSelectionType(selection) === "None") {
+  if (selection.type === "None") {
     const range = document.createRange();
     range.setStart(document.body, 0);
     range.setEnd(document.body, 0);
     return range;
   } else {
-    if (DomUtils.getSelectionType(selection) === "Range") {
+    if (selection.type === "Range") {
       selection.collapseToStart();
     }
     return selection.getRangeAt(0);

--- a/content_scripts/mode_find.js
+++ b/content_scripts/mode_find.js
@@ -8,7 +8,7 @@ class SuppressPrintable extends Mode {
     super.init(options);
     const handler = (event) =>
       KeyboardUtils.isPrintable(event) ? this.suppressEvent : this.continueBubbling;
-    const type = DomUtils.getSelectionType();
+    const initialType = globalThis.getSelection().type;
 
     // We use unshift here, so we see events after normal mode, so we only see unmapped keys.
     this.unshift({
@@ -19,7 +19,7 @@ class SuppressPrintable extends Mode {
         // If the selection type has changed (usually, no longer "Range"), then the user is
         // interacting with the input element, so we get out of the way. See discussion of option 5c
         // from #1415.
-        if (DomUtils.getSelectionType() !== type) {
+        if (globalThis.getSelection().type !== initialType) {
           return this.exit();
         }
       },
@@ -401,12 +401,13 @@ const getCurrentRange = function () {
     range.setStart(document.body, 0);
     range.setEnd(document.body, 0);
     return range;
-  } else {
-    if (selection.type === "Range") {
-      selection.collapseToStart();
-    }
-    return selection.getRangeAt(0);
+  } 
+
+  if (selection.type === "Range") {
+    selection.collapseToStart();
   }
+
+  return selection.getRangeAt(0);
 };
 
 const getLinkFromSelection = function () {

--- a/content_scripts/mode_visual.js
+++ b/content_scripts/mode_visual.js
@@ -199,7 +199,7 @@ class Movement {
 
   // Scroll the focus into view.
   scrollIntoView() {
-    if (DomUtils.getSelectionType(this.selection) !== "None") {
+    if (this.selection.type !== "None") {
       const elementWithFocus = DomUtils.getElementWithFocus(
         this.selection,
         this.getDirection() === backward,
@@ -266,7 +266,7 @@ class VisualMode extends KeyHandlerMode {
     // If there was a range selection when the user lanuched visual mode, then we retain the
     // selection on exit.
     this.shouldRetainSelectionOnExit = this.options.userLaunchedMode &&
-      (DomUtils.getSelectionType(this.selection) === "Range");
+      (this.selection.type === "Range");
 
     this.onExit((event = null) => {
       // Retain any selection, regardless of how we exit.
@@ -313,7 +313,7 @@ class VisualMode extends KeyHandlerMode {
 
     // Establish or use the initial selection. If that's not possible, then enter caret mode.
     if (this.name !== "caret") {
-      if (["Caret", "Range"].includes(DomUtils.getSelectionType(this.selection))) {
+      if (["Caret", "Range"].includes(this.selection.type)) {
         let selectionRect = this.selection.getRangeAt(0).getBoundingClientRect();
         if (globalThis.vimiumDomTestsAreRunning) {
           // We're running the DOM tests, where getBoundingClientRect() isn't available.
@@ -327,7 +327,7 @@ class VisualMode extends KeyHandlerMode {
         );
         if ((selectionRect.height >= 0) && (selectionRect.width >= 0)) {
           // The selection is visible in the current viewport.
-          if (DomUtils.getSelectionType(this.selection) === "Caret") {
+          if (this.selection.type === "Caret") {
             // The caret is in the viewport. Make make it visible.
             this.movement.extendByOneCharacter(forward) ||
               this.movement.extendByOneCharacter(backward);
@@ -339,7 +339,7 @@ class VisualMode extends KeyHandlerMode {
         }
       }
 
-      if ((DomUtils.getSelectionType(this.selection) !== "Range") && (this.name !== "caret")) {
+      if ((this.selection.type !== "Range") && (this.name !== "caret")) {
         new CaretMode().init();
         return HUD.show("No usable selection, entering caret mode...", 2500);
       }
@@ -541,10 +541,10 @@ class CaretMode extends VisualMode {
     );
 
     // Establish the initial caret.
-    switch (DomUtils.getSelectionType(this.selection)) {
+    switch (this.selection.type) {
       case "None":
         this.establishInitialSelectionAnchor();
-        if (DomUtils.getSelectionType(this.selection) === "None") {
+        if (this.selection.type === "None") {
           this.exit();
           HUD.show("Create a selection before entering visual mode.", 2500);
           return;

--- a/lib/dom_utils.js
+++ b/lib/dom_utils.js
@@ -322,15 +322,15 @@ const DomUtils = {
     if (element.isContentEditable) {
       const node = selection.anchorNode;
       return node && this.isDOMDescendant(element, node);
+    } 
+
+    if ((selection.type === "Range") && selection.isCollapsed) {
+      // The selection is inside the Shadow DOM of a node. We can check the node it registers as
+      // being before, since this represents the node whose Shadow DOM it's inside.
+      const containerNode = selection.anchorNode.childNodes[selection.anchorOffset];
+      return element === containerNode; // True if the selection is inside the Shadow DOM of our element.
     } else {
-      if ((selection.type === "Range") && selection.isCollapsed) {
-        // The selection is inside the Shadow DOM of a node. We can check the node it registers as
-        // being before, since this represents the node whose Shadow DOM it's inside.
-        const containerNode = selection.anchorNode.childNodes[selection.anchorOffset];
-        return element === containerNode; // True if the selection is inside the Shadow DOM of our element.
-      } else {
-        return false;
-      }
+      return false;
     }
   },
 

--- a/lib/dom_utils.js
+++ b/lib/dom_utils.js
@@ -323,7 +323,7 @@ const DomUtils = {
       const node = selection.anchorNode;
       return node && this.isDOMDescendant(element, node);
     } else {
-      if ((DomUtils.getSelectionType(selection) === "Range") && selection.isCollapsed) {
+      if ((selection.type === "Range") && selection.isCollapsed) {
         // The selection is inside the Shadow DOM of a node. We can check the node it registers as
         // being before, since this represents the node whose Shadow DOM it's inside.
         const containerNode = selection.anchorNode.childNodes[selection.anchorOffset];
@@ -538,26 +538,12 @@ const DomUtils = {
     };
   })(),
 
-  // Polyfill for selection.type (which is not available in Firefox).
-  getSelectionType(selection) {
-    if (selection == null) selection = document.getSelection();
-    if (selection.type) {
-      return selection.type;
-    } else if (selection.rangeCount === 0) {
-      return "None";
-    } else if (selection.isCollapsed) {
-      return "Caret";
-    } else {
-      return "Range";
-    }
-  },
-
   // Adapted from: http://roysharon.com/blog/37.
   // This finds the element containing the selection focus.
   getElementWithFocus(selection, backwards) {
     let t;
     let r = (t = selection.getRangeAt(0));
-    if (DomUtils.getSelectionType(selection) === "Range") {
+    if (selection.type === "Range") {
       r = t.cloneRange();
       r.collapse(backwards);
     }

--- a/lib/dom_utils.js
+++ b/lib/dom_utils.js
@@ -329,9 +329,9 @@ const DomUtils = {
       // being before, since this represents the node whose Shadow DOM it's inside.
       const containerNode = selection.anchorNode.childNodes[selection.anchorOffset];
       return element === containerNode; // True if the selection is inside the Shadow DOM of our element.
-    } else {
-      return false;
     }
+
+    return false;
   },
 
   simulateSelect(element) {


### PR DESCRIPTION
## Description

This potentially closes #4626, which aims to reduce some code that can be replaced by simply using `selection.type`.
