### PR TITLE
Center align "Save changes" button label in Options

### DIFF
--- a/pages/options.css
+++ b/pages/options.css
@@ -311,6 +311,9 @@ footer {
 
 #save,
 #exclusion-add-button {
+  align-items: center;
+  display: flex;
+  justify-content: center;
   white-space: nowrap;
   width: 110px;
 }


### PR DESCRIPTION
## Description

Within the Options page, the `#save` button is displayed as "No changes"
(10 chars) on load. When `onUpdated()` is called in `pages/options.js`,
it turns into "Save changes" (12 chars). This commit ensures that the
update label is appropriately centered, even if that means less padding
on left/right, as opposed to having more padding on left/right in the
fixed size button.

