### PR TITLE
Expose data-message-name on the HUD, so it can be styled with user CSS

### DIFF
--- a/content_scripts/hud.js
+++ b/content_scripts/hud.js
@@ -73,12 +73,14 @@ const HUD = {
   },
 
   // duration - if omitted, the message will show until dismissed.
-  async show(text, duration) {
+  // messageName - an optional identifier for this message, exposed as a data attribute so the HUD
+  // UI for each message can be targeted by a user's custom CSS. See #3112.
+  async show(text, duration, messageName) {
     await DomUtils.documentComplete();
     clearTimeout(this._showForDurationTimerId);
     // @hudUI.activate will take charge of making it visible
     await this.init(false);
-    this.hudUI.show({ name: "show", text });
+    this.hudUI.show({ name: "show", text, messageName });
     this.tween.fade(1.0, 150);
 
     if (duration != null) {

--- a/content_scripts/link_hints.js
+++ b/content_scripts/link_hints.js
@@ -67,31 +67,31 @@ class HintDescriptor {
   }
 }
 
-// The "name" property below is a short-form name to appear in the link-hints mode's name. It's for
-// debug only.
-//
+// The "name" property below appears in the link-hints mode's name (e.g.
+// "link-hints/open-in-current-tab"), which appears in the HUD's data-message-name attribute. This
+// allows users to write CSS for each HUD message (hiding some of them).
 const isMac = KeyboardUtils.platform === "Mac";
 const OPEN_IN_CURRENT_TAB = {
-  name: "curr-tab",
+  name: "open-in-current-tab",
   indicator: "Open link in current tab",
 };
 const OPEN_IN_NEW_BG_TAB = {
-  name: "bg-tab",
+  name: "open-in-new-background-tab",
   indicator: "Open link in new tab",
   clickModifiers: { metaKey: isMac, ctrlKey: !isMac },
 };
 const OPEN_IN_NEW_FG_TAB = {
-  name: "fg-tab",
+  name: "open-in-new-foreground-tab",
   indicator: "Open link in new tab and switch to it",
   clickModifiers: { shiftKey: true, metaKey: isMac, ctrlKey: !isMac },
 };
 const OPEN_WITH_QUEUE = {
-  name: "queue",
+  name: "open-with-queue",
   indicator: "Open multiple links in new tabs",
   clickModifiers: { metaKey: isMac, ctrlKey: !isMac },
 };
 const COPY_LINK_URL = {
-  name: "link",
+  name: "copy-link-url",
   indicator: "Copy link URL to Clipboard",
   linkActivator(link) {
     if (link.href != null) {
@@ -106,14 +106,14 @@ const COPY_LINK_URL = {
   },
 };
 const OPEN_INCOGNITO = {
-  name: "incognito",
+  name: "open-incognito",
   indicator: "Open link in incognito window",
   linkActivator(link) {
     chrome.runtime.sendMessage({ handler: "openUrlInIncognito", url: link.href });
   },
 };
 const DOWNLOAD_LINK_URL = {
-  name: "download",
+  name: "download-link-url",
   indicator: "Download link URL",
   clickModifiers: { altKey: true, ctrlKey: false, metaKey: false },
 };
@@ -132,14 +132,14 @@ const COPY_LINK_TEXT = {
   },
 };
 const HOVER_LINK = {
-  name: "hover",
+  name: "hover-link",
   indicator: "Hover link",
   linkActivator(link) {
     new HoverMode(link);
   },
 };
 const FOCUS_LINK = {
-  name: "focus",
+  name: "focus-link",
   indicator: "Focus link",
   linkActivator(link) {
     link.focus();
@@ -391,7 +391,7 @@ class LinkHintsMode {
 
     this.hintMode = new Mode();
     this.hintMode.init({
-      name: `hint/${this.mode.name}`,
+      name: `link-hints/${this.mode.name}`,
       indicator: false,
       singleton: "link-hints-mode",
       suppressAllKeyboardEvents: true,

--- a/content_scripts/mode.js
+++ b/content_scripts/mode.js
@@ -88,7 +88,7 @@ class Mode {
         // The active indicator can also be changed with @setIndicator().
         if (this.options.indicator != null) {
           if (this.options.indicator) {
-            HUD.show(this.options.indicator);
+            HUD.show(this.options.indicator, undefined, this.name);
           } else {
             HUD.hide(true, false);
           }

--- a/pages/hud_page.js
+++ b/pages/hud_page.js
@@ -85,6 +85,14 @@ function ensureClipboardIsAvailable() {
   return true;
 }
 
+function setMessageName(el, messageName) {
+  if (messageName) {
+    el.dataset.messageName = messageName;
+  } else {
+    delete el.dataset.messageName;
+  }
+}
+
 // Exported for unit tests.
 export const handlers = {
   show(data) {
@@ -93,6 +101,7 @@ export const handlers = {
     el.classList.add("vimium-ui-component-visible");
     el.classList.remove("vimium-ui-component-hidden");
     el.classList.remove("hud-find");
+    setMessageName(el, data.messageName);
   },
 
   hidden() {
@@ -102,6 +111,7 @@ export const handlers = {
     el.textContent = "";
     el.classList.add("vimium-ui-component-hidden");
     el.classList.remove("vimium-ui-component-visible");
+    setMessageName(el, null);
   },
 
   showFindMode() {

--- a/tests/dom_tests/dom_tests.js
+++ b/tests/dom_tests/dom_tests.js
@@ -279,19 +279,19 @@ context("Test link hints for changing mode", () => {
   });
 
   should("change mode on shift", () => {
-    assert.equal("curr-tab", linkHints.mode.name);
+    assert.equal("open-in-current-tab", linkHints.mode.name);
     sendKeyboardEvent("Shift", "keydown");
-    assert.equal("bg-tab", linkHints.mode.name);
+    assert.equal("open-in-new-background-tab", linkHints.mode.name);
     sendKeyboardEvent("Shift", "keyup");
-    assert.equal("curr-tab", linkHints.mode.name);
+    assert.equal("open-in-current-tab", linkHints.mode.name);
   });
 
   should("change mode on ctrl", () => {
-    assert.equal("curr-tab", linkHints.mode.name);
+    assert.equal("open-in-current-tab", linkHints.mode.name);
     sendKeyboardEvent("Control", "keydown");
-    assert.equal("fg-tab", linkHints.mode.name);
+    assert.equal("open-in-new-foreground-tab", linkHints.mode.name);
     sendKeyboardEvent("Control", "keyup");
-    assert.equal("curr-tab", linkHints.mode.name);
+    assert.equal("open-in-current-tab", linkHints.mode.name);
   });
 });
 

--- a/tests/unit_tests/hud_page_test.js
+++ b/tests/unit_tests/hud_page_test.js
@@ -34,6 +34,15 @@ context("hud page", () => {
     UIComponentMessenger.unregister();
   });
 
+  should("sets a data-message-name attribute", () => {
+    const el = document.querySelector("#hud");
+    hudPage.handlers.show({
+      text: "example",
+      messageName: "example-name",
+    });
+    assert.equal("example-name", el.dataset.messageName);
+  });
+
   should("find mode hides when escape is pressed", async () => {
     let message;
     const stubPort = {


### PR DESCRIPTION
This is a mechanism for one to hide certain messages that are too obstructive.

Fixes #3112.

Previous PR: #4758

Each link hints related message sets a different data-message-name attribute on the `#hud` element. Here's an example selector for a user's CSS:

```css
#hud[data-message-name="link-hints/open-in-current-tab"] { display: none} 
```

Names for the other HUD message types can be added later. This just populates the link hints ones.