### PR TITLE
implement nvim-like langmap option

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Examples:
   showing a bookmark dialog is suppressed.
 - `map r reload hard` maps the r key to reloading the page, and also includes the "hard" option to
   hard-reload the page.
+- `mapkey ы s` maps one key to another.
+- `langmap фыва;asdf,aAbBzZ,cC,dD` maps multiple keys with `from_keys;to_keys` or `fT` pairs, separated by comma.
 - `unmap <c-d>` removes any mapping for ctrl+d and restores Chrome's default behavior.
 - `unmap r` removes any mapping for the r key.
 

--- a/pages/options.html
+++ b/pages/options.html
@@ -43,6 +43,8 @@
           >
 map j scrollDown
 map z2 setZoom level=2
+mapkey я z
+langmap aA,йцу;qwe
 unmap j
 unmapAll
 " this is a comment

--- a/tests/unit_tests/commands_test.js
+++ b/tests/unit_tests/commands_test.js
@@ -38,6 +38,11 @@ context("KeyMappingsParser", () => {
     assert.equal({ "a": "b" }, keyToMappedKey);
   });
 
+  should("handle langmap statements", () => {
+    const { keyToMappedKey } = KeyMappingsParser.parse("langmap фы;as,a\\bAB");
+    assert.equal({ "ф": "a", "ы": "s", "a": "b", "A": "B" }, keyToMappedKey);
+  });
+
   should("handle unmap statements", () => {
     const input = "mapkey a b \n unmap a";
     const { keyToMappedKey } = KeyMappingsParser.parse(input);


### PR DESCRIPTION
## Description

This PR adds a **Neovim-like `langmap` option** to Vimium, inspired by [`:help 'langmap'`](https://neovim.io/doc/user/options.html#'langmap').

The `langmap` option allows mapping multiple keys with a single declaration. Instead of defining many individual `mapkey` statements, users can specify keyboard layout mappings compactly.

Examples:

Map keys positionally using a semicolon-separated syntax:

```langmap йцукен;qwerty```

Map keys pairwise without a separator:

```langmap йqцwуeкrеtнy```

Or combine both syntaxes in a single declaration:

```langmap йцукен;qwert,фa,ыs```

This makes it easier to support non-Latin keyboard layouts while keeping Vimium keybindings consistent.
