### PR TITLE
feat: suppress overlapping hints

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -70,6 +70,8 @@ w: https://www.wikipedia.org/w/index.php?title=Special:Search&search=%s Wikipedi
   waitForEnterForFilteredHints: true,
   helpDialog_showAdvancedCommands: false,
   ignoreKeyboardLayout: false,
+  // When true, hide overlapping link-hint markers so only one shows per overlapping region.
+  suppressOverlappingHintMarkers: true,
 };
 
 /*

--- a/pages/options.html
+++ b/pages/options.html
@@ -172,6 +172,15 @@ b: http://b.com/?q=%s description
           keyboards.
         </div>
 
+        <h2></h2>
+        <label>
+          <input name="suppressOverlappingHintMarkers" type="checkbox" />
+          Hide overlapping link-hint markers
+        </label>
+        <div class="example">
+          When hints overlap visually, show only one marker per overlapping region.
+        </div>
+
         <h2>Previous patterns</h2>
         <div>
           <input name="previousPatterns" type="text" />

--- a/pages/options.js
+++ b/pages/options.js
@@ -17,6 +17,7 @@ const options = {
   previousPatterns: "string",
   regexFindMode: "boolean",
   ignoreKeyboardLayout: "boolean",
+  suppressOverlappingHintMarkers: "boolean",
   scrollStepSize: "number",
   smoothScroll: "boolean",
   grabBackFocus: "boolean",


### PR DESCRIPTION
## Description

Adds a new user setting to control whether overlapping link-hint markers are visually de-duplicated. 
When enabled, only one marker is shown per overlapping region to reduce clutter.

### Motivation

Overlapping hints can stack and obscure each other in dense UIs.
Most of the overlapping hints on modern websites point to the same link to support tapping on mobile devices, since it's limited by the finger width.
Users may prefer either cleaner visuals or full visibility of all hints; this makes it configurable.

### Changes

* New setting: suppressOverlappingHintMarkers (default: true) in lib/settings.js.
* Options UI: Checkbox “Hide overlapping link-hint markers” added to pages/options.html.
* Options binding: Registered the setting in pages/options.js so it saves/restores with other preferences.
* Behavior gating: Calls to suppressOverlappingMarkers() in content_scripts/link_hints.js now respect the new setting.

### Default Behavior

* Enabled by default: overlapping markers are hidden except for one per overlapping region.
* Users can disable this in the Options page to show all overlapping markers.

### User-facing UI

* Options → “Hide overlapping link-hint markers” (pages/options.html).

### Testing

* Verified no linter errors.
* Manual checks:
    * Toggle setting on/off and launch link hints on dense pages.
    * With setting ON: only one marker is visible where hints overlap; rotation still functions.
    * With setting OFF: all overlapping markers display.