### PR TITLE
Fix the display of enabled keys in the action popup.

### DIFF
--- a/pages/action.js
+++ b/pages/action.js
@@ -5,7 +5,7 @@ import "../lib/settings.js";
 import * as bgUtils from "../background_scripts/bg_utils.js";
 import { ExclusionRulesEditor } from "./exclusion_rules_editor.js";
 
-const ActionPage = {
+export const ActionPage = {
   async init() {
     // Is it possible for the current tab's URL to change while this action popup is open?
     const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
@@ -123,7 +123,7 @@ const ActionPage = {
       const hasBlankPassKeysRule = rules.find((r) => r.passKeys.length == 0);
       caption = hasBlankPassKeysRule ? "No" : "Some";
     }
-    document.querySelector("#how-many-enabled").textContent = caption;
+    document.querySelector("#howManyEnabled").textContent = caption;
   },
 
   async onSave() {
@@ -162,7 +162,9 @@ const ActionPage = {
   },
 };
 
-document.addEventListener("DOMContentLoaded", async () => {
-  await Settings.onLoaded();
-  ActionPage.init();
-});
+if (!globalThis.isUnitTests) {
+  document.addEventListener("DOMContentLoaded", async () => {
+    await Settings.onLoaded();
+    ActionPage.init();
+  });
+}

--- a/tests/unit_tests/action_test.js
+++ b/tests/unit_tests/action_test.js
@@ -1,0 +1,47 @@
+import * as testHelper from "./test_helper.js";
+import "../../tests/unit_tests/test_chrome_stubs.js";
+import { ActionPage } from "../../pages/action.js";
+import { ExclusionRulesEditor } from "../../pages/exclusion_rules_editor.js";
+
+context("ActionPage", () => {
+  setup(async () => {
+    await testHelper.jsdomStub("pages/action.html");
+    await Settings.onLoaded();
+  });
+
+  const setupTest = async (rules) => {
+    const tab = { id: 1, url: "https://www.example.com/foo" };
+    stub(chrome.tabs, "query", () => Promise.resolve([tab]));
+    stub(chrome.tabs, "sendMessage", () => Promise.resolve());
+
+    stub(Settings, "get", (key) => key === "exclusionRules" ? rules : []);
+
+    stub(ExclusionRulesEditor, "init", () => {});
+    stub(ExclusionRulesEditor, "setForm", () => {});
+    stub(ExclusionRulesEditor, "getRules", () => rules);
+    stub(ExclusionRulesEditor, "addEventListener", () => {});
+
+    await ActionPage.init();
+  };
+
+  should("display 'Some' when some keys are excluded", async () => {
+    const rules = [{ pattern: "https://www.example.com/*", passKeys: "a" }];
+    await setupTest(rules);
+    const caption = document.getElementById("howManyEnabled");
+    assert.equal("Some", caption.textContent);
+  });
+
+  should("display 'No' when all keys are excluded", async () => {
+    const rules = [{ pattern: "https://www.example.com/*", passKeys: "" }];
+    await setupTest(rules);
+    const caption = document.getElementById("howManyEnabled");
+    assert.equal("No", caption.textContent);
+  });
+
+  should("display 'All' when no keys are excluded", async () => {
+    const rules = [];
+    await setupTest(rules);
+    const caption = document.getElementById("howManyEnabled");
+    assert.equal("All", caption.textContent);
+  });
+});


### PR DESCRIPTION
`syncEnabledKeysCaption` was using an incorrect ID selector.

This also adds test coverage for this feature.

This fixes #4733. The tests pass, and I loaded this pull request into Chrome and checked that the feature works there as well.