### PR TITLE
add action=hover-and-scroll

### DIFF
--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -134,8 +134,9 @@ const COPY_LINK_TEXT = {
 const HOVER_LINK = {
   name: "hover",
   indicator: "Hover link",
+  doesScroll: false,
   linkActivator(link) {
-    new HoverMode(link);
+    new HoverMode(link, HOVER_LINK.doesScroll);
   },
 };
 const FOCUS_LINK = {
@@ -310,11 +311,14 @@ const LinkHints = {
     if (count == null) count = 1;
     if (mode == null) mode = OPEN_IN_CURRENT_TAB;
 
-    switch (registryEntry?.options.action) {
+    const action = registryEntry?.options.action;
+
+    switch (action) {
       case "copy-text":
         mode = COPY_LINK_TEXT;
         break;
-      case "hover":
+      case "hover": case "hover-and-scroll":
+        HOVER_LINK.doesScroll = action !== "hover";
         mode = HOVER_LINK;
         break;
       case "focus":
@@ -1508,10 +1512,13 @@ class WaitForEnter extends Mode {
 }
 
 class HoverMode extends Mode {
-  constructor(link) {
+  constructor(link, doesScroll) {
     super();
     super.init({ name: "hover-mode", singleton: "hover-mode", exitOnEscape: true });
     this.link = link;
+    if (doesScroll) {
+      Scroller.selectElement(link);
+    }
     DomUtils.simulateHover(this.link);
     this.onExit(() => DomUtils.simulateUnhover(this.link));
   }

--- a/content_scripts/scroller.js
+++ b/content_scripts/scroller.js
@@ -415,6 +415,10 @@ const Scroller = {
     return (element !== activatedElement) && isScrollableElement(element);
   },
 
+  selectElement(element) {
+    activatedElement = element;
+  },
+
   // Scroll the top, bottom, left and right of element into view. The is used by visual mode to
   // ensure the focus remains visible.
   scrollIntoView(element) {


### PR DESCRIPTION
## Description

This issue has been asked multiple times in this repo. We need a way to hover and element and switch vimium's keybinds to make it scrollable. With the changes I made (with the issue being better documented in https://github.com/philc/vimium/issues/4656,
I have created a new action for LinkHints called "hover-and-scroll." Using this will hover over and element and make the scroll bars around it scrollable.