### PR TITLE
macOptionFix: Added support for Mac OS Option + Key presses (Fixes #3197, #3666, #3662, #3284)

### DIFF
--- a/lib/keyboard_utils.js
+++ b/lib/keyboard_utils.js
@@ -36,11 +36,8 @@ const KeyboardUtils = {
   getKeyChar(event) {
     let key;
     if (
-      (!Settings.get("ignoreKeyboardLayout") && this.platform !== "Mac") ||
-      (!Settings.get("ignoreKeyboardLayout") &&
-        (this.platform === "Mac" && !Settings.get("macOptionKeyFix"))) ||
-      (!Settings.get("ignoreKeyboardLayout") &&
-        (this.platform === "Mac" && Settings.get("macOptionKeyFix") && !event.altKey))
+      !Settings.get("ignoreKeyboardLayout") &&
+      !(this.platform === "Mac" && Settings.get("macOptionKeyFix") && event.altKey)
     ) {
       key = event.key;
     } else if (!event.code) {

--- a/lib/keyboard_utils.js
+++ b/lib/keyboard_utils.js
@@ -36,9 +36,11 @@ const KeyboardUtils = {
   getKeyChar(event) {
     let key;
     if (
-      !Settings.get("ignoreKeyboardLayout") && !Settings.get("macOptionKeyFix") ||
-      !Settings.get("ignoreKeyboardLayout") &&
-        (this.platform === "Mac" && Settings.get("macOptionKeyFix") && !event.altKey)
+      (!Settings.get("ignoreKeyboardLayout") && this.platform !== "Mac") ||
+      (!Settings.get("ignoreKeyboardLayout") &&
+        (this.platform === "Mac" && !Settings.get("macOptionKeyFix"))) ||
+      (!Settings.get("ignoreKeyboardLayout") &&
+        (this.platform === "Mac" && Settings.get("macOptionKeyFix") && !event.altKey))
     ) {
       key = event.key;
     } else if (!event.code) {

--- a/lib/keyboard_utils.js
+++ b/lib/keyboard_utils.js
@@ -31,10 +31,83 @@ const KeyboardUtils = {
     }
   },
 
+  // Adds support for Mac Option + Keypress. See #3197.
+  // (Vimium will ignore the symbols and treat them
+  // like letters, at least on a US Laptop keyboard).
+  // I only have a laptop with a US keyboard so I can only get the keypresses that are
+  // available to me, and this list can likely be expanded. I have no idea if Option +
+  // key in different regions produces different symbols or not.
+  //
+  // I suppose another way of handling this would be to simply treat any Option + (Shift? +)
+  // key press as if "Ignore Keyboard Layout" and only use the event.code value for those
+  // presses. If you'd rather implement it that way be my guest, I leave it up to you to
+  // decide which approach is better/more efficient.
+  macOptionSymbolMap: {
+    "Backquote": { unshifted: { symbol: "Dead", key: "`" }, shifted: { symbol: "`", key: "~" } },
+    "Digit1": { unshifted: { symbol: "¡", key: "1" }, shifted: { symbol: "⁄", key: "!" } },
+    "Digit2": { unshifted: { symbol: "™", key: "2" }, shifted: { symbol: "€", key: "@" } },
+    "Digit3": { unshifted: { symbol: "£", key: "3" }, shifted: { symbol: "‹", key: "#" } },
+    "Digit4": { unshifted: { symbol: "¢", key: "4" }, shifted: { symbol: "›", key: "$" } },
+    "Digit5": { unshifted: { symbol: "∞", key: "5" }, shifted: { symbol: "ﬁ", key: "%" } },
+    "Digit6": { unshifted: { symbol: "§", key: "6" }, shifted: { symbol: "ﬂ", key: "^" } },
+    "Digit7": { unshifted: { symbol: "¶", key: "7" }, shifted: { symbol: "‡", key: "&" } },
+    "Digit8": { unshifted: { symbol: "•", key: "8" }, shifted: { symbol: "°", key: "*" } },
+    "Digit9": { unshifted: { symbol: "ª", key: "9" }, shifted: { symbol: "·", key: "(" } },
+    "Digit0": { unshifted: { symbol: "º", key: "0" }, shifted: { symbol: "‚", key: ")" } },
+    "Minus": { unshifted: { symbol: "–", key: "-" }, shifted: { symbol: "—", key: "_" } },
+    "Equal": { unshifted: { symbol: "≠", key: "=" }, shifted: { symbol: "±", key: "+" } },
+    "KeyQ": { unshifted: { symbol: "œ", key: "q" }, shifted: { symbol: "Œ", key: "Q" } },
+    "KeyW": { unshifted: { symbol: "∑", key: "w" }, shifted: { symbol: "„", key: "W" } },
+    "KeyE": { unshifted: { symbol: "Dead", key: "e" }, shifted: { symbol: "´", key: "E" } },
+    "KeyR": { unshifted: { symbol: "®", key: "r" }, shifted: { symbol: "‰", key: "R" } },
+    "KeyT": { unshifted: { symbol: "†", key: "t" }, shifted: { symbol: "ˇ", key: "T" } },
+    "KeyY": { unshifted: { symbol: "¥", key: "y" }, shifted: { symbol: "Á", key: "Y" } },
+    "KeyU": { unshifted: { symbol: "Dead", key: "u" }, shifted: { symbol: "¨", key: "U" } },
+    "KeyI": { unshifted: { symbol: "Dead", key: "i" }, shifted: { symbol: "ˆ", key: "I" } },
+    "KeyO": { unshifted: { symbol: "ø", key: "o" }, shifted: { symbol: "Ø", key: "O" } },
+    "KeyP": { unshifted: { symbol: "π", key: "p" }, shifted: { symbol: "∏", key: "P" } },
+    "BracketLeft": { unshifted: { symbol: "“", key: "[" }, shifted: { symbol: "”", key: "{" } },
+    "BracketRight": { unshifted: { symbol: "‘", key: "]" }, shifted: { symbol: "’", key: "}" } },
+    "Backslash": { unshifted: { symbol: "«", key: "\\" }, shifted: { symbol: "»", key: "|" } },
+    "KeyA": { unshifted: { symbol: "å", key: "a" }, shifted: { symbol: "Å", key: "A" } },
+    "KeyS": { unshifted: { symbol: "ß", key: "s" }, shifted: { symbol: "Í", key: "S" } },
+    "KeyD": { unshifted: { symbol: "∂", key: "d" }, shifted: { symbol: "Î", key: "D" } },
+    "KeyF": { unshifted: { symbol: "ƒ", key: "f" }, shifted: { symbol: "Ï", key: "F" } },
+    "KeyG": { unshifted: { symbol: "©", key: "g" }, shifted: { symbol: "˝", key: "G" } },
+    "KeyH": { unshifted: { symbol: "˙", key: "h" }, shifted: { symbol: "Ó", key: "H" } },
+    "KeyJ": { unshifted: { symbol: "∆", key: "j" }, shifted: { symbol: "Ô", key: "J" } },
+    "KeyK": { unshifted: { symbol: "˚", key: "k" }, shifted: { symbol: "", key: "K" } },
+    "KeyL": { unshifted: { symbol: "¬", key: "l" }, shifted: { symbol: "Ò", key: "L" } },
+    "Semicolon": { unshifted: { symbol: "…", key: ";" }, shifted: { symbol: "Ú", key: ":" } },
+    "Quote": { unshifted: { symbol: "æ", key: "'" }, shifted: { symbol: "Æ", key: "\"" } },
+    "KeyZ": { unshifted: { symbol: "Ω", key: "z" }, shifted: { symbol: "¸", key: "Z" } },
+    "KeyX": { unshifted: { symbol: "≈", key: "x" }, shifted: { symbol: "˛", key: "X" } },
+    "KeyC": { unshifted: { symbol: "ç", key: "c" }, shifted: { symbol: "Ç", key: "C" } },
+    "KeyV": { unshifted: { symbol: "√", key: "v" }, shifted: { symbol: "◊", key: "V" } },
+    "KeyB": { unshifted: { symbol: "∫", key: "b" }, shifted: { symbol: "ı", key: "B" } },
+    "KeyN": { unshifted: { symbol: "Dead", key: "n" }, shifted: { symbol: "˜", key: "N" } },
+    "KeyM": { unshifted: { symbol: "µ", key: "m" }, shifted: { symbol: "Â", key: "M" } },
+    "Comma": { unshifted: { symbol: "≤", key: "," }, shifted: { symbol: "¯", key: "<" } },
+    "Period": { unshifted: { symbol: "≥", key: "." }, shifted: { symbol: "˘", key: ">" } },
+    "Slash": { unshifted: { symbol: "÷", key: "/" }, shifted: { symbol: "¿", key: "?" } }
+  },
+
   getKeyChar(event) {
     let key;
     if (!Settings.get("ignoreKeyboardLayout")) {
-      key = event.key;
+      if (this.platform !== 'Mac') key = event.key;
+      if (!event.altKey) key = event.key;
+      if (this.platform === 'Mac' && event.altKey) {
+        if (this.macOptionSymbolMap[event.code] == null) key = event.key;
+        else {
+          const mapEntry = this.macOptionSymbolMap[event.code];
+          const optionMap = event.shiftKey ? mapEntry.shifted : mapEntry.unshifted;
+
+          if (event.key === optionMap.symbol || event.key === optionMap.key) {
+            key = optionMap.key;
+          }
+        }
+      }
     } else if (!event.code) {
       key = event.key != null ? event.key : ""; // Fall back to event.key (see #3099).
     } else if (event.code.slice(0, 6) === "Numpad") {

--- a/lib/keyboard_utils.js
+++ b/lib/keyboard_utils.js
@@ -32,82 +32,15 @@ const KeyboardUtils = {
   },
 
   // Adds support for Mac Option + Keypress. See #3197.
-  // (Vimium will ignore the symbols and treat them
-  // like letters, at least on a US Laptop keyboard).
-  // I only have a laptop with a US keyboard so I can only get the keypresses that are
-  // available to me, and this list can likely be expanded. I have no idea if Option +
-  // key in different regions produces different symbols or not.
-  //
-  // I suppose another way of handling this would be to simply treat any Option + (Shift? +)
-  // key press as if "Ignore Keyboard Layout" and only use the event.code value for those
-  // presses. If you'd rather implement it that way be my guest, I leave it up to you to
-  // decide which approach is better/more efficient.
-  macOptionSymbolMap: {
-    "Backquote": { unshifted: { symbol: "Dead", key: "`" }, shifted: { symbol: "`", key: "~" } },
-    "Digit1": { unshifted: { symbol: "¡", key: "1" }, shifted: { symbol: "⁄", key: "!" } },
-    "Digit2": { unshifted: { symbol: "™", key: "2" }, shifted: { symbol: "€", key: "@" } },
-    "Digit3": { unshifted: { symbol: "£", key: "3" }, shifted: { symbol: "‹", key: "#" } },
-    "Digit4": { unshifted: { symbol: "¢", key: "4" }, shifted: { symbol: "›", key: "$" } },
-    "Digit5": { unshifted: { symbol: "∞", key: "5" }, shifted: { symbol: "ﬁ", key: "%" } },
-    "Digit6": { unshifted: { symbol: "§", key: "6" }, shifted: { symbol: "ﬂ", key: "^" } },
-    "Digit7": { unshifted: { symbol: "¶", key: "7" }, shifted: { symbol: "‡", key: "&" } },
-    "Digit8": { unshifted: { symbol: "•", key: "8" }, shifted: { symbol: "°", key: "*" } },
-    "Digit9": { unshifted: { symbol: "ª", key: "9" }, shifted: { symbol: "·", key: "(" } },
-    "Digit0": { unshifted: { symbol: "º", key: "0" }, shifted: { symbol: "‚", key: ")" } },
-    "Minus": { unshifted: { symbol: "–", key: "-" }, shifted: { symbol: "—", key: "_" } },
-    "Equal": { unshifted: { symbol: "≠", key: "=" }, shifted: { symbol: "±", key: "+" } },
-    "KeyQ": { unshifted: { symbol: "œ", key: "q" }, shifted: { symbol: "Œ", key: "Q" } },
-    "KeyW": { unshifted: { symbol: "∑", key: "w" }, shifted: { symbol: "„", key: "W" } },
-    "KeyE": { unshifted: { symbol: "Dead", key: "e" }, shifted: { symbol: "´", key: "E" } },
-    "KeyR": { unshifted: { symbol: "®", key: "r" }, shifted: { symbol: "‰", key: "R" } },
-    "KeyT": { unshifted: { symbol: "†", key: "t" }, shifted: { symbol: "ˇ", key: "T" } },
-    "KeyY": { unshifted: { symbol: "¥", key: "y" }, shifted: { symbol: "Á", key: "Y" } },
-    "KeyU": { unshifted: { symbol: "Dead", key: "u" }, shifted: { symbol: "¨", key: "U" } },
-    "KeyI": { unshifted: { symbol: "Dead", key: "i" }, shifted: { symbol: "ˆ", key: "I" } },
-    "KeyO": { unshifted: { symbol: "ø", key: "o" }, shifted: { symbol: "Ø", key: "O" } },
-    "KeyP": { unshifted: { symbol: "π", key: "p" }, shifted: { symbol: "∏", key: "P" } },
-    "BracketLeft": { unshifted: { symbol: "“", key: "[" }, shifted: { symbol: "”", key: "{" } },
-    "BracketRight": { unshifted: { symbol: "‘", key: "]" }, shifted: { symbol: "’", key: "}" } },
-    "Backslash": { unshifted: { symbol: "«", key: "\\" }, shifted: { symbol: "»", key: "|" } },
-    "KeyA": { unshifted: { symbol: "å", key: "a" }, shifted: { symbol: "Å", key: "A" } },
-    "KeyS": { unshifted: { symbol: "ß", key: "s" }, shifted: { symbol: "Í", key: "S" } },
-    "KeyD": { unshifted: { symbol: "∂", key: "d" }, shifted: { symbol: "Î", key: "D" } },
-    "KeyF": { unshifted: { symbol: "ƒ", key: "f" }, shifted: { symbol: "Ï", key: "F" } },
-    "KeyG": { unshifted: { symbol: "©", key: "g" }, shifted: { symbol: "˝", key: "G" } },
-    "KeyH": { unshifted: { symbol: "˙", key: "h" }, shifted: { symbol: "Ó", key: "H" } },
-    "KeyJ": { unshifted: { symbol: "∆", key: "j" }, shifted: { symbol: "Ô", key: "J" } },
-    "KeyK": { unshifted: { symbol: "˚", key: "k" }, shifted: { symbol: "", key: "K" } },
-    "KeyL": { unshifted: { symbol: "¬", key: "l" }, shifted: { symbol: "Ò", key: "L" } },
-    "Semicolon": { unshifted: { symbol: "…", key: ";" }, shifted: { symbol: "Ú", key: ":" } },
-    "Quote": { unshifted: { symbol: "æ", key: "'" }, shifted: { symbol: "Æ", key: '"' } },
-    "KeyZ": { unshifted: { symbol: "Ω", key: "z" }, shifted: { symbol: "¸", key: "Z" } },
-    "KeyX": { unshifted: { symbol: "≈", key: "x" }, shifted: { symbol: "˛", key: "X" } },
-    "KeyC": { unshifted: { symbol: "ç", key: "c" }, shifted: { symbol: "Ç", key: "C" } },
-    "KeyV": { unshifted: { symbol: "√", key: "v" }, shifted: { symbol: "◊", key: "V" } },
-    "KeyB": { unshifted: { symbol: "∫", key: "b" }, shifted: { symbol: "ı", key: "B" } },
-    "KeyN": { unshifted: { symbol: "Dead", key: "n" }, shifted: { symbol: "˜", key: "N" } },
-    "KeyM": { unshifted: { symbol: "µ", key: "m" }, shifted: { symbol: "Â", key: "M" } },
-    "Comma": { unshifted: { symbol: "≤", key: "," }, shifted: { symbol: "¯", key: "<" } },
-    "Period": { unshifted: { symbol: "≥", key: "." }, shifted: { symbol: "˘", key: ">" } },
-    "Slash": { unshifted: { symbol: "÷", key: "/" }, shifted: { symbol: "¿", key: "?" } },
-  },
-
+  // (Vimium will ignore the symbols and treat them like letters, at least on a US Laptop keyboard).
   getKeyChar(event) {
     let key;
-    if (!Settings.get("ignoreKeyboardLayout")) {
-      if (this.platform !== "Mac") key = event.key;
-      if (!event.altKey) key = event.key;
-      if (this.platform === "Mac" && event.altKey) {
-        if (this.macOptionSymbolMap[event.code] == null) key = event.key;
-        else {
-          const mapEntry = this.macOptionSymbolMap[event.code];
-          const optionMap = event.shiftKey ? mapEntry.shifted : mapEntry.unshifted;
-
-          if (event.key === optionMap.symbol || event.key === optionMap.key) {
-            key = optionMap.key;
-          }
-        }
-      }
+    if (
+      !Settings.get("ignoreKeyboardLayout") && !Settings.get("macOptionKeyFix") ||
+      !Settings.get("ignoreKeyboardLayout") &&
+        (this.platform === "Mac" && Settings.get("macOptionKeyFix") && !event.altKey)
+    ) {
+      key = event.key;
     } else if (!event.code) {
       key = event.key != null ? event.key : ""; // Fall back to event.key (see #3099).
     } else if (event.code.slice(0, 6) === "Numpad") {

--- a/lib/keyboard_utils.js
+++ b/lib/keyboard_utils.js
@@ -79,7 +79,7 @@ const KeyboardUtils = {
     "KeyK": { unshifted: { symbol: "˚", key: "k" }, shifted: { symbol: "", key: "K" } },
     "KeyL": { unshifted: { symbol: "¬", key: "l" }, shifted: { symbol: "Ò", key: "L" } },
     "Semicolon": { unshifted: { symbol: "…", key: ";" }, shifted: { symbol: "Ú", key: ":" } },
-    "Quote": { unshifted: { symbol: "æ", key: "'" }, shifted: { symbol: "Æ", key: "\"" } },
+    "Quote": { unshifted: { symbol: "æ", key: "'" }, shifted: { symbol: "Æ", key: '"' } },
     "KeyZ": { unshifted: { symbol: "Ω", key: "z" }, shifted: { symbol: "¸", key: "Z" } },
     "KeyX": { unshifted: { symbol: "≈", key: "x" }, shifted: { symbol: "˛", key: "X" } },
     "KeyC": { unshifted: { symbol: "ç", key: "c" }, shifted: { symbol: "Ç", key: "C" } },
@@ -89,15 +89,15 @@ const KeyboardUtils = {
     "KeyM": { unshifted: { symbol: "µ", key: "m" }, shifted: { symbol: "Â", key: "M" } },
     "Comma": { unshifted: { symbol: "≤", key: "," }, shifted: { symbol: "¯", key: "<" } },
     "Period": { unshifted: { symbol: "≥", key: "." }, shifted: { symbol: "˘", key: ">" } },
-    "Slash": { unshifted: { symbol: "÷", key: "/" }, shifted: { symbol: "¿", key: "?" } }
+    "Slash": { unshifted: { symbol: "÷", key: "/" }, shifted: { symbol: "¿", key: "?" } },
   },
 
   getKeyChar(event) {
     let key;
     if (!Settings.get("ignoreKeyboardLayout")) {
-      if (this.platform !== 'Mac') key = event.key;
+      if (this.platform !== "Mac") key = event.key;
       if (!event.altKey) key = event.key;
-      if (this.platform === 'Mac' && event.altKey) {
+      if (this.platform === "Mac" && event.altKey) {
         if (this.macOptionSymbolMap[event.code] == null) key = event.key;
         else {
           const mapEntry = this.macOptionSymbolMap[event.code];

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -68,6 +68,7 @@ w: https://www.wikipedia.org/w/index.php?title=Special:Search&search=%s Wikipedi
   regexFindMode: false,
   waitForEnterForFilteredHints: true,
   helpDialog_showAdvancedCommands: false,
+  macOptionKeyFix: true,
   ignoreKeyboardLayout: false,
 };
 

--- a/pages/options.css
+++ b/pages/options.css
@@ -157,6 +157,10 @@ div#exampleKeyMapping {
   margin-top: 5px;
 }
 
+div#macos {
+  display: none;
+}
+
 #linkHintCharactersContainer,
 #linkHintNumbersContainer,
 #waitForEnterForFilteredHintsContainer {

--- a/pages/options.html
+++ b/pages/options.html
@@ -185,7 +185,7 @@ b: http://b.com/?q=%s description
           <div class="example">
             This forces Vimium to treat an <code>Option + Key</code> keypress that would produce a
             symbol on macOS as the equivalent <code>Alt + Letter</code> keypress. (With this
-            enabled, you can create maps such as <code>&lt;a-f&gt;</code> rather than
+            enabled, you can create maps such as <code>&lt;a-j&gt;</code> rather than
             <code>&lt;a-&Delta;&gt;</code>.)
           </div>
         </div>

--- a/pages/options.html
+++ b/pages/options.html
@@ -1,291 +1,289 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>Vimium Options</title>
-    <meta name="color-scheme" content="light dark">
-    <link rel="stylesheet" type="text/css" href="options.css">
-    <link rel="stylesheet" type="text/css" href="../content_scripts/vimium.css" />
-    <script src="../background_scripts/commands.js"></script>
 
-    <script src="../lib/utils.js"></script>
-    <script src="../lib/url_utils.js"></script>
-    <script src="../lib/keyboard_utils.js"></script>
-    <script src="../lib/dom_utils.js"></script>
-    <script src="../lib/rect.js"></script>
-    <script src="../lib/handler_stack.js"></script>
-    <script src="../lib/settings.js"></script>
-    <script src="../lib/find_mode_history.js"></script>
-    <script src="../content_scripts/mode.js"></script>
-    <script src="../content_scripts/ui_component.js"></script>
-    <script src="../content_scripts/link_hints.js"></script>
-    <script src="../content_scripts/vomnibar.js"></script>
-    <script src="../content_scripts/scroller.js"></script>
-    <script src="../content_scripts/marks.js"></script>
-    <script src="../content_scripts/mode_insert.js"></script>
-    <script src="../content_scripts/mode_find.js"></script>
-    <script src="../content_scripts/mode_key_handler.js"></script>
-    <script src="../content_scripts/mode_visual.js"></script>
-    <script src="../content_scripts/hud.js"></script>
-    <script src="../content_scripts/mode_normal.js"></script>
-    <script src="../content_scripts/vimium_frontend.js"></script>
+<head>
+  <title>Vimium Options</title>
+  <meta name="color-scheme" content="light dark">
+  <link rel="stylesheet" type="text/css" href="options.css">
+  <link rel="stylesheet" type="text/css" href="../content_scripts/vimium.css" />
+  <script src="../background_scripts/commands.js"></script>
 
-    <script src="exclusion_rules_editor.js"></script>
-    <script src="options.js"></script>
-  </head>
+  <script src="../lib/utils.js"></script>
+  <script src="../lib/url_utils.js"></script>
+  <script src="../lib/keyboard_utils.js"></script>
+  <script src="../lib/dom_utils.js"></script>
+  <script src="../lib/rect.js"></script>
+  <script src="../lib/handler_stack.js"></script>
+  <script src="../lib/settings.js"></script>
+  <script src="../lib/find_mode_history.js"></script>
+  <script src="../content_scripts/mode.js"></script>
+  <script src="../content_scripts/ui_component.js"></script>
+  <script src="../content_scripts/link_hints.js"></script>
+  <script src="../content_scripts/vomnibar.js"></script>
+  <script src="../content_scripts/scroller.js"></script>
+  <script src="../content_scripts/marks.js"></script>
+  <script src="../content_scripts/mode_insert.js"></script>
+  <script src="../content_scripts/mode_find.js"></script>
+  <script src="../content_scripts/mode_key_handler.js"></script>
+  <script src="../content_scripts/mode_visual.js"></script>
+  <script src="../content_scripts/hud.js"></script>
+  <script src="../content_scripts/mode_normal.js"></script>
+  <script src="../content_scripts/vimium_frontend.js"></script>
 
-  <body class="vimiumBody">
-    <div id="wrapper">
-      <header>Vimium Options</header>
-      <input type="hidden" id="settingsVersion" />
+  <script src="exclusion_rules_editor.js"></script>
+  <script src="options.js"></script>
+</head>
 
-      <div id="settings-grid-container">
-        <h2>Excluded URLs and keys</h2>
-        <div>
-          <div id="exclusionScrollBox">
-            <table id="exclusionRules">
-              <tr>
-                <td><span class="exclusionHeaderText">Patterns</span></td>
-                <td><span class="exclusionHeaderText">Keys to exclude</span></td>
-              </tr>
-            </table>
-          </div>
-          <button id="exclusionAddButton">Add rule</button>
+<body class="vimiumBody">
+  <div id="wrapper">
+    <header>Vimium Options</header>
+    <input type="hidden" id="settingsVersion" />
+
+    <div id="settings-grid-container">
+      <h2>Excluded URLs and keys</h2>
+      <div>
+        <div id="exclusionScrollBox">
+          <table id="exclusionRules">
+            <tr>
+              <td><span class="exclusionHeaderText">Patterns</span></td>
+              <td><span class="exclusionHeaderText">Keys to exclude</span></td>
+            </tr>
+          </table>
         </div>
-        <div class="example">
-          Disable Vimium on URLs.<br>
-          "Patterns" are URL regular expressions. <code>*</code> will match zero or more characters.
-          <br>
-          "Keys": Vimium will exclude these keys and pass them through to the page.
-        </div>
+        <button id="exclusionAddButton">Add rule</button>
+      </div>
+      <div class="example">
+        Disable Vimium on URLs.<br>
+        "Patterns" are URL regular expressions. <code>*</code> will match zero or more characters.
+        <br>
+        "Keys": Vimium will exclude these keys and pass them through to the page.
+      </div>
 
-        <h2>Custom key mappings</h2>
-        <textarea id="keyMappings" type="text"></textarea>
-        <div class="example">
-          Enter commands to remap your keys. Available commands:<br>
-          <pre
-            id="exampleKeyMapping"
-          >
+      <h2>Custom key mappings</h2>
+      <textarea id="keyMappings" type="text"></textarea>
+      <div class="example">
+        Enter commands to remap your keys. Available commands:<br>
+        <pre id="exampleKeyMapping">
 map j scrollDown
 unmap j
 unmapAll
 " this is a comment
 # this is also a comment</pre>
-          <a href="#" id="showCommands">Show available commands</a>.
-        </div>
+        <a href="#" id="showCommands">Show available commands</a>.
+      </div>
 
-        <h2>Custom search engines</h2>
-        <textarea id="searchEngines"></textarea>
-        <div class="example">
-          Add search-engine shortcuts to the Vomnibar. Format:<br>
-          <pre
-          >
+      <h2>Custom search engines</h2>
+      <textarea id="searchEngines"></textarea>
+      <div class="example">
+        Add search-engine shortcuts to the Vomnibar. Format:<br>
+        <pre>
 a: http://a.com/?q=%s
 b: http://b.com/?q=%s description
 " this is a comment
-# this is also a comment</pre
-          >
-          %s is replaced with the search terms. <br>
-          For search completion, see <a href="completion_engines.html" target="_blank">here</a>.
-        </div>
+# this is also a comment</pre>
+        %s is replaced with the search terms. <br>
+        For search completion, see <a href="completion_engines.html" target="_blank">here</a>.
+      </div>
 
-        <header>Advanced Options</header>
+      <header>Advanced Options</header>
 
-        <h2>Scroll step size</h2>
-        <span>
-          <input id="scrollStepSize" type="number" />px
-        </span>
-        <div class="example">
-          The size for basic movements (usually j/k/h/l).
-        </div>
+      <h2>Scroll step size</h2>
+      <span>
+        <input id="scrollStepSize" type="number" />px
+      </span>
+      <div class="example">
+        The size for basic movements (usually j/k/h/l).
+      </div>
 
-        <div id="linkHintCharactersContainer">
-          <h2>Characters used for link hints</h2>
-          <div class="linkHintCharactersField">
-            <input id="linkHintCharacters" type="text" />
-            <div class="example reset-link"><a href="#">Reset</a></div>
-          </div>
-          <div class="example">
-            The characters placed next to each link after typing "f" to enter link-hint mode.
-          </div>
-        </div>
-
-        <div id="linkHintNumbersContainer">
-          <h2>Numbers used for link hints</h2>
-          <div class="linkHintCharactersField">
-            <input id="linkHintNumbers" type="text" />
-            <div class="example reset-link"><a href="#">Reset</a></div>
-          </div>
-          <div class="example">
-            The characters placed next to each link after typing "f" to enter link-hint mode.
-          </div>
-        </div>
-
-        <div class="spacer"></div>
-
-        <label>
-          <input id="smoothScroll" type="checkbox" />
-          Use smooth scrolling
-        </label>
-        <div class="example"></div>
-
-        <h2></h2>
-        <label>
-          <input id="filterLinkHints" type="checkbox" />
-          Use the link's name and characters for link-hint filtering
-        </label>
-        <div class="example">
-          In link-hint mode, this option lets you select a link by typing its text.
-        </div>
-
-        <div id="waitForEnterForFilteredHintsContainer">
-          <h2></h2>
-          <label>
-            <input id="waitForEnterForFilteredHints" type="checkbox" />
-            Require <tt>Enter</tt> when filtering hints
-          </label>
-          <div class="example">
-            You activate the link with <tt>Enter</tt>, <em>always</em>; so you never accidentally
-            type Vimium commands.
-          </div>
-        </div>
-
-        <h2></h2>
-        <label>
-          <input id="grabBackFocus" type="checkbox" />
-          Don't let pages steal the focus on load
-        </label>
-        <div class="example">
-          Prevent pages from focusing an input on load (e.g. Google, Bing, etc.).
-        </div>
-
-        <h2></h2>
-        <label>
-          <input id="hideHud" type="checkbox" />
-          Hide the Heads Up Display (HUD) in insert mode
-        </label>
-        <div class="example">
-          When enabled, the HUD will not be displayed in insert mode.
-        </div>
-
-        <h2></h2>
-        <label>
-          <input id="regexFindMode" type="checkbox" />
-          Treat find queries as JavaScript regular expressions
-        </label>
-        <div class="example">
-          Switch back to plain find mode by using the <code>\R</code> escape sequence.
-        </div>
-
-        <h2></h2>
-        <div id="macos">
-          <label>
-            <input id="macOptionKeyFix" type="checkbox" />
-            macOS: Treat Option as Alt/Meta
-          </label>
-          <div class="example">
-            This forces Vimium to treat an <code>Option + Key</code> keypress that would produce a
-            symbol on macOS as the equivalent <code>Alt + Letter</code> keypress. (With this
-            enabled, you can create maps such as <code>&lt;a-f&gt;</code> rather than
-            <code>&lt;a-∆&gt;</code>.)
-          </div>
-        </div>
-
-        <h2></h2>
-        <label>
-          <input id="ignoreKeyboardLayout" type="checkbox" />
-          Ignore keyboard layout
-        </label>
-        <div class="example">
-          This forces the use of <code>en-US</code> QWERTY layout and can be helpful for non-Latin
-          keyboards.
-        </div>
-
-        <h2>Previous patterns</h2>
-        <div>
-          <input id="previousPatterns" type="text" />
+      <div id="linkHintCharactersContainer">
+        <h2>Characters used for link hints</h2>
+        <div class="linkHintCharactersField">
+          <input id="linkHintCharacters" type="text" />
           <div class="example reset-link"><a href="#">Reset</a></div>
         </div>
         <div class="example">
-          The "navigate to previous page" command uses these patterns to find the link to follow.
-        </div>
-
-        <h2>Next patterns</h2>
-        <div>
-          <input id="nextPatterns" type="text" />
-          <div class="example reset-link"><a href="#">Reset</a></div>
-        </div>
-        <div class="example">
-          The "navigate to next page" command uses these patterns to find the link to follow.
-        </div>
-
-        <h2>New tab URL</h2>
-        <div>
-          <input id="newTabUrl" type="text" />
-          <div class="example reset-link"><a href="#">Reset</a></div>
-        </div>
-        <div class="example">
-          The page to open with the "create new tab" command. Set this to "<tt>pages/blank.html</tt
-          >" for a blank page (except incognito mode).<br>
-        </div>
-
-        <h2>CSS for Vimium UI</h2>
-        <div>
-          <textarea id="userDefinedLinkHintCss" class="code" type="text"></textarea>
-          <div class="example reset-link"><a href="#">Reset</a></div>
-        </div>
-        <div class="example">
-          These styles are applied to link hints, the Vomnibar, the help dialog, the exclusions
-          pop-up and the HUD.<br>
-          By default, this CSS is used to style the characters next to each link hint.<br>
-          <br>
-          These styles are used in addition to and take precedence over Vimium's default styles.
-        </div>
-
-        <header>Backup and Restore</header>
-
-        <h2>Backup</h2>
-        <a id="downloadBackup" download="vimium-options.json" href="#">Download backup</a>
-        <div class="example">Download a backup of your settings.</div>
-
-        <h2>Restore</h2>
-        <input id="uploadBackup" type="file" accept=".json" />
-        <div class="example">
-          Choose a backup file to restore.
+          The characters placed next to each link after typing "f" to enter link-hint mode.
         </div>
       </div>
 
-      <div id="footer">
-        <div id="footerWrapper">
-          <table id="footerTable">
-            <tr>
-              <td id="footerTableData">
-                <span id="helpText">
-                  Type <strong>?</strong> to show the help dialog.
-                  <br>
-                  Type <strong>Ctrl-Enter</strong> to save <i>all</i> options.
-                </span>
-              </td>
-              <td id="saveOptionsTableData" nowrap>
-                <button id="saveOptions" disabled="disabled">No changes</button>
-              </td>
-            </tr>
-          </table>
+      <div id="linkHintNumbersContainer">
+        <h2>Numbers used for link hints</h2>
+        <div class="linkHintCharactersField">
+          <input id="linkHintNumbers" type="text" />
+          <div class="example reset-link"><a href="#">Reset</a></div>
         </div>
+        <div class="example">
+          The characters placed next to each link after typing "f" to enter link-hint mode.
+        </div>
+      </div>
+
+      <div class="spacer"></div>
+
+      <label>
+        <input id="smoothScroll" type="checkbox" />
+        Use smooth scrolling
+      </label>
+      <div class="example"></div>
+
+      <h2></h2>
+      <label>
+        <input id="filterLinkHints" type="checkbox" />
+        Use the link's name and characters for link-hint filtering
+      </label>
+      <div class="example">
+        In link-hint mode, this option lets you select a link by typing its text.
+      </div>
+
+      <div id="waitForEnterForFilteredHintsContainer">
+        <h2></h2>
+        <label>
+          <input id="waitForEnterForFilteredHints" type="checkbox" />
+          Require <tt>Enter</tt> when filtering hints
+        </label>
+        <div class="example">
+          You activate the link with <tt>Enter</tt>, <em>always</em>; so you never accidentally
+          type Vimium commands.
+        </div>
+      </div>
+
+      <h2></h2>
+      <label>
+        <input id="grabBackFocus" type="checkbox" />
+        Don't let pages steal the focus on load
+      </label>
+      <div class="example">
+        Prevent pages from focusing an input on load (e.g. Google, Bing, etc.).
+      </div>
+
+      <h2></h2>
+      <label>
+        <input id="hideHud" type="checkbox" />
+        Hide the Heads Up Display (HUD) in insert mode
+      </label>
+      <div class="example">
+        When enabled, the HUD will not be displayed in insert mode.
+      </div>
+
+      <h2></h2>
+      <label>
+        <input id="regexFindMode" type="checkbox" />
+        Treat find queries as JavaScript regular expressions
+      </label>
+      <div class="example">
+        Switch back to plain find mode by using the <code>\R</code> escape sequence.
+      </div>
+
+      <h2></h2>
+      <div id="macos">
+        <label>
+          <input id="macOptionKeyFix" type="checkbox" />
+          macOS: Treat Option as Alt/Meta
+        </label>
+        <div class="example">
+          This forces Vimium to treat an <code>Option + Key</code> keypress that would produce a
+          symbol on macOS as the equivalent <code>Alt + Letter</code> keypress. (With this
+          enabled, you can create maps such as <code>&lt;a-f&gt;</code> rather than
+          <code>&lt;a-&Delta;&gt;</code>.)
+        </div>
+      </div>
+
+      <h2></h2>
+      <label>
+        <input id="ignoreKeyboardLayout" type="checkbox" />
+        Ignore keyboard layout
+      </label>
+      <div class="example">
+        This forces the use of <code>en-US</code> QWERTY layout and can be helpful for non-Latin
+        keyboards.
+      </div>
+
+      <h2>Previous patterns</h2>
+      <div>
+        <input id="previousPatterns" type="text" />
+        <div class="example reset-link"><a href="#">Reset</a></div>
+      </div>
+      <div class="example">
+        The "navigate to previous page" command uses these patterns to find the link to follow.
+      </div>
+
+      <h2>Next patterns</h2>
+      <div>
+        <input id="nextPatterns" type="text" />
+        <div class="example reset-link"><a href="#">Reset</a></div>
+      </div>
+      <div class="example">
+        The "navigate to next page" command uses these patterns to find the link to follow.
+      </div>
+
+      <h2>New tab URL</h2>
+      <div>
+        <input id="newTabUrl" type="text" />
+        <div class="example reset-link"><a href="#">Reset</a></div>
+      </div>
+      <div class="example">
+        The page to open with the "create new tab" command. Set this to "<tt>pages/blank.html</tt>" for a blank page
+        (except incognito mode).<br>
+      </div>
+
+      <h2>CSS for Vimium UI</h2>
+      <div>
+        <textarea id="userDefinedLinkHintCss" class="code" type="text"></textarea>
+        <div class="example reset-link"><a href="#">Reset</a></div>
+      </div>
+      <div class="example">
+        These styles are applied to link hints, the Vomnibar, the help dialog, the exclusions
+        pop-up and the HUD.<br>
+        By default, this CSS is used to style the characters next to each link hint.<br>
+        <br>
+        These styles are used in addition to and take precedence over Vimium's default styles.
+      </div>
+
+      <header>Backup and Restore</header>
+
+      <h2>Backup</h2>
+      <a id="downloadBackup" download="vimium-options.json" href="#">Download backup</a>
+      <div class="example">Download a backup of your settings.</div>
+
+      <h2>Restore</h2>
+      <input id="uploadBackup" type="file" accept=".json" />
+      <div class="example">
+        Choose a backup file to restore.
       </div>
     </div>
 
-    <template id="exclusionRuleTemplate">
-      <tr class="rule">
-        <td>
-          <input type="text" name="pattern" spellcheck="false" placeholder="URL pattern" />
-        </td>
-        <td>
-          <input type="text" name="passKeys" spellcheck="false" placeholder="All" />
-        </td>
-        <td>
-          <input type="button" class="remove" value="&#x2716;" />
-        </td>
-      </tr>
-    </template>
-  </body>
+    <div id="footer">
+      <div id="footerWrapper">
+        <table id="footerTable">
+          <tr>
+            <td id="footerTableData">
+              <span id="helpText">
+                Type <strong>?</strong> to show the help dialog.
+                <br>
+                Type <strong>Ctrl-Enter</strong> to save <i>all</i> options.
+              </span>
+            </td>
+            <td id="saveOptionsTableData" nowrap>
+              <button id="saveOptions" disabled="disabled">No changes</button>
+            </td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <template id="exclusionRuleTemplate">
+    <tr class="rule">
+      <td>
+        <input type="text" name="pattern" spellcheck="false" placeholder="URL pattern" />
+      </td>
+      <td>
+        <input type="text" name="passKeys" spellcheck="false" placeholder="All" />
+      </td>
+      <td>
+        <input type="button" class="remove" value="&#x2716;" />
+      </td>
+    </tr>
+  </template>
+</body>
+
 </html>

--- a/pages/options.html
+++ b/pages/options.html
@@ -177,6 +177,20 @@ b: http://b.com/?q=%s description
         </div>
 
         <h2></h2>
+        <div id="macos">
+          <label>
+            <input id="macOptionKeyFix" type="checkbox" />
+            macOS: Treat Option as Alt/Meta
+          </label>
+          <div class="example">
+            This forces Vimium to treat an <code>Option + Key</code> keypress that would produce a
+            symbol on macOS as the equivalent <code>Alt + Letter</code> keypress. (With this
+            enabled, you can create maps such as <code>&lt;a-f&gt;</code> rather than
+            <code>&lt;a-∆&gt;</code>.)
+          </div>
+        </div>
+
+        <h2></h2>
         <label>
           <input id="ignoreKeyboardLayout" type="checkbox" />
           Ignore keyboard layout

--- a/pages/options.html
+++ b/pages/options.html
@@ -1,289 +1,291 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <title>Vimium Options</title>
+    <meta name="color-scheme" content="light dark">
+    <link rel="stylesheet" type="text/css" href="options.css">
+    <link rel="stylesheet" type="text/css" href="../content_scripts/vimium.css" />
+    <script src="../background_scripts/commands.js"></script>
 
-<head>
-  <title>Vimium Options</title>
-  <meta name="color-scheme" content="light dark">
-  <link rel="stylesheet" type="text/css" href="options.css">
-  <link rel="stylesheet" type="text/css" href="../content_scripts/vimium.css" />
-  <script src="../background_scripts/commands.js"></script>
+    <script src="../lib/utils.js"></script>
+    <script src="../lib/url_utils.js"></script>
+    <script src="../lib/keyboard_utils.js"></script>
+    <script src="../lib/dom_utils.js"></script>
+    <script src="../lib/rect.js"></script>
+    <script src="../lib/handler_stack.js"></script>
+    <script src="../lib/settings.js"></script>
+    <script src="../lib/find_mode_history.js"></script>
+    <script src="../content_scripts/mode.js"></script>
+    <script src="../content_scripts/ui_component.js"></script>
+    <script src="../content_scripts/link_hints.js"></script>
+    <script src="../content_scripts/vomnibar.js"></script>
+    <script src="../content_scripts/scroller.js"></script>
+    <script src="../content_scripts/marks.js"></script>
+    <script src="../content_scripts/mode_insert.js"></script>
+    <script src="../content_scripts/mode_find.js"></script>
+    <script src="../content_scripts/mode_key_handler.js"></script>
+    <script src="../content_scripts/mode_visual.js"></script>
+    <script src="../content_scripts/hud.js"></script>
+    <script src="../content_scripts/mode_normal.js"></script>
+    <script src="../content_scripts/vimium_frontend.js"></script>
 
-  <script src="../lib/utils.js"></script>
-  <script src="../lib/url_utils.js"></script>
-  <script src="../lib/keyboard_utils.js"></script>
-  <script src="../lib/dom_utils.js"></script>
-  <script src="../lib/rect.js"></script>
-  <script src="../lib/handler_stack.js"></script>
-  <script src="../lib/settings.js"></script>
-  <script src="../lib/find_mode_history.js"></script>
-  <script src="../content_scripts/mode.js"></script>
-  <script src="../content_scripts/ui_component.js"></script>
-  <script src="../content_scripts/link_hints.js"></script>
-  <script src="../content_scripts/vomnibar.js"></script>
-  <script src="../content_scripts/scroller.js"></script>
-  <script src="../content_scripts/marks.js"></script>
-  <script src="../content_scripts/mode_insert.js"></script>
-  <script src="../content_scripts/mode_find.js"></script>
-  <script src="../content_scripts/mode_key_handler.js"></script>
-  <script src="../content_scripts/mode_visual.js"></script>
-  <script src="../content_scripts/hud.js"></script>
-  <script src="../content_scripts/mode_normal.js"></script>
-  <script src="../content_scripts/vimium_frontend.js"></script>
+    <script src="exclusion_rules_editor.js"></script>
+    <script src="options.js"></script>
+  </head>
 
-  <script src="exclusion_rules_editor.js"></script>
-  <script src="options.js"></script>
-</head>
+  <body class="vimiumBody">
+    <div id="wrapper">
+      <header>Vimium Options</header>
+      <input type="hidden" id="settingsVersion" />
 
-<body class="vimiumBody">
-  <div id="wrapper">
-    <header>Vimium Options</header>
-    <input type="hidden" id="settingsVersion" />
-
-    <div id="settings-grid-container">
-      <h2>Excluded URLs and keys</h2>
-      <div>
-        <div id="exclusionScrollBox">
-          <table id="exclusionRules">
-            <tr>
-              <td><span class="exclusionHeaderText">Patterns</span></td>
-              <td><span class="exclusionHeaderText">Keys to exclude</span></td>
-            </tr>
-          </table>
+      <div id="settings-grid-container">
+        <h2>Excluded URLs and keys</h2>
+        <div>
+          <div id="exclusionScrollBox">
+            <table id="exclusionRules">
+              <tr>
+                <td><span class="exclusionHeaderText">Patterns</span></td>
+                <td><span class="exclusionHeaderText">Keys to exclude</span></td>
+              </tr>
+            </table>
+          </div>
+          <button id="exclusionAddButton">Add rule</button>
         </div>
-        <button id="exclusionAddButton">Add rule</button>
-      </div>
-      <div class="example">
-        Disable Vimium on URLs.<br>
-        "Patterns" are URL regular expressions. <code>*</code> will match zero or more characters.
-        <br>
-        "Keys": Vimium will exclude these keys and pass them through to the page.
-      </div>
+        <div class="example">
+          Disable Vimium on URLs.<br>
+          "Patterns" are URL regular expressions. <code>*</code> will match zero or more characters.
+          <br>
+          "Keys": Vimium will exclude these keys and pass them through to the page.
+        </div>
 
-      <h2>Custom key mappings</h2>
-      <textarea id="keyMappings" type="text"></textarea>
-      <div class="example">
-        Enter commands to remap your keys. Available commands:<br>
-        <pre id="exampleKeyMapping">
+        <h2>Custom key mappings</h2>
+        <textarea id="keyMappings" type="text"></textarea>
+        <div class="example">
+          Enter commands to remap your keys. Available commands:<br>
+          <pre
+            id="exampleKeyMapping"
+          >
 map j scrollDown
 unmap j
 unmapAll
 " this is a comment
 # this is also a comment</pre>
-        <a href="#" id="showCommands">Show available commands</a>.
-      </div>
+          <a href="#" id="showCommands">Show available commands</a>.
+        </div>
 
-      <h2>Custom search engines</h2>
-      <textarea id="searchEngines"></textarea>
-      <div class="example">
-        Add search-engine shortcuts to the Vomnibar. Format:<br>
-        <pre>
+        <h2>Custom search engines</h2>
+        <textarea id="searchEngines"></textarea>
+        <div class="example">
+          Add search-engine shortcuts to the Vomnibar. Format:<br>
+          <pre
+          >
 a: http://a.com/?q=%s
 b: http://b.com/?q=%s description
 " this is a comment
-# this is also a comment</pre>
-        %s is replaced with the search terms. <br>
-        For search completion, see <a href="completion_engines.html" target="_blank">here</a>.
-      </div>
-
-      <header>Advanced Options</header>
-
-      <h2>Scroll step size</h2>
-      <span>
-        <input id="scrollStepSize" type="number" />px
-      </span>
-      <div class="example">
-        The size for basic movements (usually j/k/h/l).
-      </div>
-
-      <div id="linkHintCharactersContainer">
-        <h2>Characters used for link hints</h2>
-        <div class="linkHintCharactersField">
-          <input id="linkHintCharacters" type="text" />
-          <div class="example reset-link"><a href="#">Reset</a></div>
+# this is also a comment</pre
+          >
+          %s is replaced with the search terms. <br>
+          For search completion, see <a href="completion_engines.html" target="_blank">here</a>.
         </div>
+
+        <header>Advanced Options</header>
+
+        <h2>Scroll step size</h2>
+        <span>
+          <input id="scrollStepSize" type="number" />px
+        </span>
         <div class="example">
-          The characters placed next to each link after typing "f" to enter link-hint mode.
+          The size for basic movements (usually j/k/h/l).
         </div>
-      </div>
 
-      <div id="linkHintNumbersContainer">
-        <h2>Numbers used for link hints</h2>
-        <div class="linkHintCharactersField">
-          <input id="linkHintNumbers" type="text" />
-          <div class="example reset-link"><a href="#">Reset</a></div>
+        <div id="linkHintCharactersContainer">
+          <h2>Characters used for link hints</h2>
+          <div class="linkHintCharactersField">
+            <input id="linkHintCharacters" type="text" />
+            <div class="example reset-link"><a href="#">Reset</a></div>
+          </div>
+          <div class="example">
+            The characters placed next to each link after typing "f" to enter link-hint mode.
+          </div>
         </div>
-        <div class="example">
-          The characters placed next to each link after typing "f" to enter link-hint mode.
+
+        <div id="linkHintNumbersContainer">
+          <h2>Numbers used for link hints</h2>
+          <div class="linkHintCharactersField">
+            <input id="linkHintNumbers" type="text" />
+            <div class="example reset-link"><a href="#">Reset</a></div>
+          </div>
+          <div class="example">
+            The characters placed next to each link after typing "f" to enter link-hint mode.
+          </div>
         </div>
-      </div>
 
-      <div class="spacer"></div>
+        <div class="spacer"></div>
 
-      <label>
-        <input id="smoothScroll" type="checkbox" />
-        Use smooth scrolling
-      </label>
-      <div class="example"></div>
+        <label>
+          <input id="smoothScroll" type="checkbox" />
+          Use smooth scrolling
+        </label>
+        <div class="example"></div>
 
-      <h2></h2>
-      <label>
-        <input id="filterLinkHints" type="checkbox" />
-        Use the link's name and characters for link-hint filtering
-      </label>
-      <div class="example">
-        In link-hint mode, this option lets you select a link by typing its text.
-      </div>
-
-      <div id="waitForEnterForFilteredHintsContainer">
         <h2></h2>
         <label>
-          <input id="waitForEnterForFilteredHints" type="checkbox" />
-          Require <tt>Enter</tt> when filtering hints
+          <input id="filterLinkHints" type="checkbox" />
+          Use the link's name and characters for link-hint filtering
         </label>
         <div class="example">
-          You activate the link with <tt>Enter</tt>, <em>always</em>; so you never accidentally
-          type Vimium commands.
+          In link-hint mode, this option lets you select a link by typing its text.
         </div>
-      </div>
 
-      <h2></h2>
-      <label>
-        <input id="grabBackFocus" type="checkbox" />
-        Don't let pages steal the focus on load
-      </label>
-      <div class="example">
-        Prevent pages from focusing an input on load (e.g. Google, Bing, etc.).
-      </div>
+        <div id="waitForEnterForFilteredHintsContainer">
+          <h2></h2>
+          <label>
+            <input id="waitForEnterForFilteredHints" type="checkbox" />
+            Require <tt>Enter</tt> when filtering hints
+          </label>
+          <div class="example">
+            You activate the link with <tt>Enter</tt>, <em>always</em>; so you never accidentally
+            type Vimium commands.
+          </div>
+        </div>
 
-      <h2></h2>
-      <label>
-        <input id="hideHud" type="checkbox" />
-        Hide the Heads Up Display (HUD) in insert mode
-      </label>
-      <div class="example">
-        When enabled, the HUD will not be displayed in insert mode.
-      </div>
-
-      <h2></h2>
-      <label>
-        <input id="regexFindMode" type="checkbox" />
-        Treat find queries as JavaScript regular expressions
-      </label>
-      <div class="example">
-        Switch back to plain find mode by using the <code>\R</code> escape sequence.
-      </div>
-
-      <h2></h2>
-      <div id="macos">
+        <h2></h2>
         <label>
-          <input id="macOptionKeyFix" type="checkbox" />
-          macOS: Treat Option as Alt/Meta
+          <input id="grabBackFocus" type="checkbox" />
+          Don't let pages steal the focus on load
         </label>
         <div class="example">
-          This forces Vimium to treat an <code>Option + Key</code> keypress that would produce a
-          symbol on macOS as the equivalent <code>Alt + Letter</code> keypress. (With this
-          enabled, you can create maps such as <code>&lt;a-f&gt;</code> rather than
-          <code>&lt;a-&Delta;&gt;</code>.)
+          Prevent pages from focusing an input on load (e.g. Google, Bing, etc.).
+        </div>
+
+        <h2></h2>
+        <label>
+          <input id="hideHud" type="checkbox" />
+          Hide the Heads Up Display (HUD) in insert mode
+        </label>
+        <div class="example">
+          When enabled, the HUD will not be displayed in insert mode.
+        </div>
+
+        <h2></h2>
+        <label>
+          <input id="regexFindMode" type="checkbox" />
+          Treat find queries as JavaScript regular expressions
+        </label>
+        <div class="example">
+          Switch back to plain find mode by using the <code>\R</code> escape sequence.
+        </div>
+
+        <h2></h2>
+        <div id="macos">
+          <label>
+            <input id="macOptionKeyFix" type="checkbox" />
+            macOS: Treat Option as Alt/Meta
+          </label>
+          <div class="example">
+            This forces Vimium to treat an <code>Option + Key</code> keypress that would produce a
+            symbol on macOS as the equivalent <code>Alt + Letter</code> keypress. (With this
+            enabled, you can create maps such as <code>&lt;a-f&gt;</code> rather than
+            <code>&lt;a-&Delta;&gt;</code>.)
+          </div>
+        </div>
+
+        <h2></h2>
+        <label>
+          <input id="ignoreKeyboardLayout" type="checkbox" />
+          Ignore keyboard layout
+        </label>
+        <div class="example">
+          This forces the use of <code>en-US</code> QWERTY layout and can be helpful for non-Latin
+          keyboards.
+        </div>
+
+        <h2>Previous patterns</h2>
+        <div>
+          <input id="previousPatterns" type="text" />
+          <div class="example reset-link"><a href="#">Reset</a></div>
+        </div>
+        <div class="example">
+          The "navigate to previous page" command uses these patterns to find the link to follow.
+        </div>
+
+        <h2>Next patterns</h2>
+        <div>
+          <input id="nextPatterns" type="text" />
+          <div class="example reset-link"><a href="#">Reset</a></div>
+        </div>
+        <div class="example">
+          The "navigate to next page" command uses these patterns to find the link to follow.
+        </div>
+
+        <h2>New tab URL</h2>
+        <div>
+          <input id="newTabUrl" type="text" />
+          <div class="example reset-link"><a href="#">Reset</a></div>
+        </div>
+        <div class="example">
+          The page to open with the "create new tab" command. Set this to "<tt>pages/blank.html</tt
+          >" for a blank page (except incognito mode).<br>
+        </div>
+
+        <h2>CSS for Vimium UI</h2>
+        <div>
+          <textarea id="userDefinedLinkHintCss" class="code" type="text"></textarea>
+          <div class="example reset-link"><a href="#">Reset</a></div>
+        </div>
+        <div class="example">
+          These styles are applied to link hints, the Vomnibar, the help dialog, the exclusions
+          pop-up and the HUD.<br>
+          By default, this CSS is used to style the characters next to each link hint.<br>
+          <br>
+          These styles are used in addition to and take precedence over Vimium's default styles.
+        </div>
+
+        <header>Backup and Restore</header>
+
+        <h2>Backup</h2>
+        <a id="downloadBackup" download="vimium-options.json" href="#">Download backup</a>
+        <div class="example">Download a backup of your settings.</div>
+
+        <h2>Restore</h2>
+        <input id="uploadBackup" type="file" accept=".json" />
+        <div class="example">
+          Choose a backup file to restore.
         </div>
       </div>
 
-      <h2></h2>
-      <label>
-        <input id="ignoreKeyboardLayout" type="checkbox" />
-        Ignore keyboard layout
-      </label>
-      <div class="example">
-        This forces the use of <code>en-US</code> QWERTY layout and can be helpful for non-Latin
-        keyboards.
-      </div>
-
-      <h2>Previous patterns</h2>
-      <div>
-        <input id="previousPatterns" type="text" />
-        <div class="example reset-link"><a href="#">Reset</a></div>
-      </div>
-      <div class="example">
-        The "navigate to previous page" command uses these patterns to find the link to follow.
-      </div>
-
-      <h2>Next patterns</h2>
-      <div>
-        <input id="nextPatterns" type="text" />
-        <div class="example reset-link"><a href="#">Reset</a></div>
-      </div>
-      <div class="example">
-        The "navigate to next page" command uses these patterns to find the link to follow.
-      </div>
-
-      <h2>New tab URL</h2>
-      <div>
-        <input id="newTabUrl" type="text" />
-        <div class="example reset-link"><a href="#">Reset</a></div>
-      </div>
-      <div class="example">
-        The page to open with the "create new tab" command. Set this to "<tt>pages/blank.html</tt>" for a blank page
-        (except incognito mode).<br>
-      </div>
-
-      <h2>CSS for Vimium UI</h2>
-      <div>
-        <textarea id="userDefinedLinkHintCss" class="code" type="text"></textarea>
-        <div class="example reset-link"><a href="#">Reset</a></div>
-      </div>
-      <div class="example">
-        These styles are applied to link hints, the Vomnibar, the help dialog, the exclusions
-        pop-up and the HUD.<br>
-        By default, this CSS is used to style the characters next to each link hint.<br>
-        <br>
-        These styles are used in addition to and take precedence over Vimium's default styles.
-      </div>
-
-      <header>Backup and Restore</header>
-
-      <h2>Backup</h2>
-      <a id="downloadBackup" download="vimium-options.json" href="#">Download backup</a>
-      <div class="example">Download a backup of your settings.</div>
-
-      <h2>Restore</h2>
-      <input id="uploadBackup" type="file" accept=".json" />
-      <div class="example">
-        Choose a backup file to restore.
+      <div id="footer">
+        <div id="footerWrapper">
+          <table id="footerTable">
+            <tr>
+              <td id="footerTableData">
+                <span id="helpText">
+                  Type <strong>?</strong> to show the help dialog.
+                  <br>
+                  Type <strong>Ctrl-Enter</strong> to save <i>all</i> options.
+                </span>
+              </td>
+              <td id="saveOptionsTableData" nowrap>
+                <button id="saveOptions" disabled="disabled">No changes</button>
+              </td>
+            </tr>
+          </table>
+        </div>
       </div>
     </div>
 
-    <div id="footer">
-      <div id="footerWrapper">
-        <table id="footerTable">
-          <tr>
-            <td id="footerTableData">
-              <span id="helpText">
-                Type <strong>?</strong> to show the help dialog.
-                <br>
-                Type <strong>Ctrl-Enter</strong> to save <i>all</i> options.
-              </span>
-            </td>
-            <td id="saveOptionsTableData" nowrap>
-              <button id="saveOptions" disabled="disabled">No changes</button>
-            </td>
-          </tr>
-        </table>
-      </div>
-    </div>
-  </div>
-
-  <template id="exclusionRuleTemplate">
-    <tr class="rule">
-      <td>
-        <input type="text" name="pattern" spellcheck="false" placeholder="URL pattern" />
-      </td>
-      <td>
-        <input type="text" name="passKeys" spellcheck="false" placeholder="All" />
-      </td>
-      <td>
-        <input type="button" class="remove" value="&#x2716;" />
-      </td>
-    </tr>
-  </template>
-</body>
-
+    <template id="exclusionRuleTemplate">
+      <tr class="rule">
+        <td>
+          <input type="text" name="pattern" spellcheck="false" placeholder="URL pattern" />
+        </td>
+        <td>
+          <input type="text" name="passKeys" spellcheck="false" placeholder="All" />
+        </td>
+        <td>
+          <input type="button" class="remove" value="&#x2716;" />
+        </td>
+      </tr>
+    </template>
+  </body>
 </html>

--- a/pages/options.js
+++ b/pages/options.js
@@ -9,6 +9,7 @@ const options = {
   nextPatterns: "string",
   previousPatterns: "string",
   regexFindMode: "boolean",
+  macOptionKeyFix: "boolean",
   ignoreKeyboardLayout: "boolean",
   scrollStepSize: "number",
   smoothScroll: "boolean",
@@ -23,6 +24,9 @@ const OptionsPage = {
     await Settings.onLoaded();
 
     const saveOptionsEl = document.querySelector("#saveOptions");
+
+    const isMacOS = KeyboardUtils.platform === "Mac";
+    if (isMacOS) document.getElementById("macos").style.display = "contents";
 
     const onUpdated = () => {
       saveOptionsEl.disabled = false;


### PR DESCRIPTION
## Description

This PR adds in support for <a-{key}> shortcuts in Vimium on MacOS. On MacOS, when the setting is enabled, Vimium will treat any \<a> and <a-{key}> presses as if keyboard layout is ignored, thereby avoiding Mac's øπ†îøñ ß¥µ∫ø¬ß (aka option symbols).

My apologies if the style isn't up to snuff - I'm somewhat scrappy and not exactly the most familiar with AirBnB style, but I'm happy to make revisions if you let me know what needs to be addressed!

Should fix #3197
Should fix #3666
Should fix #3662
Should fix #3284