### PR TITLE
Fix opening default Vomnibar search next to current tab

### DIFF
--- a/pages/vomnibar_page.js
+++ b/pages/vomnibar_page.js
@@ -288,13 +288,22 @@ class VomnibarUI {
         if (isUrl) {
           this.hide(() => this.launchUrl(query, openInNewTab));
         } else {
-          this.hide(() =>
-            chrome.runtime.sendMessage({
-              handler: "launchSearchQuery",
-              query,
-              openInNewTab,
-            })
-          );
+          if (openInNewTab) {
+            this.hide(() =>
+              chrome.runtime.sendMessage({
+                handler: "openUrlInNewTab",
+                url: query,
+              })
+            );
+          } else {
+            this.hide(() =>
+              chrome.runtime.sendMessage({
+                handler: "launchSearchQuery",
+                query,
+                openInNewTab,
+              })
+            );
+          }
         }
       }
     } else if (isPrimarySearchSuggestion(completion)) {


### PR DESCRIPTION
## Description

Unify the new-tab placement behavior for Vomnibar searches.

**Before**
- Default Vomnibar search (no engine keyword): new tab opens at the far right.
- Specific search (with engine keyword): new tab opens next to the focused tab.

**After**
- Default Vomnibar search (no engine keyword): new tab opens next to the focused tab.
- Specific search (with engine keyword): unchanged, still opens next to the focused tab.

