### PR TITLE
feat: add tab group support (skip collapsed groups, zc/zj/zk navigation)

### DIFF
--- a/background_scripts/all_commands.js
+++ b/background_scripts/all_commands.js
@@ -494,6 +494,30 @@ const allCommands = [
   },
 
   {
+    name: "collapseTabGroup",
+    desc: "Collapse current tab's group",
+    group: "tabs",
+    background: true,
+    noRepeat: true,
+  },
+
+  {
+    name: "previousTabGroup",
+    desc: "Switch to previous tab group",
+    group: "tabs",
+    background: true,
+    noRepeat: true,
+  },
+
+  {
+    name: "nextTabGroup",
+    desc: "Switch to next tab group",
+    group: "tabs",
+    background: true,
+    noRepeat: true,
+  },
+
+  {
     name: "removeTab",
     desc: "Close current tab",
     group: "tabs",

--- a/background_scripts/commands.js
+++ b/background_scripts/commands.js
@@ -482,6 +482,9 @@ const defaultKeyMappings = {
   "zi": "zoomIn",
   "zo": "zoomOut",
   "z0": "zoomReset",
+  "zc": "collapseTabGroup",
+  "zj": "previousTabGroup",
+  "zk": "nextTabGroup",
 
   // Marks
   "m": "Marks.activateCreateMode",

--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -340,6 +340,22 @@ const BackgroundCommands = {
     });
   },
   toggleMuteTab,
+  // Tab group commands (Chrome only; no-op on Firefox).
+  async collapseTabGroup({ tab }) {
+    if (bgUtils.isFirefox() || !chrome.tabGroups || tab.groupId == -1) return;
+    const tabs = await chrome.tabs.query({ currentWindow: true });
+    let nextTab = tabs.find((t) => t.index > tab.index && t.groupId != tab.groupId) ||
+      tabs.findLast((t) => t.index < tab.index && t.groupId != tab.groupId);
+    if (!nextTab) nextTab = await chrome.tabs.create({}); // All tabs are in this group.
+    await chrome.tabs.update(nextTab.id, { active: true });
+    chrome.tabGroups.update(tab.groupId, { collapsed: true });
+  },
+  previousTabGroup({ tab }) {
+    return goToTabGroup(tab, -1);
+  },
+  nextTabGroup({ tab }) {
+    return goToTabGroup(tab, 1);
+  },
   moveTabLeft: moveTab,
   moveTabRight: moveTab,
 
@@ -464,11 +480,33 @@ async function removeTabsRelative(direction, { count, tab }) {
   await chrome.tabs.remove(toRemove.map((t) => t.id));
 }
 
