### PR TITLE
Add `goUp` options to pop URL anchor/fragment/hash & query string. Fixes #3763

### DIFF
--- a/background_scripts/all_commands.js
+++ b/background_scripts/all_commands.js
@@ -132,6 +132,7 @@ const allCommands = [
     advanced: true,
     options: {
       popAnchor: "Remove the anchor/fragment/hash from the URL, if present.",
+      popQuery: "Remove query parameters from the URL, if present.",
     },
   },
 

--- a/background_scripts/all_commands.js
+++ b/background_scripts/all_commands.js
@@ -130,6 +130,9 @@ const allCommands = [
     desc: "Go up the URL hierarchy",
     group: "navigation",
     advanced: true,
+    options: {
+      popAnchor: "Remove the anchor/fragment/hash from the URL, if present.",
+    },
   },
 
   {

--- a/content_scripts/mode_normal.js
+++ b/content_scripts/mode_normal.js
@@ -135,16 +135,17 @@ const NormalModeCommands = {
 
   // Url manipulation.
   goUp(count) {
-    let url = globalThis.location.href;
-    if (url.endsWith("/")) {
-      url = url.substring(0, url.length - 1);
+    const url = new URL(globalThis.location.href);
+
+    // Pop path segments.
+    if (url.pathname != "/") {
+      url.pathname = url.pathname.split("/").slice(0, -count).join("/");
+      url.search = "";
+      url.hash = "";
     }
 
-    let urlsplit = url.split("/");
-    // make sure we haven't hit the base domain yet
-    if (urlsplit.length > 3) {
-      urlsplit = urlsplit.slice(0, Math.max(3, urlsplit.length - count));
-      globalThis.location.href = urlsplit.join("/");
+    if (globalThis.location.href !== url.toString()) {
+      globalThis.location.href = url.toString();
     }
   },
 

--- a/content_scripts/mode_normal.js
+++ b/content_scripts/mode_normal.js
@@ -134,14 +134,22 @@ const NormalModeCommands = {
   },
 
   // Url manipulation.
-  goUp(count) {
+  goUp(count, { registryEntry }) {
+    let c = count;
     const url = new URL(globalThis.location.href);
 
+    // Pop anchor.
+    if (c > 0 && registryEntry.options.popAnchor && url.hash !== "") {
+      url.hash = "";
+      --c;
+    }
+
     // Pop path segments.
-    if (url.pathname != "/") {
-      url.pathname = url.pathname.split("/").slice(0, -count).join("/");
+    if (c > 0 && url.pathname != "/") {
+      url.pathname = url.pathname.split("/").slice(0, -c).join("/");
       url.search = "";
       url.hash = "";
+      --c;
     }
 
     if (globalThis.location.href !== url.toString()) {

--- a/content_scripts/mode_normal.js
+++ b/content_scripts/mode_normal.js
@@ -144,6 +144,13 @@ const NormalModeCommands = {
       --c;
     }
 
+    // Pop query params.
+    if (c > 0 && registryEntry.options.popQuery && url.search !== "") {
+      url.search = "";
+      url.hash = "";
+      --c;
+    }
+
     // Pop path segments.
     if (c > 0 && url.pathname != "/") {
       url.pathname = url.pathname.split("/").slice(0, -c).join("/");


### PR DESCRIPTION
## Description

This PR,

- Changes how `goUp` manipulates the URL, using a `URL` object to parse/get/set its components where possible.

- Adds 2 count-compatible Boolean options to `goUp`:
  - `popAnchor` removes the hash/anchor/fragment/hash from the URL.
  `example.com/a?b=c#d` → `example.com/a?b=c`.

  - `popQuery` removes query params and the hash from the URL.
  `example.com/a?b=c#d` → `example.com/a`.

## Usage

- `map gu goUp`  
  `example.com/a/b?c=d#e` → `example.com/a` → `example.com`

- `map gu goUp popAnchor`  
  `example.com/a/b?c=d#e` → `example.com/a/b?c=d` → `example.com/a` → `example.com`

- `map gu goUp popQuery`  
  `example.com/a/b?c=d#e` → `example.com/a/b` → `example.com/a` → `example.com`

- `map gu goUp popAnchor popQuery`  
  `example.com/a/b?c=d#e` → `example.com/a/b?c=d` → `example.com/a/b` → `example.com/a` → `example.com`

## Subdomains 🤔

#3763 also suggests popping subdomains, but it's unclear how/if port numbers should be manipulated when navigating up a subdomain. e.g., should `goUp` from `owo.example.com:1337` navigate to,
- `owo.example.com` (dropped port)?
- `example.com:1337` (dropped subdomain)?
- `example.com` (both dropped)?

IMO, there is no correct option here because it depends on what's at the URL, so would it be best to leave the host name as-is?