### PR TITLE
Change the google suggestquery completion url to use https

### DIFF
--- a/background_scripts/completion/search_engines.js
+++ b/background_scripts/completion/search_engines.js
@@ -50,7 +50,7 @@ class BaseEngine {
 export class Google extends BaseEngine {
   constructor() {
     super({
-      engineUrl: "http://suggestqueries.google.com/complete/search?client=chrome&q=%s",
+      engineUrl: "https://suggestqueries.google.com/complete/search?client=chrome&q=%s",
       regexps: ["^https?://[a-z]+\\.google\\.(com|ie|co\\.(uk|jp)|ca|com\\.au)/"],
       example: {
         searchUrl: "https://www.google.com/search?q=%s",
@@ -70,7 +70,7 @@ export class GoogleMaps extends BaseEngine {
   constructor() {
     super({
       engineUrl:
-        `http://suggestqueries.google.com/complete/search?client=chrome&ds=yt&q=${googleMapsPrefix}%s`,
+        `https://suggestqueries.google.com/complete/search?client=chrome&ds=yt&q=${googleMapsPrefix}%s`,
       regexps: ["^https?://[a-z]+\\.google\\.(com|ie|co\\.(uk|jp)|ca|com\\.au)/maps"],
       example: {
         searchUrl: "https://www.google.com/maps?q=%s",
@@ -94,7 +94,7 @@ search.\
 export class Youtube extends BaseEngine {
   constructor() {
     super({
-      engineUrl: "http://suggestqueries.google.com/complete/search?client=chrome&ds=yt&q=%s",
+      engineUrl: "https://suggestqueries.google.com/complete/search?client=chrome&ds=yt&q=%s",
       regexps: ["^https?://[a-z]+\\.youtube\\.com/results"],
       example: {
         searchUrl: "https://www.youtube.com/results?search_query=%s",


### PR DESCRIPTION
## Description

search_engines.js use http for the google suggestqueries url. While it seems like browsers upgrade to TLS automatically, at least Firefox do, it would be better to be explicit about it. In case someone is running a browser which doesn't upgrade, unencrypted queries would leak.

Changed http to https in three places, for Google, Google Maps and Youtube queries.