### PR TITLE
fix: use documentReady instead of documentComplete in HUD methods

### DIFF
--- a/content_scripts/hud.js
+++ b/content_scripts/hud.js
@@ -177,14 +177,14 @@ const HUD = {
   // * events.
   // * the HUD shouldn't be active for this frame while any of the copy/paste commands are running.
   async copyToClipboard(text) {
-    await DomUtils.documentComplete();
+    await DomUtils.documentReady();
     await this.init();
     this.hudUI.postMessage({ name: "copyToClipboard", data: text });
   },
 
   async pasteFromClipboard(pasteListener) {
     this.pasteListener = pasteListener;
-    await DomUtils.documentComplete();
+    await DomUtils.documentReady();
     await this.init();
     this.tween.fade(0, 0);
     this.hudUI.postMessage({ name: "pasteFromClipboard" });

--- a/content_scripts/hud.js
+++ b/content_scripts/hud.js
@@ -74,7 +74,7 @@ const HUD = {
 
   // duration - if omitted, the message will show until dismissed.
   async show(text, duration) {
-    await DomUtils.documentComplete();
+    await DomUtils.documentReady();
     clearTimeout(this._showForDurationTimerId);
     // @hudUI.activate will take charge of making it visible
     await this.init(false);
@@ -88,7 +88,7 @@ const HUD = {
 
   async showFindMode(findMode = null) {
     this.findMode = findMode;
-    await DomUtils.documentComplete();
+    await DomUtils.documentReady();
     await this.init();
     this.hudUI.show({ name: "showFindMode" });
     this.tween.fade(1.0, 150);


### PR DESCRIPTION
## Problem

On pages whose `load` event is delayed (slow external resources, network stalls,
or intentionally hung requests), pressing `yy` to copy the URL silently does
nothing: the URL is never written to the clipboard and the \"Yanked\" feedback
HUD never appears.

Root cause: `HUD.show()`, `HUD.showFindMode()`, `HUD.copyToClipboard()`, and
`HUD.pasteFromClipboard()` all call `await DomUtils.documentComplete()`, which
waits for the `load` event. If that event is delayed, all HUD operations are
blocked for the same duration.

## Fix

Replace `documentComplete()` (waits for `load`) with `documentReady()` (waits
for `DOMContentLoaded`) in all four methods.

`documentReady()` already handles all readyState cases correctly: it resolves
immediately when `document.readyState !== \"loading\"` and only adds a
`DOMContentLoaded` listener when the page is still in the loading state.
The HUD is a `chrome-extension://` iframe overlay with its own independent
lifecycle — it does not depend on the host page's external resources finishing.

`showClipboardUnavailableMessage` is intentionally left on `documentComplete()`
since it is only emitted after a clipboard operation has already been attempted.

## Testing

1. Open a page that stalls at the `load` event (e.g. one with a slow/hanging
   external resource, or use DevTools to throttle network after DOMContentLoaded).
2. Press `yy` — before this fix the HUD would stay silent until the page fully
   loaded; after the fix the \"Yanked\" notification appears immediately and the
   URL is in the clipboard.
3. Verify `yy` still works normally on fully-loaded pages.