### PR TITLE
Improve HTML escaping in Vomnibar suggestions

### DIFF
--- a/background_scripts/completion/completers.js
+++ b/background_scripts/completion/completers.js
@@ -89,7 +89,9 @@ export class Suggestion {
     if (this.isCustomSearch) {
       this.html = `\
 <div class="top-half">
-   <span class="source ${insertTextClass}">${insertTextIndicator}</span><span class="source">${this.description}</span>
+   <span class="source ${insertTextClass}">${insertTextIndicator}</span><span class="source">${
+        Utils.escapeHtml(this.description)
+      }</span>
    <span class="title">${this.highlightQueryTerms(Utils.escapeHtml(this.title))}</span>
    ${relevancyHtml}
  </div>\
@@ -97,7 +99,9 @@ export class Suggestion {
     } else {
       this.html = `\
 <div class="top-half">
-   <span class="source ${insertTextClass}">${insertTextIndicator}</span><span class="source">${this.description}</span>
+   <span class="source ${insertTextClass}">${insertTextIndicator}</span><span class="source">${
+        Utils.escapeHtml(this.description)
+      }</span>
    <span class="title">${this.highlightQueryTerms(Utils.escapeHtml(this.title))}</span>
  </div>
  <div class="bottom-half">

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -71,7 +71,11 @@ const Utils = {
   })(),
 
   escapeHtml(string) {
-    return string.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    return string.replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
   },
 
   // Generates a unique ID

--- a/tests/unit_tests/completion/completers_test.js
+++ b/tests/unit_tests/completion/completers_test.js
@@ -416,6 +416,17 @@ context("suggestions", () => {
     assert.isTrue(suggestion.generateHtml({}).indexOf("title &lt;span&gt;") >= 0);
   });
 
+  should("escape html in descriptions", () => {
+    const suggestion = new Suggestion({
+      queryTerms: ["queryterm"],
+      description: "tab <span>",
+      url: "url",
+      title: "title",
+      relevancyFunction: returns(1),
+    });
+    assert.isTrue(suggestion.generateHtml({}).indexOf("tab &lt;span&gt;") >= 0);
+  });
+
   should("highlight query words", () => {
     const suggestion = new Suggestion({
       queryTerms: ["ninj", "words"],

--- a/tests/unit_tests/utils_test.js
+++ b/tests/unit_tests/utils_test.js
@@ -149,6 +149,23 @@ context("extractQuery", () => {
   });
 });
 
+context("escapeHtml", () => {
+  should("escape HTML special characters", () => {
+    assert.equal("&amp;", Utils.escapeHtml("&"));
+    assert.equal("&lt;", Utils.escapeHtml("<"));
+    assert.equal("&gt;", Utils.escapeHtml(">"));
+    assert.equal("&quot;", Utils.escapeHtml('"'));
+    assert.equal("&#39;", Utils.escapeHtml("'"));
+  });
+
+  should("escape a string with multiple special characters", () => {
+    assert.equal(
+      "&lt;a href=&quot;foo&quot;&gt;bar &amp; baz&#39;s&lt;/a&gt;",
+      Utils.escapeHtml('<a href="foo">bar & baz\'s</a>'),
+    );
+  });
+});
+
 context("pick", () => {
   should("omit properties", () => {
     assert.equal({ a: 1, b: 2 }, Utils.pick({ a: 1, b: 2, c: 3 }, ["a", "b", "d"]));


### PR DESCRIPTION
## Description

This change hardens the Vomnibar against potential HTML injection by:
- Updating Utils.escapeHtml to escape all special characters (&, <, >, ", ').
- Ensuring this.description is escaped in Suggestion.generateHtml.
- Adding unit tests for Utils.escapeHtml and Suggestion descriptions.

While these fields were mostly safe due to being rendered in text nodes or being user-configured, these improvements align with best practices and provide defense-in-depth.

This change escapes HTML in custom search engine descriptions