+// Jump to the next (direction=1) or previous (direction=-1) tab group.
+async function goToTabGroup(tab, direction) {
+  if (bgUtils.isFirefox() || !chrome.tabGroups) return;
+  const tabs = await chrome.tabs.query({ currentWindow: true });
+  const inDifferentGroup = (t) => t.groupId != -1 && t.groupId != tab.groupId;
+  const target = direction > 0
+    ? tabs.find((t) => t.index > tab.index && inDifferentGroup(t))
+    : tabs.findLast((t) => t.index < tab.index && inDifferentGroup(t));
+  if (target) {
+    await chrome.tabGroups.update(target.groupId, { collapsed: false });
+    chrome.tabs.update(target.id, { active: true });
+  }
+}
+
 // Selects a tab before or after the currently selected tab.
 // - direction: "next", "previous", "first" or "last".
 function selectTab(direction, { count, tab }) {
-  chrome.tabs.query(visibleTabsQueryArgs, function (tabs) {
+  chrome.tabs.query(visibleTabsQueryArgs, async function (tabs) {
     if (tabs.length > 1) {
+      // On Chrome, skip tabs in collapsed tab groups.
+      if (!bgUtils.isFirefox() && chrome.tabGroups) {
+        const groups = await chrome.tabGroups.query({ windowId: tab.windowId, collapsed: true });
+        const collapsedGroupIds = new Set(groups.map((g) => g.id));
+        tabs = tabs.filter((t) => t.id === tab.id || !collapsedGroupIds.has(t.groupId));
+        if (tabs.length <= 1) return;
+      }
+
       const toSelect = (() => {
         switch (direction) {
           case "next":

--- a/background_scripts/main.js
+++ b/background_scripts/main.js
@@ -340,14 +340,15 @@ const BackgroundCommands = {
     });
   },
   toggleMuteTab,
-  // Tab group commands (Chrome only; no-op on Firefox).
   async collapseTabGroup({ tab }) {
-    if (bgUtils.isFirefox() || !chrome.tabGroups || tab.groupId == -1) return;
+    if (!chrome.tabGroups || tab.groupId == -1) return;
     const tabs = await chrome.tabs.query({ currentWindow: true });
     let nextTab = tabs.find((t) => t.index > tab.index && t.groupId != tab.groupId) ||
       tabs.findLast((t) => t.index < tab.index && t.groupId != tab.groupId);
-    if (!nextTab) nextTab = await chrome.tabs.create({}); // All tabs are in this group.
-    await chrome.tabs.update(nextTab.id, { active: true });
+    if (!nextTab && !bgUtils.isFirefox()) {
+      nextTab = await chrome.tabs.create({});
+    }
+    if (nextTab) await chrome.tabs.update(nextTab.id, { active: true });
     chrome.tabGroups.update(tab.groupId, { collapsed: true });
   },
   previousTabGroup({ tab }) {
@@ -482,7 +483,7 @@ async function removeTabsRelative(direction, { count, tab }) {
 
 // Jump to the next (direction=1) or previous (direction=-1) tab group.
 async function goToTabGroup(tab, direction) {
-  if (bgUtils.isFirefox() || !chrome.tabGroups) return;
+  if (!chrome.tabGroups) return;
   const tabs = await chrome.tabs.query({ currentWindow: true });
   const inDifferentGroup = (t) => t.groupId != -1 && t.groupId != tab.groupId;
   const target = direction > 0
@@ -499,8 +500,8 @@ async function goToTabGroup(tab, direction) {
 function selectTab(direction, { count, tab }) {
   chrome.tabs.query(visibleTabsQueryArgs, async function (tabs) {
     if (tabs.length > 1) {
-      // On Chrome, skip tabs in collapsed tab groups.
-      if (!bgUtils.isFirefox() && chrome.tabGroups) {
+      // Skip tabs in collapsed tab groups.
+      if (chrome.tabGroups) {
         const groups = await chrome.tabGroups.query({ windowId: tab.windowId, collapsed: true });
         const collapsedGroupIds = new Set(groups.map((g) => g.id));
         tabs = tabs.filter((t) => t.id === tab.id || !collapsedGroupIds.has(t.groupId));

--- a/manifest.json
+++ b/manifest.json
@@ -25,6 +25,7 @@
   ],
   "permissions": [
     "tabs",
+    "tabGroups",
     "bookmarks",
     "history",
     "storage",


### PR DESCRIPTION
## Description

Fixes #4693
Related #3937, #4639

This PR adds tab group support to Vimium:

**1. Skip collapsed tab groups when navigating (J/K/gt/gT/g0/g$)**

Chrome and Firefox's native `Ctrl+Tab` skips collapsed tab groups, but Vimium's `J/K` currently navigates into them. This aligns Vimium's behavior with Chrome and Firefox's native UX.

**2. New commands for tab group navigation (Vim fold-style keybindings)**


| Key | Command | Description |
|-----|---------|-------------|
| `zc` | `collapseTabGroup` | Collapse current tab's group |
| `zj` | `previousTabGroup` | Switch to previous tab group |
| `zk` | `nextTabGroup` | Switch to next tab group |

These follow Vim's fold navigation conventions (`z` prefix, `j`/`k` for direction).

  Notes:
  - Adds `tabGroups` permission (no new user-facing permission warnings)
  - Works on any browser with tabGroups API support (Chrome, Firefox 140+); no-ops on older versions
  - Users can still access tabs in collapsed groups via `T` (Vomnibar tab search)