### PR TITLE
feat(UI): animate activated link hint (scale + fade-out) before cleanup

### DIFF
--- a/content_scripts/vimium.css
+++ b/content_scripts/vimium.css
@@ -118,6 +118,13 @@ div.internal-vimium-hint-marker {
   z-index: 2147483647;
 }
 
+/* Applied briefly when a hint is activated to fade it out before removal. */
+div.internal-vimium-hint-marker.vimium-hint-fade-out {
+  opacity: 0;
+  transform: scale(1.5);
+  transform-origin: center center;
+}
+
 div.internal-vimium-hint-marker span {
   color: #302505;
   font-family: Helvetica, Arial, sans-serif;


### PR DESCRIPTION
## Description

Adds a brief animation to the activated hint: it scales up and fades out while non-activated hints are hidden immediately. 
Hint markers are removed only after the animation completes.

### Motivation

Provides clearer visual confirmation of the chosen hint and improves perceived polish without impacting interaction speed.

### User-facing behavior

* Before: All hint markers disappeared instantly upon activation.
* After: The selected hint remains, scales to 1.5x, and fades to 0 opacity over the configured duration; others are hidden instantly. All markers are removed once the animation finishes.

### Testing

Open any page, trigger hints (f), choose a hint: activated marker should scale+fade while others hide immediately; markers should then be removed.
Validate no lingering elements or pointer-event issues post-animation.

![vimium-fadeout](https://github.com/user-attachments/assets/315a89fc-d077-4eb6-a790-f0b3fec3db32)