### PR TITLE
Treat spaceless queries with a trailing / as hostnames

### DIFF
--- a/lib/url_utils.js
+++ b/lib/url_utils.js
@@ -83,6 +83,9 @@ const UrlUtils = {
     // Allow IPv4 addresses
     if (/^(\d{1,3}\.){3}\d{1,3}$/.test(hostName)) return true;
 
+    // Identify as URL if it ends with a '/' (we already checked it has no spaces)
+    if (str.endsWith("/")) return true;
+
     // Fallback: no URL
     return false;
   },


### PR DESCRIPTION
## Description

Treat spaceless queries with a trailing / as hostnames to make it easier to access non-standard TLDs

Closes #4890