### PR TITLE
fixes #4481 missing LinkHint for YouTube comment textbox

### DIFF
--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -1144,6 +1144,7 @@ const LocalHints = {
         "menuitemcheckbox",
         "menuitemradio",
         "radio",
+        "textbox",
       ];
       if (role != null && clickableRoles.includes(role.toLowerCase())) {
         isClickable = true;


### PR DESCRIPTION
## Description

The text input on YouTube is a weird placeholder element when it's not focused yet. That's the reason why the existing LinkHints logic doesn't detect it as clickable. This element can be identified reliably by it's `role="textbox"` attribute, so this was added to the list of `clickableRoles`.

This seemed like the most simple and generic fix for issue #4481 that might also be beneficial on other sites.

I've tested the change locally in these environments:
- Firefox 141.0 (64-bit) Arch Linux
- Chromium Version 138.0.7204.168 (Official Build) Arch Linux (64-bit)
