### PR TITLE
Fix Firefox version retrieval logic by using isFirefox() check

### DIFF
--- a/background_scripts/bg_utils.js
+++ b/background_scripts/bg_utils.js
@@ -14,7 +14,7 @@ export function isFirefox() {
 }
 
 export async function getFirefoxVersion() {
-  return globalThis.browser ? (await browser.runtime.getBrowserInfo()).version : null;
+  return isFirefox() ? (await browser.runtime.getBrowserInfo()).version : null;
 }
 
 // TODO(philc): tabRecency imports bg_utils. We should resovle the cycle for the sake of clarity.


### PR DESCRIPTION
## Description

In Chrome Dev 144.0.7512.1, `globalThis.browser` is an object instead of `undefined`, which breaks the Firefox detection logic.

<img width="1246" height="626" alt="image" src="https://github.com/user-attachments/assets/d9d56c5a-118c-4803-9970-147b9a6be976" />


This PR update the code to use the more reliable version the Firefox check.

Related issue: #4785
