### PR TITLE
fix typo noRepat -> noRepeat

### DIFF
--- a/background_scripts/all_commands.js
+++ b/background_scripts/all_commands.js
@@ -541,7 +541,7 @@ const allCommands = [
     group: "tabs",
     advanced: true,
     background: true,
-    noRepat: true,
+    noRepeat: true,
   },
 
   {


### PR DESCRIPTION
1 character change: fix typo noRepat -> noRepeat

Found a typo in the `closeOtherTabs` command in `all_commands.js` while working on my own feature. Thought I should put in a pr. 

All tests still pass with `./make.js test`