### PR TITLE
Add noop command

### DIFF
--- a/background_scripts/all_commands.js
+++ b/background_scripts/all_commands.js
@@ -614,6 +614,14 @@ const allCommands = [
     noRepeat: true,
     topFrame: true,
   },
+
+  {
+    name: "noop",
+    desc: "No-op (do nothing); useful to override/unmap native browser mappings",
+    group: "misc",
+    noRepeat: true,
+    topFrame: true,
+  },
 ];
 
 export { allCommands };

--- a/content_scripts/mode_normal.js
+++ b/content_scripts/mode_normal.js
@@ -163,6 +163,9 @@ const NormalModeCommands = {
     });
   },
 
+  noop() {
+  },
+
   copyCurrentUrl() {
     chrome.runtime.sendMessage({ handler: "getCurrentTabUrl" }, function (url) {
       HUD.copyToClipboard(url);


### PR DESCRIPTION
This is useful to "unmap" native browser mappings; for example I sometimes accidentally press &lt;c-h> or &lt;c-b> instead of &lt;c-g> to find the next match, which opens the sidebar which I then need to hide with the mouse. It's pretty annoying.

With this, I can do:

	map <c-h> noop
	map <c-b> noop

And it won't do anything.

Tested locally in Firefox 145 and Chromium 143.0.7499.40

Fixes #4213