### PR TITLE
fixes #4629 SyntaxError in Selection.modify

### DIFF
--- a/content_scripts/mode_visual.js
+++ b/content_scripts/mode_visual.js
@@ -62,35 +62,43 @@ class Movement {
     // Native word movements behave differently on Linux and Windows, see #1441. So we implement
     // some of them character-by-character.
     if ((granularity === vimword) && (direction === forward)) {
+      // extent selection to the end of the 'vimword'
       while (this.nextCharacterIsWordCharacter()) {
         if (this.extendByOneCharacter(forward) === 0) {
           return;
         }
       }
+      // extend selection after the 'vimword' to position before next word
       while (this.getNextForwardCharacter() && !this.nextCharacterIsWordCharacter()) {
         if (this.extendByOneCharacter(forward) === 0) {
           return;
         }
       }
+      return;
     } else if (granularity === vimword) {
       this.selection.modify(this.alterMethod, backward, word);
+      return;
     }
 
     // As above, we implement this character-by-character to get consistent behavior on Windows and
     // Linux.
     if ((granularity === word) && (direction === forward)) {
+      // extent selection to the start of the next 'word' (non-word characters, e.g. whitespace)
       while (this.getNextForwardCharacter() && !this.nextCharacterIsWordCharacter()) {
         if (this.extendByOneCharacter(forward) === 0) {
           return;
         }
       }
+      // extend selection to the end of the 'word'
       while (this.nextCharacterIsWordCharacter()) {
         if (this.extendByOneCharacter(forward) === 0) {
           return;
         }
       }
+      return;
     } else {
-      return this.selection.modify(this.alterMethod, direction, granularity);
+      this.selection.modify(this.alterMethod, direction, granularity);
+      return;
     }
   }
 


### PR DESCRIPTION
- fixes #4629  SyntaxError on Selection.modify() due to invalid granularity parameter 'vimword' due to missing return statements

## Bug analysis:

- just for reference - valid parameters for `Selection.modify()`:
  - https://developer.mozilla.org/en-US/docs/Web/API/Selection/modify#granularity
  - side note: Firefox supports fewer options than Chromium, but it doesn't matter in this case
  - side note: Chromium will never throw a `SyntaxError` and instead will fail / return silently when an invalid `granularity` is given
- Vimium differentiates `word` and `vimword`
  - `forward word` is triggered with `e` to **jump forward** to the **end of a word**
  - `backward word` is triggered by `b` to **jump back** to the **start of a word**
  - `forward vimword` is triggered with `w` to jump forward right before the **start of the next word** (therefore including non-word characters after the original word's end)
  - I think there's **no way to trigger `backward vimword`**, but there is a code section that handles that case (and does the same as `backward word`)
- missing `return` statements in several places in `content_scripts/mode_visual.js` in function `Movement.runMovement` lead to the `SyntaxError`
  - the section handling `vimword` functionality runs properly
    - `forward vimword` advances char-by-char and thus doesn't rely on `modify`'s `granularity` parameter
    - `backward vimword` has no binding, but would work fine, since it replaces the `granularity` value by `word` when handing it over as a parameter to `Selection.modify()`
    - neither of those code sections have `return` statements after their work is done
    - this leads to the `else` section at the very end being called for the `vimword` cases which have already been handled

## Implementation notes

- I've added `return` statements to the `vimword` code sections
- I've also added `return` statements to the remaining `if else` blocks to avoid this problem in case the function gets extended in the future
- I've added some short comments to highlight the differences in the two code blocks for `vimword` and `word` since they look confusingly similar at the first glance
- optionally we could completely get rid of the `else` sections and have the code as consecutive `if() { doSomething(); return; }` blocks, since each block is meant to `return` when done
- in one of the cases the existing code returned the result of `.modify()` despite the function not having a return type, so I moved the `return` to a separate line instead
