### PR TITLE
Remove 'f' from default linkHintCharacters

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -11,7 +11,7 @@ const defaultOptions = {
   scrollStepSize: 60,
   smoothScroll: true,
   keyMappings: "# Insert your preferred key mappings here.",
-  linkHintCharacters: "sadfjklewcmpgh",
+  linkHintCharacters: "sadjklewcmpgh",
   linkHintNumbers: "0123456789",
   filterLinkHints: false,
   hideHud: false,


### PR DESCRIPTION
## Summary
- Removes `f` from the default `linkHintCharacters` setting to prevent accidental link clicks when pressing `f` twice (once to activate hints, once matching a hint label starting with `f`).

## Test plan
- Press `f` to activate link hints and verify no hint labels contain the letter `f`
- Confirm all other hint characters still work as expected