### PR TITLE
Fixes Scroll instantly to next result in Find mode #4661

### DIFF
--- a/content_scripts/mode_find.js
+++ b/content_scripts/mode_find.js
@@ -477,7 +477,9 @@ const highlight = (textNode, startIndex, length) => {
     const screenHeight = globalThis.innerHeight;
     globalThis.scrollTo({
       top: globalThis.scrollY + rect.top + rect.height / 2 - screenHeight / 2,
-      behavior: "smooth",
+      // #4661: Since Chrome and Firefox scroll instantly to search results, we
+      // ignore Vimium's smoothScroll Setting and scroll instantly as well.
+      behavior: "instant",
     });
   }
 


### PR DESCRIPTION
Navigating between search results in find mode now happens instantly to match native Browser behavior.

## Description

This fixes #4661.
As requested by https://github.com/philc/vimium/issues/4661#issuecomment-2791582643 the fix now uses instant scroll behavior for find mode hard-coded instead of respecting the Vimium `smoothScroll` Setting. That way it will behave like the native browser search in Chromium / Firefox based browsers.

This is blocked by #4676 as find mode on the current master is broken.

Edit:
I successfully tested this based on the current master plus the suggested fix from #4676 **- which is not part of this PR -** in:
- Chromium Version 135.0.7049.84 (Official Build) Arch Linux (64-bit)
- Firefox 137.0.1 (64-bit) for Arch Linux