### PR TITLE
Give keyMapping and searchEngines "code" class to enable monospace look

### DIFF
--- a/pages/options.html
+++ b/pages/options.html
@@ -35,7 +35,7 @@
         </div>
 
         <h2>Custom key mappings</h2>
-        <textarea name="keyMappings" type="text"></textarea>
+        <textarea name="keyMappings" type="text" class="code"></textarea>
         <div class="example">
           Enter commands to remap your keys. Available commands:<br>
           <pre
@@ -50,7 +50,7 @@ unmapAll
         </div>
 
         <h2>Custom search engines</h2>
-        <textarea name="searchEngines"></textarea>
+        <textarea name="searchEngines" class="code"></textarea>
         <div class="example">
           Add search-engine shortcuts to the Vomnibar. Format:<br>
           <pre


### PR DESCRIPTION
## Description

This gives the "Custom key mappings" and "Custom search engines" textareas the same styling as the "CSS for Vimium UI" field. Since "Custom key mappings" is vimscript, and "Custom search engines" seems like YAML, it's nice to view them in the same monospace font that the custom CSS field has
