### PR TITLE
Add a CI config to check formatting and run tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  - pull_request
+  - push
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/puppeteer/puppeteer:23.11.1
+      # Run as root to fix permission issues with Github Actions workspace.
+      # SYS_ADMIN is recommended for running Chrome in Docker.
+      options: --user root --cap-add=SYS_ADMIN
+      env:
+        # Point Puppeteer to the Chrome binary installed in the pptruser home directory, since running as root changes $HOME.
+        PUPPETEER_CACHE_DIR: /home/pptruser/.cache/puppeteer
+
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+          cache: true
+
+      - name: Verify formatting
+        run: deno fmt --check
+
+      - name: Run tests
+        run: ./make.js test

--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,6 @@
 {
   "fmt": {
+    "exclude": ["icons/*.svg"],
     "lineWidth": 100
   },
   "imports": {

--- a/make.js
+++ b/make.js
@@ -317,7 +317,10 @@ async function testDom() {
   });
 
   const files = ["dom_tests.html"];
-  const browser = await puppeteer.launch();
+  const browser = await puppeteer.launch({
+    // When running in CI, this is run as root. This flag is needed to avoid https://crbug.com/638180.
+    args: [`--no-sandbox`],
+  });
   let success = true;
   for (const file of files) {
     const page = await browser.newPage();


### PR DESCRIPTION
This uses Github Actions to run `deno fmt --check` and then `./make.js test`. It also configures `deno fmt` to ignore the icon SVGs, and changes the DOM tests to launch Puppeteer with `--no-sandbox`.