### PR TITLE
Address: unreadable input selection in default dark mode vomnibar #4729

### DIFF
--- a/pages/vomnibar_page.css
+++ b/pages/vomnibar_page.css
@@ -187,4 +187,9 @@ ul {
   #vomnibar li .title .match {
     color: white;
   }
+
+  #vomnibar input::selection {
+    background-color: #ffffff;
+    color: #000000;
+  }
 }


### PR DESCRIPTION
Very minor update to CSS to make vomnibar text visible when highlighting in dark mode