### PR TITLE
feat: passing link mode.name to lint marker's classname, added .bg-ta…

### DIFF
--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -380,7 +380,7 @@ class LinkHintsMode {
     // This count is used to rank equal-scoring hints when sorting, thereby making JavaScript's sort
     // stable.
     this.stableSortCount = 0;
-    this.hintMarkers = hintDescriptors.map((desc) => this.createMarkerFor(desc));
+    this.hintMarkers = hintDescriptors.map((desc) => this.createMarkerFor(desc, mode));
     this.markerMatcher = Settings.get("filterLinkHints") ? new FilterHints() : new AlphabetHints();
     this.markerMatcher.fillInMarkers(this.hintMarkers);
 
@@ -473,7 +473,7 @@ class LinkHintsMode {
   }
 
   // Creates a link marker for the given link.
-  createMarkerFor(desc) {
+  createMarkerFor(desc, mode) {
     const marker = new HintMarker();
     const isLocalMarker = desc.frameId === frameId;
     if (isLocalMarker) {
@@ -483,7 +483,7 @@ class LinkHintsMode {
       el.style.top = localHint.rect.top + "px";
       // Note that Vimium's CSS is user-customizable. We're adding the "vimiumHintMarker" class here
       // for users to customize. See further comments about this in vimium.css.
-      el.className = "vimium-reset internal-vimium-hint-marker vimiumHintMarker";
+      el.className = `vimium-reset internal-vimium-hint-marker vimiumHintMarker ${mode.name}`;
       Object.assign(marker, {
         element: el,
         localHint,

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -16,6 +16,12 @@ background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#FFF78
 border: 1px solid #E3BE23;
 }
 
+div > .vimiumHintMarker.bg-tab {
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#FFC485),
+  color-stop(100%,#FF9142));
+border: 1px solid #E39C22;
+}
+
 div > .vimiumHintMarker span {
 /* linkhint text */
 color: black;


### PR DESCRIPTION
Resolves #4783 #2049 

`open a link in a new tab` link hint is now visually distinguishable from `open in current tab`.

It can be achieved by exposing the mode's name directly to link_hint's classname.
Since all the mode names are kebab-cased, it's fully compatible with CSS classnames.
Also, other modes can be modified by adding additional styles in CSS.

I adjusted the hue slightly from the original color to choose a new one.
Please feel free to share any thoughts or preferences regarding the color.

|mode|before|after|
|---|---|---|
|open in current tab| <img width="1317" height="830" alt="image" src="https://github.com/user-attachments/assets/5e07980e-e575-4c3f-a10a-8f8b9156b8a8" />| <img width="1317" height="830" alt="image" src="https://github.com/user-attachments/assets/5e07980e-e575-4c3f-a10a-8f8b9156b8a8" />|
|open in new tab|<img width="1317" height="830" alt="image" src="https://github.com/user-attachments/assets/5e07980e-e575-4c3f-a10a-8f8b9156b8a8" />|<img width="1290" height="822" alt="image" src="https://github.com/user-attachments/assets/43124f10-ce08-4388-9d9c-870985a81101" />|

