### PR TITLE
Marks: fix local marks not restoring position in internal scrollable elements

### DIFF
--- a/content_scripts/marks.js
+++ b/content_scripts/marks.js
@@ -20,9 +20,20 @@ const Marks = {
   },
 
   getMarkString() {
+    let localScrollX = 0;
+    let localScrollY = 0;
+    if (globalThis.Scroller) {
+      const scrollableEl = Scroller.activeElement();
+      if (scrollableEl) {
+        localScrollX = scrollableEl.scrollLeft;
+        localScrollY = scrollableEl.scrollTop;
+      }
+    }
     return JSON.stringify({
       scrollX: globalThis.scrollX,
       scrollY: globalThis.scrollY,
+      localScrollX,
+      localScrollY,
       hash: globalThis.location.hash,
     });
   },
@@ -117,10 +128,19 @@ const Marks = {
               if (markString != null) {
                 this.setPreviousPosition();
                 const position = JSON.parse(markString);
-                if (position.hash && (position.scrollX === 0) && (position.scrollY === 0)) {
+                if (position.hash && (position.scrollX === 0) && (position.scrollY === 0) && !position.localScrollX && !position.localScrollY) {
                   globalThis.location.hash = position.hash;
                 } else {
                   globalThis.scrollTo(position.scrollX, position.scrollY);
+                  if ("localScrollX" in position) {
+                    if (globalThis.Scroller) {
+                      const scrollableEl = Scroller.activeElement();
+                      if (scrollableEl) {
+                        scrollableEl.scrollLeft = position.localScrollX;
+                        scrollableEl.scrollTop = position.localScrollY;
+                      }
+                    }
+                  }
                 }
                 this.showMessage("Jumped to local mark", keyChar);
               } else {

--- a/content_scripts/scroller.js
+++ b/content_scripts/scroller.js
@@ -450,6 +450,14 @@ const Scroller = {
       }
     }
   },
+
+  activeElement() {
+    if (!activatedElement || !document.body.contains(activatedElement)) {
+      activatedElement = (getScrollingElement() && firstScrollableElement()) ||
+        getScrollingElement();
+    }
+    return activatedElement;
+  },
 };
 
 const getSpecialScrollingElement = function () {


### PR DESCRIPTION
## Description

**Rationale:**
Currently, Vimium's local marks (`ma`, `` `a ``) fail to jump back to the correct scroll position on websites that use an internal `div` for scrolling (which is increasingly common in modern SPAs like Twitter, Reddit, etc.). 

The bug occurs because `Marks` only saves and restores `globalThis.scrollX` and `globalThis.scrollY`, which both remain `0` when an internal container is scrolled.

**Changes made:**
- Added a simple `activeElement()` helper in `Scroller` to expose the currently active scrolling element (ensuring it's still in the DOM).
- Updated `marks.js` to optionally record `localScrollX` and `localScrollY` alongside the window scroll values.
- Updated the goto logic to restore the internal container's scroll position if those values exist.