### PR TITLE
Fix getFirefoxVersion() throwing errors in chrome

### DIFF
--- a/background_scripts/bg_utils.js
+++ b/background_scripts/bg_utils.js
@@ -14,7 +14,7 @@ export function isFirefox() {
 }
 
 export async function getFirefoxVersion() {
-  return globalThis.browser ? (await browser.runtime.getBrowserInfo()).version : null;
+  return isFirefox() ? (await browser.runtime.getBrowserInfo()).version : null;
 }
 
 // TODO(philc): tabRecency imports bg_utils. We should resovle the cycle for the sake of clarity.


### PR DESCRIPTION
## Description

Avoid calling `browser.runtime.getBrowserInfo()` on chrome by relying on `isFirefox()` isntead of the presence of `globalThis.browser`. This prevents this uncaught error from being thrown in the service worker:

```
bg_utils.js:17 Uncaught (in promise) TypeError: browser.runtime.getBrowserInfo is not a function
 at Module.getFirefoxVersion (bg_utils.js:17:54)
 at initializeFrame (main.js:704:37)
 at main.js:764:36
 at async utils.js:272:24
```

Fixes: #4789
