### PR TITLE
Pass `Escape` if permanent insert mode is active

### DIFF
--- a/content_scripts/mode_insert.js
+++ b/content_scripts/mode_insert.js
@@ -49,7 +49,9 @@ class InsertMode extends Mode {
 
         if (!this.permanent) {
           this.exit();
+          return this.suppressEvent;
         }
+        return this.passEventToPage;
       } else {
         return this.passEventToPage;
       }


### PR DESCRIPTION
# Description

Many web pages handle `Escape` to dismiss an editable input field, e.g. Todoist's "Quick Add" or YouTube Music's search field. Before this change Vimium when a user hits `Escape` Todoist doesn't dismiss the dialog, the same happens with YouTube Music and probably many more web apps. With this improvement everything works as expected.

# Demo 

## Before

[vimium-before.webm](https://github.com/user-attachments/assets/bd82336e-8774-47a9-8172-202bef15ceca)

## After 

[vimium-after.webm](https://github.com/user-attachments/assets/f870717f-e0d7-4d08-a4e2-6c2f286df9be)
