### PR TITLE
[fix] Test configuration

### DIFF
--- a/make.js
+++ b/make.js
@@ -256,13 +256,27 @@ async function buildStorePackage() {
   ]);
 }
 
+function collectFiles(dir) {
+  const results = [];
+  for (const entry of Deno.readDirSync(dir)) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory) {
+      results.push(...collectFiles(fullPath));
+    } else if (entry.isFile) {
+      results.push(fullPath);
+    }
+  }
+  return results.sort();
+}
+
 async function runUnitTests() {
   // Import every test file.
   const dir = path.join(projectPath, "tests/unit_tests");
-  const files = Array.from(Deno.readDirSync(dir)).map((f) => f.name).sort();
+  const files = collectFiles(dir);
+
   for (let f of files) {
     if (f.endsWith("_test.js")) {
-      await import(path.join(dir, f));
+      await import(f);
     }
   }
 

--- a/tests/unit_tests/ui_component_test.js
+++ b/tests/unit_tests/ui_component_test.js
@@ -2,6 +2,7 @@ import * as testHelper from "./test_helper.js";
 import "../../lib/utils.js";
 import "../../lib/dom_utils.js";
 import "../../content_scripts/ui_component.js";
+import "../../lib/settings.js";
 
 function stubPostMessage(iframeEl, fn) {
   if (!iframeEl || !fn) throw new Error("iframeEl and fn are required.");
@@ -19,6 +20,7 @@ context("UIComponent", () => {
     // Which page we load doesn't matter; we just need any DOM.
     await testHelper.jsdomStub("pages/help_dialog_page.html");
     stub(Utils, "isFirefox", () => false);
+    await Settings.load();
   });
 
   teardown(() => {


### PR DESCRIPTION
- Collect tests in sub-directories.
- Fix loading of settings for tests.

## Description

This PR is based on discussion threads in #4880.

The `Settings.load()` call is necessary because the tests would fail to run on my machine and I was getting the following error output.
``` bash
$ ./make.js test
run: started
test-unit: started
Fail "UIComponent: focus the frame when showing"
Error: Getting the setting userDefinedLinkHintCss before settings have been loaded.
    at Object.get (file:///home/charalampos.kardaris/src/vimium/lib/settings.js:137:13)
    at Object.injectUserCss (file:///home/charalampos.kardaris/src/vimium/lib/dom_utils.js:566:34)
    at UIComponent.load (file:///home/charalampos.kardaris/src/vimium/content_scripts/ui_component.js:63:14)
    at Object.<anonymous> (file:///home/charalampos.kardaris/src/vimium/tests/unit_tests/ui_component_test.js:35:13)
    at Object.runTest (file:///home/charalampos.kardaris/src/vimium/tests/vendor/shoulda.js:253:29)
    at eventLoopTick (ext:core/01_core.js:187:7)
    at async Object.runContext (file:///home/charalampos.kardaris/src/vimium/tests/vendor/shoulda.js:214:9)
    at async Object.run (file:///home/charalampos.kardaris/src/vimium/tests/vendor/shoulda.js:187:7)
    at async runUnitTests (file:///home/charalampos.kardaris/src/vimium/make.js:283:10)
    at async Task.<anonymous> (file:///home/charalampos.kardaris/src/vimium/make.js:351:19)
---
TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
    at Object.<anonymous> (file:///home/charalampos.kardaris/src/vimium/tests/unit_tests/ui_component_test.js:28:25)
    at Object.runTest (file:///home/charalampos.kardaris/src/vimium/tests/vendor/shoulda.js:261:38)
    at eventLoopTick (ext:core/01_core.js:187:7)
    at async Object.runContext (file:///home/charalampos.kardaris/src/vimium/tests/vendor/shoulda.js:214:9)
    at async Object.run (file:///home/charalampos.kardaris/src/vimium/tests/vendor/shoulda.js:187:7)
    at async runUnitTests (file:///home/charalampos.kardaris/src/vimium/make.js:283:10)
    at async Task.<anonymous> (file:///home/charalampos.kardaris/src/vimium/make.js:351:19)
    at async Promise.all (index 0)
    at async TaskRegistry.execute (https://deno.land/x/drake@v1.5.1/lib/tasks.ts:446:5)
    at async TaskRegistry.run (https://deno.land/x/drake@v1.5.1/lib/tasks.ts:379:9)
Fail (1/244)
error: test-unit failed
```