### PR TITLE
Move advanced flag from scrollRight to scrollToRight command

### DIFF
--- a/background_scripts/all_commands.js
+++ b/background_scripts/all_commands.js
@@ -74,7 +74,6 @@ const allCommands = [
     name: "scrollRight",
     desc: "Scroll right",
     group: "navigation",
-    advanced: true,
   },
 
   {
@@ -88,6 +87,7 @@ const allCommands = [
     name: "scrollToRight",
     desc: "Scroll all the way to the right",
     group: "navigation",
+    advanced: true,
   },
 
   {


### PR DESCRIPTION
In basic mode perhaps the intention was to show

```
 h Scroll left
 l Scroll right
```
instead of
```
 h Scroll left
zL Scroll all the way to the right
```
So I created a PR. Feel free to close if that was intentional.

![Untitled](https://github.com/user-attachments/assets/1f1fa286-39c1-478b-b7e1-845727470a55)
